### PR TITLE
Feature/do not sleep in tests

### DIFF
--- a/manticore/tests/integration/net.i2cat.mantychore.tests.repository/src/test/java/net/i2cat/mantychore/repository/tests/ResourceManagerIntegrationTest.java
+++ b/manticore/tests/integration/net.i2cat.mantychore.tests.repository/src/test/java/net/i2cat/mantychore/repository/tests/ResourceManagerIntegrationTest.java
@@ -173,7 +173,6 @@ public class ResourceManagerIntegrationTest
 		Assert.assertNotNull(resource);
 
 		Assert.assertEquals(org.opennaas.core.resources.ILifecycle.State.INITIALIZED, resource.getState());
-		Thread.sleep(5000);
 	}
 
 	public void removeResource() throws ResourceException {


### PR DESCRIPTION
Quite a number of test use sleeping as a form of synchronization.
Besides being bad style and fragile, this adds to the runtime
of the tests.

This patch removes some of the sleeps and replaces them with other
means of synchronization.

There are tests left that sleep, but they are not easily fixed and
require deeper changes.

Tests done: Unit and integration tests pass.
