### PR TITLE
Feature/fix race condition in resource manager

### DIFF
--- a/core/opennaas-core-resources/src/main/java/org/opennaas/core/resources/IResourceManager.java
+++ b/core/opennaas-core-resources/src/main/java/org/opennaas/core/resources/IResourceManager.java
@@ -67,6 +67,11 @@ public interface IResourceManager {
 	public List<IResource> listResources();
 
 	/**
+	 * Returns a list of available resource types.
+	 */
+	public List<String> getResourceTypes();
+
+	/**
 	 * Get an existing resource
 	 *
 	 * @param resourceIdentifier

--- a/core/opennaas-core-resources/src/main/java/org/opennaas/core/resources/shell/CreateResourceCommand.java
+++ b/core/opennaas-core-resources/src/main/java/org/opennaas/core/resources/shell/CreateResourceCommand.java
@@ -24,6 +24,7 @@ import org.opennaas.core.resources.IResourceManager;
 import org.opennaas.core.resources.IResourceRepository;
 import org.opennaas.core.resources.ResourceException;
 import org.opennaas.core.resources.ResourceManager;
+import org.opennaas.core.resources.descriptor.Information;
 import org.opennaas.core.resources.descriptor.ResourceDescriptor;
 import org.opennaas.core.resources.descriptor.network.NetworkTopology;
 import org.xml.sax.SAXException;
@@ -81,27 +82,23 @@ public class CreateResourceCommand extends GenericKarafCommand {
 			// Override profile in the descriptor
 			descriptor.setProfileId(profileName);
 		}
-		IResource resource = null;
 		try {
 			// printInfo("Creating Resource ...... ");
-			resource = manager.createResource(descriptor);
+			IResource resource = manager.createResource(descriptor);
+			Information information = resource.getResourceDescriptor().getInformation();
+			printInfo("Created resource " + information.getType() +
+					  ":" + information.getName());
+			return 0;
 		} catch (ResourceException e) {
-
 			printError(e.getLocalizedMessage());
-			ResourceManager rm = (ResourceManager) manager;
-			Hashtable<String, IResourceRepository> rr = (Hashtable<String, IResourceRepository>) rm.getResourceRepositories();
-			if (rr.isEmpty()) {
+			if (manager.getResourceTypes().isEmpty()) {
 				printError("There aren't any Resource Repositories registered.");
-				return -1;
 			}
 			return -1;
 		} catch (NullPointerException e) {
 			printError(e);
 			return -1;
 		}
-		printInfo("Created resource " + resource.getResourceDescriptor().getInformation().getType() + ":" + resource.getResourceDescriptor()
-				.getInformation().getName());
-		return 0;
 	}
 
 	public ResourceDescriptor getResourceDescriptor(String filename) throws JAXBException, IOException, ResourceException, SAXException {


### PR DESCRIPTION
Resource manager maintains a hash table of resource repositories.
Most accesses to this hash table are synchronized, however a few
are not. This lead to the following exception:

```
org.ops4j.pax.exam.TestContainerException: [startedResourceModelHasNameTest(net.i2cat.mantychore.repository.tests.MantychoreRepositoryIntegrationTest): null]
at org.ops4j.pax.exam.invoker.junit.internal.JUnitProbeInvoker.invokeViaJUnit(JUnitProbeInvoker.java:112)
at org.ops4j.pax.exam.invoker.junit.internal.JUnitProbeInvoker.findAndInvoke(JUnitProbeInvoker.java:89)
at org.ops4j.pax.exam.invoker.junit.internal.JUnitProbeInvoker.call(JUnitProbeInvoker.java:72)
at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
at java.lang.reflect.Method.invoke(Method.java:597)
at org.ops4j.pax.exam.rbc.internal.RemoteBundleContextImpl.remoteCall(RemoteBundleContextImpl.java:86)
at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
at java.lang.reflect.Method.invoke(Method.java:597)
at sun.rmi.server.UnicastServerRef.dispatch(UnicastServerRef.java:303)
at sun.rmi.transport.Transport$1.run(Transport.java:159)
at java.security.AccessController.doPrivileged(Native Method)
at sun.rmi.transport.Transport.serviceCall(Transport.java:155)
at sun.rmi.transport.tcp.TCPTransport.handleMessages(TCPTransport.java:535)
at sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run0(TCPTransport.java:790)
at sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run(TCPTransport.java:649)
at java.util.concurrent.ThreadPoolExecutor$Worker.runTask(ThreadPoolExecutor.java:886)
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:908)
at java.lang.Thread.run(Thread.java:662)
Caused by: java.util.ConcurrentModificationException
at java.util.Hashtable$Enumerator.next(Hashtable.java:1031)
at org.opennaas.core.resources.ResourceManager.listResources(ResourceManager.java:115)
at net.i2cat.mantychore.repository.tests.MantychoreRepositoryIntegrationTest.startedResourceModelHasNameTest(MantychoreRepositoryIntegrationTest.java:226)
at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
at java.lang.reflect.Method.invoke(Method.java:597)
at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:45)
at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:15)
at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:42)
at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:20)
at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:30)
at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:263)
at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:68)
at org.ops4j.pax.exam.invoker.junit.internal.ContainerTestRunner.runChild(ContainerTestRunner.java:58)
at org.ops4j.pax.exam.invoker.junit.internal.ContainerTestRunner.runChild(ContainerTestRunner.java:32)
at org.junit.runners.ParentRunner$3.run(ParentRunner.java:231)
at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:60)
at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:229)
at org.junit.runners.ParentRunner.access$000(ParentRunner.java:50)
at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:222)
at org.junit.runners.ParentRunner.run(ParentRunner.java:300)
at org.junit.runner.JUnitCore.run(JUnitCore.java:157)
at org.junit.runner.JUnitCore.run(JUnitCore.java:136)
at org.ops4j.pax.exam.invoker.junit.internal.JUnitProbeInvoker.invokeViaJUnit(JUnitProbeInvoker.java:108)
... 21 more
```

Although Hashtable itself is synchronized, an iterator over
Hashtable may not be interleaved with modifications to the
hash table. The solution is thus to synchronize all access
to the hash table.

The patch fixes the problem and also cleans up the code a bit:
- Uses HashMap rather than the legacy Hashtable class.
- Adds @Override annotations.
- Removes some unnecessary collection allocations.
- Simplifies a number of loops over collections.
- Prevents exposing internal data structures.
- Avoid breaking encapsulating caused by casting interfaces
  to implementations.

Testing done: Unit and integration tests pass.
