### PR TITLE
Upgrade to latest release of FUSE ESB

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -13,10 +13,10 @@
 		<opennaas.release.name>${project.version}</opennaas.release.name>
 		<opennaas.platform.basedir>opennaas-${opennaas.release.name}</opennaas.platform.basedir>
 		<opennaas.platform.name>opennaas-${opennaas.release.name}</opennaas.platform.name>
-		<opennaas.platform.path>../platform/target/opennaas/apache-servicemix-4.4.0-fuse-00-43</opennaas.platform.path>
+		<opennaas.platform.path>../platform/target/opennaas/apache-servicemix-${servicemix.version}</opennaas.platform.path>
 	</properties>
 	<packaging>pom</packaging>
-	<!-- | imported (non-local) bundles are listed here as dependencies | and 
+	<!-- | imported (non-local) bundles are listed here as dependencies | and
 		will be deployed by pax:provision unless they are marked | with <optional>true</optional> -->
 	<build>
 		<plugins>

--- a/core/opennaas-core-features/src/main/resources/features.xml
+++ b/core/opennaas-core-features/src/main/resources/features.xml
@@ -1,30 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features>
-	<!--<repository>mvn:org.apache.karaf.assemblies.features/standard/2.2.0-fuse-00-43/xml/features</repository>
-	<repository>mvn:org.apache.karaf.assemblies.features/enterprise/2.2.0-fuse-00-43/xml/features</repository>-->
-	<!--	<repository>mvn:org.apache.karaf.assemblies.features/standard/2.2.2-fuse-00-08/xml/features</repository>
-	<repository>mvn:org.apache.karaf.assemblies.features/enterprise/2.2.2-fuse-00-08/xml/features</repository>
-	<repository>mvn:org.apache.servicemix.nmr/apache-servicemix-nmr/1.5.0-fuse-00-43/xml/features</repository>
-	<repository>mvn:org.apache.servicemix/apache-servicemix/4.4.0-fuse-00-43/xml/features</repository>
-	<repository>mvn:org.apache.camel.karaf/apache-camel/2.7.1-fuse-00-43/xml/features</repository>
-	<repository>mvn:org.apache.activemq/activemq-karaf/5.5.0-fuse-00-43/xml/features</repository>
-	<repository>mvn:org.opennaas/opennaas-core-features/1.0.0-SNAPSHOT/xml/features</repository> -->
-	<feature name="opennaas-core-deps" version="1.0.0-SNAPSHOT">
-		<!--		<feature>karaf-framework</feature> -->
+	<repository>mvn:org.apache.karaf.assemblies.features/standard/${karaf.version}/xml/features</repository>
+	<repository>mvn:org.apache.servicemix/apache-servicemix/${servicemix.version}/xml/features</repository>
+	<repository>mvn:org.apache.servicemix.nmr/apache-servicemix-nmr/${nmr.version}/xml/features</repository>
+	<repository>mvn:org.apache.activemq/activemq-karaf/${activemq.version}/xml/features</repository>
+	<!--
+	<repository>mvn:org.apache.camel.karaf/apache-camel/2.7.1-fuse-00-43/xml/features</repository>-->
+	<feature name="opennaas-core-deps" version="${project.version}">
+		<feature>spring</feature>
+		<feature>jetty</feature> <!-- In 4.4.1-fuse-01-20 cxf is missing
+		                              this dependency -->
+		<feature>cxf</feature>
+		<feature>activemq</feature>
+
 		<bundle>mvn:org.dynamicjava.osgi/classloading-utils/1.0.1</bundle>
 		<bundle>mvn:org.dynamicjava.osgi/service-binding-utils/1.0.0</bundle>
 		<bundle>mvn:org.dynamicjava.osgi/dynamic-jpa/1.0.0</bundle>
 		<!--<bundle>mvn:org.apache.geronimo.specs/geronimo-jpa_1.0_spec/1.1.2</bundle>-->
 		<bundle>mvn:org.hsqldb/com.springsource.org.hsqldb/1.8.0.10</bundle>
