### PR TITLE
integration-tests: Don't try to start fragments

### DIFF
--- a/manticore/tests/integration/net.i2cat.nexus.tests.resources/src/test/java/net/i2cat/nexus/resources/tests/ResourcesWithProfileTest.java
+++ b/manticore/tests/integration/net.i2cat.nexus.tests.resources/src/test/java/net/i2cat/nexus/resources/tests/ResourcesWithProfileTest.java
@@ -212,30 +212,18 @@ public class ResourcesWithProfileTest {
 		int MAX_RETRIES = 20;
 		Bundle b = null;
 		boolean active = true;
-		List<Integer> fragments = new ArrayList<Integer>();
-		String strBundles;
 
 		for (int i = 0; i < MAX_RETRIES; i++) {
 			active = true;
 			for (int j = 0; j < bundleContext.getBundles().length; j++) {
-				if (!fragments.contains(new Integer(j))) {
-					if (bundleContext.getBundles()[j].getState() == Bundle.RESOLVED) {
-						active = false;
-						try {
-							bundleContext.getBundles()[j].start();
-						} catch (Exception ex) {
-							ex.printStackTrace();
-							if (ex.getMessage().indexOf("fragment") != -1) {
-								fragments.add(new Integer(j));
-
-								Dictionary headers_dic = bundleContext.getBundles()[j].getHeaders();
-								Enumeration headers = headers_dic.keys();
-								log.info("Fragment headers:");
-								while (headers.hasMoreElements()) {
-									log.info(headers.nextElement());
-								}
-							}
-						}
+				Bundle bundle = bundleContext.getBundles()[j];
+				if (bundle.getHeaders().get("Fragment-Host") == null &&
+					bundle.getState() == Bundle.RESOLVED) {
+					active = false;
+					try {
+						bundleContext.getBundles()[j].start();
+					} catch (Exception ex) {
+						ex.printStackTrace();
 					}
 				}
 			}
@@ -244,7 +232,7 @@ public class ResourcesWithProfileTest {
 				break;
 			}
 
-			strBundles = listBundles(bundleContext);
+			listBundles(bundleContext);
 			log.info("Waiting for activation of all bundles, this is the " + i + " try. Sleeping for 1 second");
 			try {
 				Thread.sleep(1000);
@@ -254,12 +242,7 @@ public class ResourcesWithProfileTest {
 			}
 		}
 
-		strBundles = listBundles(bundleContext);
-		String fragmentsNums = "";
-		for (Integer num : fragments) {
-			fragmentsNums += num.toString() + ", ";
-		}
-		log.info("Detected " + fragments.size() + " fragments: " + fragmentsNums);
+		listBundles(bundleContext);
 
 		if (active)
 			log.info("All the bundles activated. Waiting for 15 seconds more to allow Blueprint to publish all the services into the OSGi registry");

--- a/manticore/tests/integration/net.i2cat.nexus.tests.resources/src/test/java/net/i2cat/nexus/resources/tests/UseProfileBundleTest.java
+++ b/manticore/tests/integration/net.i2cat.nexus.tests.resources/src/test/java/net/i2cat/nexus/resources/tests/UseProfileBundleTest.java
@@ -56,7 +56,7 @@ public class UseProfileBundleTest { // extends AbstractIntegrationTest {
 
 	/*
 	 * @Configuration public static Option[] configure() {
-	 * 
+	 *
 	 * Option[] options = combine( IntegrationTestsHelper.getMantychoreTestOptions(),
 	 * //mavenBundle().groupId("net.i2cat.nexus").artifactId("net.i2cat.nexus.tests.helper"),
 	 * mavenBundle().groupId("org.opennaas").artifactId("opennaas-core-tests-mockprofile") // ,
@@ -202,30 +202,18 @@ public class UseProfileBundleTest { // extends AbstractIntegrationTest {
 		int MAX_RETRIES = 20;
 		Bundle b = null;
 		boolean active = true;
-		List<Integer> fragments = new ArrayList<Integer>();
-		String strBundles;
 
 		for (int i = 0; i < MAX_RETRIES; i++) {
 			active = true;
 			for (int j = 0; j < bundleContext.getBundles().length; j++) {
-				if (!fragments.contains(new Integer(j))) {
-					if (bundleContext.getBundles()[j].getState() == Bundle.RESOLVED) {
-						active = false;
-						try {
-							bundleContext.getBundles()[j].start();
-						} catch (Exception ex) {
-							ex.printStackTrace();
-							if (ex.getMessage().indexOf("fragment") != -1) {
-								fragments.add(new Integer(j));
-
-								Dictionary headers_dic = bundleContext.getBundles()[j].getHeaders();
-								Enumeration headers = headers_dic.keys();
-								log.info("Fragment headers:");
-								while (headers.hasMoreElements()) {
-									log.info(headers.nextElement());
-								}
-							}
-						}
+				Bundle bundle = bundleContext.getBundles()[j];
+				if (bundle.getHeaders().get("Fragment-Host") == null &&
+					bundle.getState() == Bundle.RESOLVED) {
+					active = false;
+					try {
+						bundleContext.getBundles()[j].start();
+					} catch (Exception ex) {
+						ex.printStackTrace();
 					}
 				}
 			}
@@ -234,7 +222,7 @@ public class UseProfileBundleTest { // extends AbstractIntegrationTest {
 				break;
 			}
 
-			strBundles = listBundles(bundleContext);
+			listBundles(bundleContext);
 			log.info("Waiting for activation of all bundles, this is the " + i + " try. Sleeping for 1 second");
 			try {
 				Thread.sleep(1000);
@@ -244,12 +232,7 @@ public class UseProfileBundleTest { // extends AbstractIntegrationTest {
 			}
 		}
 
-		strBundles = listBundles(bundleContext);
-		String fragmentsNums = "";
-		for (Integer num : fragments) {
-			fragmentsNums += num.toString() + ", ";
-		}
-		log.info("Detected " + fragments.size() + " fragments: " + fragmentsNums);
+		listBundles(bundleContext);
 
 		if (active)
 			log.info("All the bundles activated. Waiting for 15 seconds more to allow Blueprint to publish all the services into the OSGi registry");


### PR DESCRIPTION
Some integration tests attempt to start bundles. This will fail for fragments. There is code in the tests to detect such cases. The code parses the error message of the exception. This fails because the code looks for "fragment" (lower case) while the error message uses a capital F. As a consequence the code tries to start the fragment over and over.

Rather than simply replacing the search string, this patch changes the code to proactively skip fragments. Thus the error newer occurs.

The following is the exception that used to be printed during test:

```
00:24:55,612 | INFO  | ion(3)-127.0.0.1 | ResourcesWithProfileTest         | s.tests.ResourcesWithProfileTest  248 | Waiting for activation of all bundles, this is the 18 try. Sleeping for 1 second
org.osgi.framework.BundleException: Fragment bundles can not be started.
at org.apache.felix.framework.Felix.startBundle(Felix.java:1670)
at org.apache.felix.framework.BundleImpl.start(BundleImpl.java:927)
at org.apache.felix.framework.BundleImpl.start(BundleImpl.java:914)
at net.i2cat.nexus.resources.tests.ResourcesWithProfileTest.waitForAllBundlesActive(ResourcesWithProfileTest.java:225)
at net.i2cat.nexus.resources.tests.ResourcesWithProfileTest.initBundles(ResourcesWithProfileTest.java:87)
at net.i2cat.nexus.resources.tests.ResourcesWithProfileTest.createResourceWithProfile(ResourcesWithProfileTest.java:134)
at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
at java.lang.reflect.Method.invoke(Method.java:597)
at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:45)
at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:15)
at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:42)
at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:20)
at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:263)
at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:68)
at org.ops4j.pax.exam.invoker.junit.internal.ContainerTestRunner.runChild(ContainerTestRunner.java:58)
at org.ops4j.pax.exam.invoker.junit.internal.ContainerTestRunner.runChild(ContainerTestRunner.java:32)
at org.junit.runners.ParentRunner$3.run(ParentRunner.java:231)
at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:60)
at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:229)
at org.junit.runners.ParentRunner.access$000(ParentRunner.java:50)
at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:222)
at org.junit.runners.ParentRunner.run(ParentRunner.java:300)
at org.junit.runner.JUnitCore.run(JUnitCore.java:157)
at org.junit.runner.JUnitCore.run(JUnitCore.java:136)
at org.ops4j.pax.exam.invoker.junit.internal.JUnitProbeInvoker.invokeViaJUnit(JUnitProbeInvoker.java:108)
at org.ops4j.pax.exam.invoker.junit.internal.JUnitProbeInvoker.findAndInvoke(JUnitProbeInvoker.java:89)
at org.ops4j.pax.exam.invoker.junit.internal.JUnitProbeInvoker.call(JUnitProbeInvoker.java:72)
at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
at java.lang.reflect.Method.invoke(Method.java:597)
at org.ops4j.pax.exam.rbc.internal.RemoteBundleContextImpl.remoteCall(RemoteBundleContextImpl.java:86)
at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
at java.lang.reflect.Method.invoke(Method.java:597)
at sun.rmi.server.UnicastServerRef.dispatch(UnicastServerRef.java:303)
at sun.rmi.transport.Transport$1.run(Transport.java:159)
at java.security.AccessController.doPrivileged(Native Method)
at sun.rmi.transport.Transport.serviceCall(Transport.java:155)
at sun.rmi.transport.tcp.TCPTransport.handleMessages(TCPTransport.java:535)
at sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run0(TCPTransport.java:790)
at sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run(TCPTransport.java:649)
at java.util.concurrent.ThreadPoolExecutor$Worker.runTask(ThreadPoolExecutor.java:886)
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:908)
at java.lang.Thread.run(Thread.java:662)
```

One consequnce of the patch is that the count to 20 followed by a 15 second sleep is gone.
