### PR TITLE
Feature/typesafe properties

### DIFF
--- a/core/opennaas-core-persistence/src/main/java/org/opennaas/core/persistence/GenericOSGiJpaRepository.java
+++ b/core/opennaas-core-persistence/src/main/java/org/opennaas/core/persistence/GenericOSGiJpaRepository.java
@@ -109,18 +109,15 @@ public class GenericOSGiJpaRepository<T, ID extends Serializable> extends Generi
 	}
 
 	private Filter createServiceFilter(String clazz, Properties properties) throws InvalidSyntaxException {
-		String objectClass = "(" + Constants.OBJECTCLASS + "=" + clazz + ")";
-		String filterString = "(& " + objectClass;
-
-		Enumeration<Object> keys = properties.keys();
-		while (keys.hasMoreElements()) {
-			String currentKey = (String) keys.nextElement();
-			filterString += "(" + currentKey + "=" + properties.getProperty(currentKey) + ")";
+		StringBuilder query = new StringBuilder();
+		query.append("(&");
+		query.append("(").append(Constants.OBJECTCLASS).append("=").append(clazz).append(")");
+		for (String key: properties.stringPropertyNames()) {
+			String value = properties.getProperty(key);
+			query.append("(").append(key).append("=").append(value).append(")");
 		}
-		filterString += ")";
-		Filter filter = FrameworkUtil.createFilter(filterString);
-
-		return filter;
+		query.append(")");
+		return FrameworkUtil.createFilter(query.toString());
 	}
 
 	private Object getServiceFromRegistry(BundleContext bundleContext, Filter filter) throws InterruptedException {

--- a/core/opennaas-core-resources/src/main/java/org/opennaas/core/resources/AbstractActivator.java
+++ b/core/opennaas-core-resources/src/main/java/org/opennaas/core/resources/AbstractActivator.java
@@ -18,30 +18,24 @@ public abstract class AbstractActivator {
 
 	/**
 	 * Create a Filter to give to the service tracker based on the information about the service to lookup in the properties
-	 * 
+	 *
 	 * @throws InvalidSyntaxException
 	 */
 	protected static Filter createServiceFilter(String clazz, Properties properties) throws InvalidSyntaxException {
-		String objectClass = "(" + Constants.OBJECTCLASS + "=" + clazz + ")";
-
-		String filterString = "(&" + objectClass;
-
-		Enumeration<Object> keys = properties.keys();
-		while (keys.hasMoreElements()) {
-			String currentKey = (String) keys.nextElement();
-			filterString += "(" + currentKey + "=" + properties.getProperty(currentKey) + ")";
+		StringBuilder query = new StringBuilder();
+		query.append("(&");
+		query.append("(").append(Constants.OBJECTCLASS).append("=").append(clazz).append(")");
+		for (String key: properties.stringPropertyNames()) {
+			String value = properties.getProperty(key);
+			query.append("(").append(key).append("=").append(value).append(")");
 		}
-
-		filterString += ")";
-
-		Filter filter = FrameworkUtil.createFilter(filterString);
-
-		return filter;
+		query.append(")");
+		return FrameworkUtil.createFilter(query.toString());
 	}
 
 	/**
 	 * Fetch a service from OSGI Registry
-	 * 
+	 *
 	 * @return Object service instance
 	 * @throws InterruptedException
 	 * @throws InterruptedException
@@ -70,7 +64,7 @@ public abstract class AbstractActivator {
 
 	/**
 	 * Fetch a service from OSGI Registry
-	 * 
+	 *
 	 * @return Object service instance
 	 * @throws InterruptedException
 	 * @throws InterruptedException


### PR DESCRIPTION
Hi,

While debugging some other problems, I stumbled over the following filter in the log:

```
01-19@16:23:00 [Blueprint Extender: 3]DEBUG org.opennaas.core.persistence.GenericOSGiJpaRepository - Looking up Service from registry with properties: (&(objectClass=javax.persistence.EntityManagerFactory)(isDynamicFactory=null)(persistenceUnit=ResourceCore))
```

Notice (isDynamicFactory=null) when is should have been (isDynamicFactory=true). The problem is that the code puts a non-string value into a Properties instance.

I fixed this problem and also updated the code to use the type-safe setProperty(), getProperty() and stringPropertynames().

No unit tests, but I recompiled everything and Mantychore was able to create, persist and load a resource.

I have a similar patch for Mantychore itself. Once the OpenNaaS changes have been merged I will send the rest as a patch per email.