-		<bundle>mvn:org.springframework/spring-core/3.0.6.RELEASE</bundle>
-		<bundle>mvn:org.springframework/spring-beans/3.0.6.RELEASE</bundle>
-		<bundle>mvn:org.springframework/spring-context/3.0.6.RELEASE</bundle>
-		<bundle>mvn:org.springframework/org.springframework.asm/3.0.6.RELEASE</bundle>
-		<!--	<feature>cxf</feature>  -->
-		<!--<bundle>mvn:org.apache.geronimo.specs/geronimo-ws-metadata_2.0_spec/1.1.3</bundle>-->
-		<!--<bundle>mvn:org.apache.geronimo.specs/geronimo-jms_1.1_spec/1.1.1</bundle>-->
-		<!--<bundle>mvn:org.apache.geronimo.specs/geronimo-jpa_2.0_spec/1.1</bundle>-->
-		<!--	<feature>activemq</feature> -->
 		<bundle>mvn:org.apache.felix/org.apache.felix.gogo.runtime/0.6.1</bundle>
 		<bundle>mvn:org.apache.felix/org.apache.felix.gogo.command/0.6.1</bundle>
 		<!--<bundle>mvn:org.apache.felix/org.apache.felix.gogo.shell/0.6.1</bundle>-->
@@ -35,7 +28,6 @@
 		<!-- nexus events stuff end -->
 		<!-- mantychore needs these -->
 		<bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jaxp-ri/1.4.2_1</bundle>
-		<bundle>mvn:org.codehaus.woodstox/stax2-api/3.1.1</bundle>
 		<!--<bundle>mvn:commons-jxpath/commons-jxpath/1.3</bundle>-->
 		<!-- mantychore needs these end -->
 	</feature>

--- a/core/opennaas-core-platformmanager/pom.xml
+++ b/core/opennaas-core-platformmanager/pom.xml
@@ -15,7 +15,7 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.servicemix.specs</groupId>
-			<artifactId>org.apache.servicemix.specs.jaxb-api-2.1</artifactId>
+			<artifactId>org.apache.servicemix.specs.jaxb-api-2.2</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.geronimo.specs</groupId>
@@ -158,7 +158,7 @@
 							<!--org.osgi.service.command,-->
 							*</Import-Package>
 						<Export-Package>
-							org.opennaas.core.platformmanager*;version="${project.version}", 
+							org.opennaas.core.platformmanager*;version="${project.version}",
     						</Export-Package>
 						<Require-Bundle>org.apache.cxf.bundle</Require-Bundle>
 						<DynamicImport-Package>org.apache.cxf.*</DynamicImport-Package>

--- a/core/opennaas-core-resources/pom.xml
+++ b/core/opennaas-core-resources/pom.xml
@@ -16,7 +16,7 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.servicemix.specs</groupId>
-			<artifactId>org.apache.servicemix.specs.jaxb-api-2.1</artifactId>
+			<artifactId>org.apache.servicemix.specs.jaxb-api-2.2</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -9,10 +9,6 @@
 	</parent>
 	<name>OpenNaaS :: Core</name>
 	<artifactId>opennaas-core</artifactId>
-	<properties>
-		<cxf.version>2.4.0-fuse-00-27</cxf.version>
-		<karaf.version>2.2.2-fuse-00-08</karaf.version>
-	</properties>
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
@@ -43,12 +39,12 @@
 			<dependency>
 				<groupId>org.apache.servicemix.bundles</groupId>
 				<artifactId>org.apache.servicemix.bundles.commons-dbcp</artifactId>
-				<version>1.2.2_5</version>
+				<version>1.2.2_7</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.servicemix.specs</groupId>
-				<artifactId>org.apache.servicemix.specs.jaxb-api-2.1</artifactId>
-				<version>1.6.0</version>
+				<artifactId>org.apache.servicemix.specs.jaxb-api-2.2</artifactId>
+				<version>1.8.0</version>
 			</dependency>
 			<dependency>
 				<groupId>org.dynamicjava.osgi</groupId>

--- a/platform/pom.xml
+++ b/platform/pom.xml
@@ -14,9 +14,6 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<target-platform.path>target/opennaas</target-platform.path>
 		<servicemix.path>apache-servicemix-${servicemix.version}</servicemix.path>
