### PR TITLE
Fix bad use of Properties.

### DIFF
--- a/core/opennaas-core-resources/src/main/java/org/opennaas/core/resources/alarms/ResourceAlarm.java
+++ b/core/opennaas-core-resources/src/main/java/org/opennaas/core/resources/alarms/ResourceAlarm.java
@@ -34,12 +34,12 @@ public class ResourceAlarm extends Event {
 		INFO, WARNING, MINOR, MAJOR, CRITICAL
 	}
 
-	public ResourceAlarm(Properties properties) {
-		super(TOPIC, (Map) properties);
+	public ResourceAlarm(Map<String, Object> properties) {
+		super(TOPIC, properties);
 
-		resourceId = properties.getProperty(RESOURCE_ID_PROPERTY);
-		alarmCode = properties.getProperty(ALARM_CODE_PROPERTY);
-		arrivalTime = properties.getProperty(ARRIVAL_TIME_PROPERTY);
+		resourceId = properties.get(RESOURCE_ID_PROPERTY).toString();
+		alarmCode = properties.get(ALARM_CODE_PROPERTY).toString();
+		arrivalTime = properties.get(ARRIVAL_TIME_PROPERTY).toString();
 	}
 
 	@Override

--- a/core/opennaas-core-resources/src/main/java/org/opennaas/core/resources/alarms/SessionAlarm.java
+++ b/core/opennaas-core-resources/src/main/java/org/opennaas/core/resources/alarms/SessionAlarm.java
@@ -19,8 +19,8 @@ public class SessionAlarm extends Event {
 	 */
 	public static final String	CAUSE_PROPERY		= "cause";
 
-	public SessionAlarm(Properties properties) {
-		super(TOPIC, (Map) properties);
+	public SessionAlarm(Map<String, Object> properties) {
+		super(TOPIC, properties);
 	}
 
 }


### PR DESCRIPTION
Properties were used to store Object instead of String values.
This patch replaces the use of Properties with Map<String, Object> in Alarm constructors.

This patch doen't fix any bug nor provides new functionalities. It's just for sanitizing the code and preventing future errors.

This changes require modifications in Mantychore side.
Isart already have a patch with them. 