-		<!-- Using this as 2.2 up to and including 2.2.0-fuse-00-43 gave us nightmares. Let's try 2.2+ versions again sometime.-->
-		<karaf.version>2.2.2-fuse-00-08</karaf.version>
-		<servicemix.version>4.4.0-fuse-00-43</servicemix.version>
 	</properties>
 	<repositories>
 		<repository>
@@ -162,9 +159,9 @@
 				</executions>
 			</plugin>
 			<plugin>
-				<groupId>org.apache.felix.karaf.tooling</groupId>
+				<groupId>org.apache.karaf.tooling</groupId>
 				<artifactId>features-maven-plugin</artifactId>
-				<version>1.4.0-fuse-02-00</version>
+				<version>${karaf.version}</version>
 				<executions>
 					<execution>
 						<id>add-features-to-repo</id>
@@ -173,9 +170,18 @@
 							<goal>add-features-to-repo</goal>
 						</goals>
 						<configuration>
+							<karafVersion>${karaf.version}</karafVersion>
 							<descriptors>
-								<descriptor>mvn:org.opennaas/opennaas-core-features/1.0.0-SNAPSHOT/xml/features</descriptor>
+								<descriptor>mvn:org.apache.servicemix/apache-servicemix/${servicemix.version}/xml/features</descriptor>
+								<descriptor>mvn:org.apache.servicemix.nmr/apache-servicemix-nmr/${nmr.version}/xml/features</descriptor>
+								<descriptor>mvn:org.apache.activemq/activemq-karaf/${activemq.version}/xml/features</descriptor>
+								<descriptor>mvn:org.opennaas/opennaas-core-features/${project.version}/xml/features</descriptor>
 							</descriptors>
+							<!-- Only add the features we specify
+							     explicitly.  Remaining features are
+							     included by copying servicemix above.
+							     -->
+							<addTransitiveFeatures>false</addTransitiveFeatures>
 							<features>
 								<feature>opennaas-core-deps</feature>
 								<feature>opennaas-core</feature>

--- a/platform/src/main/filtered-resources/etc/org.apache.karaf.features.cfg
+++ b/platform/src/main/filtered-resources/etc/org.apache.karaf.features.cfg
@@ -20,11 +20,9 @@
 #
 # Comma separated list of features repositories to register by default
 #
-featuresRepositories=mvn:org.apache.karaf.assemblies.features/standard/2.2.0-fuse-00-43/xml/features,mvn:org.apache.karaf.assemblies.features/enterprise/2.2.0-fuse-00-43/xml/features,mvn:org.apache.servicemix.nmr/apache-servicemix-nmr/1.5.0-fuse-00-43/xml/features,mvn:org.apache.servicemix/apache-servicemix/4.4.0-fuse-00-43/xml/features,mvn:org.apache.camel.karaf/apache-camel/2.7.1-fuse-00-43/xml/features,mvn:org.apache.activemq/activemq-karaf/5.5.0-fuse-00-43/xml/features,mvn:org.opennaas/opennaas-core-features/1.0.0-SNAPSHOT/xml/features
-#featuresRepositories=mvn:org.opennaas/opennaas-core-features/1.0.0-SNAPSHOT/xml/features
+featuresRepositories=mvn:org.apache.karaf.assemblies.features/standard/${karaf.version}/xml/features,mvn:org.apache.karaf.assemblies.features/enterprise/${karaf.version}/xml/features,mvn:org.apache.servicemix.nmr/apache-servicemix-nmr/${nmr.version}/xml/features,mvn:org.apache.servicemix/apache-servicemix/${servicemix.version}/xml/features,mvn:org.apache.camel.karaf/apache-camel/${camel.version}/xml/features,mvn:org.apache.activemq/activemq-karaf/${activemq.version}/xml/features,mvn:org.opennaas/opennaas-core-features/${project.version}/xml/features
 
 #
 # Comma separated list of features to install at startup
 #
-#featuresBoot=karaf-framework,config,activemq-broker,camel,camel-activemq,camel-nmr,camel-cxf,jbi-cluster,war,servicemix-cxf-bc,servicemix-file,servicemix-ftp,servicemix-http,servicemix-jms,servicemix-mail,servicemix-smpp,servicemix-snmp,servicemix-vfs,servicemix-bean,servicemix-camel,servicemix-cxf-se,servicemix-drools,servicemix-eip,servicemix-osworkflow,servicemix-quartz,servicemix-scripting,servicemix-validation,servicemix-saxon,servicemix-wsn2005
-featuresBoot=karaf-framework,config,cxf,activemq,opennaas-core
+featuresBoot=config,ssh,management,opennaas-core

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,12 @@
      | some example OSGi runtime properties
     <org.osgi.service.http.port>8080</org.osgi.service.http.port>
     <org.osgi.service.http.port.secure>8443</org.osgi.service.http.port.secure>-->
+		<karaf.version>2.2.2-fuse-02-20</karaf.version>
+		<servicemix.version>4.4.1-fuse-01-20</servicemix.version>
+		<camel.version>2.8.0-fuse-01-20</camel.version>
+		<nmr.version>1.5.1-fuse-01-20</nmr.version>
+		<cxf.version>2.4.3-fuse-00-20</cxf.version>
+		<activemq.version>5.5.1-fuse-01-20</activemq.version>
 	</properties>
 	<packaging>pom</packaging>
 	<modules>


### PR DESCRIPTION
Hi Isart,

I am certain you are aware of the annoying misfeature that the first startup of OpenNaaS always prints the welcome message twice, followed by a stack trace.

I found this quite annoying and tried to locate the source of the problem. I did locate it and think it is a bug in Karaf. The problem is triggered by a combination of 
1. OpenNaaS relying on the OSGi compendium bundle
2. OpenNaaS being installed through the bootFeatures feature
3. The bootFeatures feature listing karaf-framework
4. Bundles in karaf-framework having an optional import on packages exported by the compendium bundle

What happens is that Karaf when loading a feature checks whether any of the required bundles are already installed - if so it doesn't need to install them again. It does however check whether any of those bundles have optional imports on other bundles part of the feature. If so it restarts the already installed bundle to resolve the optional dependency. It only does this for bundles part of the feature to install. Other bundles already installed are not subject to this check and are not restarted.

During boot when installing the bootFeatures Karaf however considers all bundles belonging to the boot features to belong together. This has a unfortunate side effect:
1. It builds a list containing bundles of karaf-framework and opennaas-core-deps
2. It sees that all the bundles of karaf-framework are already installed, so they are not installed again
3. Some of those bundles however have an optional import of opennaas-core-deps, so they are restarted
4. Among the restarted bundles are the console service (causing the repeated print of the welcome message) and the features admin; the latter is causing the stack trace. The stack trace happens because the feature admin is the one installing the boot features; when it gets restarted in the middle of installing the boot features, the bundle context becomes invalid and thus causes a stack trace to be printed.

The amazing thing is that if you install the opennaas feature manually after boot then the problem does not occur: This is because Karaf in that situation only looks at the bundles belonging to the opennaas feature and its dependencies. These don't include the console or feature admin, and thus those bundles don't get restarted (even though they have optional imports on the compendium packages).

In the end I think this is a Karaf bug. There are actually two bugs:
1. Karaf fails to save the state of the feature admin if the restart involves the feature admin itself
2. Karaf treats features installed manually one by one different from features installed through bootFeatures property

I will try to create a minimal example outside OpenNaaS, based on only Karaf, and submit a bug report upstream.

This branch I am asking you to pull upgrades OpenNaaS to the latest FUSE version. I was hoping the latest version would fix the bug. They did make changes to the boot features functionality (see the patch description), however the specific bugs I mentioned are unfortunately not fixed. The patch however includes a simple workaround: The default boot features of the new FUSE does not include karaf-framework (as it is installed by default in Karaf). This means we don't hit the problem.

Even though the core problem I tried to resolve wasn't fixed in the new version, I think it is worth upgrading to the latest version as it is a bug fix release.

Please note that the JPA change on feature/close-jpa-entitymanager is not included; depending on which change you merge first I will have to rebase the other branch before you can merge it.

Naturally the version numbers need to be incremented in Mantychore as well; I will submit a patch to you for doing do.

Cheers,

/gerd
