### PR TITLE
Feature/reduce integration test dependencies

### DIFF
--- a/manticore/tests/integration/net.i2cat.luminis.tests.actions/src/test/java/net/i2cat/luminis/actions/tests/ConnectionActionsIntegrationTest.java
+++ b/manticore/tests/integration/net.i2cat.luminis.tests.actions/src/test/java/net/i2cat/luminis/actions/tests/ConnectionActionsIntegrationTest.java
@@ -1,7 +1,6 @@
 package net.i2cat.luminis.actions.tests;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
 
 import java.util.HashMap;
 import java.util.List;
@@ -71,6 +70,12 @@ public class ConnectionActionsIntegrationTest {
 					   .karafVersion("2.2.2")
 					   .name("mantychore")
 					   .unpackDirectory(new File("target/paxexam")),
+					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
+												"featuresBoot",
+												"opennaas-luminis"),
+					   configureConsole()
+					   .ignoreLocalConsole()
+					   .ignoreRemoteShell(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/integration/net.i2cat.luminis.tests.actions/src/test/java/net/i2cat/luminis/actions/tests/LockUnlockCommandsTest.java
+++ b/manticore/tests/integration/net.i2cat.luminis.tests.actions/src/test/java/net/i2cat/luminis/actions/tests/LockUnlockCommandsTest.java
@@ -1,7 +1,6 @@
 package net.i2cat.luminis.actions.tests;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
 
 import net.i2cat.luminis.commandsets.wonesys.WonesysCommand;
 import net.i2cat.luminis.commandsets.wonesys.commands.LockNodeCommand;
@@ -57,6 +56,12 @@ public class LockUnlockCommandsTest {
 					   .karafVersion("2.2.2")
 					   .name("mantychore")
 					   .unpackDirectory(new File("target/paxexam")),
+					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
+												"featuresBoot",
+												"opennaas-luminis"),
+					   configureConsole()
+					   .ignoreLocalConsole()
+					   .ignoreRemoteShell(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/integration/net.i2cat.luminis.tests.capability/src/test/java/net/i2cat/luminis/capability/connections/test/ConnectionsCapabilityIntegrationTest.java
+++ b/manticore/tests/integration/net.i2cat.luminis.tests.capability/src/test/java/net/i2cat/luminis/capability/connections/test/ConnectionsCapabilityIntegrationTest.java
@@ -1,7 +1,6 @@
 package net.i2cat.luminis.capability.connections.test;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
 
 import static org.ops4j.pax.exam.CoreOptions.maven;
 import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
@@ -101,6 +100,12 @@ public class ConnectionsCapabilityIntegrationTest
 					   .karafVersion("2.2.2")
 					   .name("mantychore")
 					   .unpackDirectory(new File("target/paxexam")),
+					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
+												"featuresBoot",
+												"opennaas-luminis"),
+					   configureConsole()
+					   .ignoreLocalConsole()
+					   .ignoreRemoteShell(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/integration/net.i2cat.luminis.tests.commandsKaraf/src/test/java/net/i2cat/luminis/commandsKaraf/tests/ConnectionsKarafCommandsTest.java
+++ b/manticore/tests/integration/net.i2cat.luminis.tests.commandsKaraf/src/test/java/net/i2cat/luminis/commandsKaraf/tests/ConnectionsKarafCommandsTest.java
@@ -1,7 +1,6 @@
 package net.i2cat.luminis.commandsKaraf.tests;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
 
 import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.TestProbeBuilder;
@@ -457,6 +456,12 @@ public class ConnectionsKarafCommandsTest
 					   .karafVersion("2.2.2")
 					   .name("mantychore")
 					   .unpackDirectory(new File("target/paxexam")),
+					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
+												"featuresBoot",
+												"opennaas-luminis"),
+					   configureConsole()
+					   .ignoreLocalConsole()
+					   .ignoreRemoteShell(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/integration/net.i2cat.luminis.tests.protocols.wonesys/src/test/java/net/i2cat/luminis/protocols/wonesys/tests/ReceiveAlarmsTest.java
+++ b/manticore/tests/integration/net.i2cat.luminis.tests.protocols.wonesys/src/test/java/net/i2cat/luminis/protocols/wonesys/tests/ReceiveAlarmsTest.java
@@ -1,7 +1,6 @@
 package net.i2cat.luminis.protocols.wonesys.tests;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
 
 import static org.ops4j.pax.exam.CoreOptions.maven;
 import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
@@ -106,6 +105,12 @@ public class ReceiveAlarmsTest implements EventHandler {
 					   .karafVersion("2.2.2")
 					   .name("mantychore")
 					   .unpackDirectory(new File("target/paxexam")),
+					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
+												"featuresBoot",
+												"opennaas-luminis"),
+					   configureConsole()
+					   .ignoreLocalConsole()
+					   .ignoreRemoteShell(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/integration/net.i2cat.luminis.tests.protocols.wonesys/src/test/java/net/i2cat/luminis/protocols/wonesys/tests/SendCommandTest.java
+++ b/manticore/tests/integration/net.i2cat.luminis.tests.protocols.wonesys/src/test/java/net/i2cat/luminis/protocols/wonesys/tests/SendCommandTest.java
@@ -1,7 +1,6 @@
 package net.i2cat.luminis.protocols.wonesys.tests;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
 
 import static org.ops4j.pax.exam.CoreOptions.maven;
 import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
@@ -90,6 +89,12 @@ public class SendCommandTest {
 					   .karafVersion("2.2.2")
 					   .name("mantychore")
 					   .unpackDirectory(new File("target/paxexam")),
+					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
+												"featuresBoot",
+												"opennaas-luminis"),
+					   configureConsole()
+					   .ignoreLocalConsole()
+					   .ignoreRemoteShell(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/integration/net.i2cat.luminis.tests.protocols.wonesys/src/test/java/net/i2cat/luminis/transports/wonesys/tests/WonesysTransportTest.java
+++ b/manticore/tests/integration/net.i2cat.luminis.tests.protocols.wonesys/src/test/java/net/i2cat/luminis/transports/wonesys/tests/WonesysTransportTest.java
@@ -1,7 +1,6 @@
 package net.i2cat.luminis.transports.wonesys.tests;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
 
 import static org.ops4j.pax.exam.CoreOptions.maven;
 import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
@@ -72,6 +71,12 @@ public class WonesysTransportTest implements ITransportListener {
 					   .karafVersion("2.2.2")
 					   .name("mantychore")
 					   .unpackDirectory(new File("target/paxexam")),
+					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
+												"featuresBoot",
+												"opennaas-luminis"),
+					   configureConsole()
+					   .ignoreLocalConsole()
+					   .ignoreRemoteShell(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/integration/net.i2cat.luminis.tests.repository/src/test/java/net/i2cat/luminis/ROADM/repository/tests/ROADMRespositoryIntegrationTest.java
+++ b/manticore/tests/integration/net.i2cat.luminis.tests.repository/src/test/java/net/i2cat/luminis/ROADM/repository/tests/ROADMRespositoryIntegrationTest.java
@@ -1,7 +1,6 @@
 package net.i2cat.luminis.ROADM.repository.tests;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
 
 import static org.ops4j.pax.exam.CoreOptions.maven;
 import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
@@ -96,6 +95,12 @@ public class ROADMRespositoryIntegrationTest
 					   .karafVersion("2.2.2")
 					   .name("mantychore")
 					   .unpackDirectory(new File("target/paxexam")),
+					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
+												"featuresBoot",
+												"opennaas-luminis,nexus-tests-helper"),
+					   configureConsole()
+					   .ignoreLocalConsole()
+					   .ignoreRemoteShell(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/integration/net.i2cat.mantychore.tests.capability.queue/pom.xml
+++ b/manticore/tests/integration/net.i2cat.mantychore.tests.capability.queue/pom.xml
@@ -23,8 +23,8 @@
 			<artifactId>net.i2cat.mantychore.queuemanager</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>net.i2cat.mantychore.capability</groupId>
-			<artifactId>net.i2cat.mantychore.capability.chassis</artifactId>
+			<groupId>net.i2cat.mantychore.protocols</groupId>
+			<artifactId>net.i2cat.mantychore.protocols.netconf</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>net.i2cat.netconf</groupId>

--- a/manticore/tests/integration/net.i2cat.mantychore.tests.capability.queue/src/test/java/net/i2cat/mantychore/queuemanager/tests/PrepareCommitRollbackTest.java
+++ b/manticore/tests/integration/net.i2cat.mantychore.tests.capability.queue/src/test/java/net/i2cat/mantychore/queuemanager/tests/PrepareCommitRollbackTest.java
@@ -1,7 +1,6 @@
 package net.i2cat.mantychore.queuemanager.tests;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
 
 import static org.ops4j.pax.exam.CoreOptions.maven;
 import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
@@ -98,6 +97,12 @@ public class PrepareCommitRollbackTest
 					   .karafVersion("2.2.2")
 					   .name("mantychore")
 					   .unpackDirectory(new File("target/paxexam")),
+					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
+												"featuresBoot",
+												"opennaas-router"),
+					   configureConsole()
+					   .ignoreLocalConsole()
+					   .ignoreRemoteShell(),
 					   mavenBundle()
 					   .groupId("org.ops4j.base")
 					   .artifactId("ops4j-base-spi")

--- a/manticore/tests/integration/net.i2cat.mantychore.tests.capability.queue/src/test/java/net/i2cat/mantychore/queuemanager/tests/QueuemanagerTest.java
+++ b/manticore/tests/integration/net.i2cat.mantychore.tests.capability.queue/src/test/java/net/i2cat/mantychore/queuemanager/tests/QueuemanagerTest.java
@@ -1,7 +1,6 @@
 package net.i2cat.mantychore.queuemanager.tests;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -86,6 +85,12 @@ public class QueuemanagerTest
 					   .karafVersion("2.2.2")
 					   .name("mantychore")
 					   .unpackDirectory(new File("target/paxexam")),
+					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
+												"featuresBoot",
+												"opennaas-router"),
+					   configureConsole()
+					   .ignoreLocalConsole()
+					   .ignoreRemoteShell(),
 					   mavenBundle()
 					   .groupId("org.ops4j.base")
 					   .artifactId("ops4j-base-spi")

--- a/manticore/tests/integration/net.i2cat.mantychore.tests.capability/src/test/java/net/i2cat/mantychore/chassiscapability/test/ChassisCapabilityIntegrationTest.java
+++ b/manticore/tests/integration/net.i2cat.mantychore.tests.capability/src/test/java/net/i2cat/mantychore/chassiscapability/test/ChassisCapabilityIntegrationTest.java
@@ -1,7 +1,6 @@
 package net.i2cat.mantychore.chassiscapability.test;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
 
 import static org.ops4j.pax.exam.CoreOptions.maven;
 import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
@@ -99,6 +98,12 @@ public class ChassisCapabilityIntegrationTest
 					   .karafVersion("2.2.2")
 					   .name("mantychore")
 					   .unpackDirectory(new File("target/paxexam")),
+					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
+												"featuresBoot",
+												"opennaas-router"),
+					   configureConsole()
+					   .ignoreLocalConsole()
+					   .ignoreRemoteShell(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/integration/net.i2cat.mantychore.tests.capability/src/test/java/net/i2cat/mantychore/chassiscapability/test/UpDownTest.java
+++ b/manticore/tests/integration/net.i2cat.mantychore.tests.capability/src/test/java/net/i2cat/mantychore/chassiscapability/test/UpDownTest.java
@@ -1,7 +1,6 @@
 package net.i2cat.mantychore.chassiscapability.test;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
 import static org.ops4j.pax.exam.CoreOptions.maven;
 import static org.ops4j.pax.exam.CoreOptions.options;
 
@@ -93,6 +92,12 @@ public class UpDownTest
 				.karafVersion("2.2.2")
 				.name("mantychore")
 				.unpackDirectory(new File("target/paxexam")),
+					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
+												"featuresBoot",
+												"opennaas-router"),
+					   configureConsole()
+					   .ignoreLocalConsole()
+					   .ignoreRemoteShell(),
 				keepRuntimeFolder());
 	}
 

--- a/manticore/tests/integration/net.i2cat.mantychore.tests.capability/src/test/java/net/i2cat/mantychore/ipcapability/test/IPCapabilityIntegrationTest.java
+++ b/manticore/tests/integration/net.i2cat.mantychore.tests.capability/src/test/java/net/i2cat/mantychore/ipcapability/test/IPCapabilityIntegrationTest.java
@@ -1,7 +1,6 @@
 package net.i2cat.mantychore.ipcapability.test;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
 
 import static org.ops4j.pax.exam.CoreOptions.maven;
 import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
@@ -96,6 +95,12 @@ public class IPCapabilityIntegrationTest
 					   .karafVersion("2.2.2")
 					   .name("mantychore")
 					   .unpackDirectory(new File("target/paxexam")),
+					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
+												"featuresBoot",
+												"opennaas-router"),
+					   configureConsole()
+					   .ignoreLocalConsole()
+					   .ignoreRemoteShell(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/integration/net.i2cat.mantychore.tests.commandsKaraf/src/test/java/net/i2cat/mantychore/commandskaraf/L2BoDCommandsKarafTest.java
+++ b/manticore/tests/integration/net.i2cat.mantychore.tests.commandsKaraf/src/test/java/net/i2cat/mantychore/commandskaraf/L2BoDCommandsKarafTest.java
@@ -1,8 +1,7 @@
 package net.i2cat.mantychore.commandskaraf;
 
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
 
 import static org.ops4j.pax.exam.CoreOptions.maven;
 import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
@@ -104,6 +103,12 @@ public class L2BoDCommandsKarafTest
 					   .karafVersion("2.2.2")
 					   .name("mantychore")
 					   .unpackDirectory(new File("target/paxexam")),
+					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
+												"featuresBoot",
+												"opennaas-bod,opennaas-netconf,nexus-tests-helper"),
+					   configureConsole()
+					   .ignoreLocalConsole()
+					   .ignoreRemoteShell(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/integration/net.i2cat.mantychore.tests.commandsKaraf/src/test/java/net/i2cat/mantychore/commandskaraf/ProfileCommandsKarafTest.java
+++ b/manticore/tests/integration/net.i2cat.mantychore.tests.commandsKaraf/src/test/java/net/i2cat/mantychore/commandskaraf/ProfileCommandsKarafTest.java
@@ -1,7 +1,6 @@
 package net.i2cat.mantychore.commandskaraf;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
 
 import static org.ops4j.pax.exam.CoreOptions.maven;
 import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
@@ -100,6 +99,12 @@ public class ProfileCommandsKarafTest
 					   .karafVersion("2.2.2")
 					   .name("mantychore")
 					   .unpackDirectory(new File("target/paxexam")),
+					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
+												"featuresBoot",
+												"opennaas-router,nexus-tests-helper"),
+					   configureConsole()
+					   .ignoreLocalConsole()
+					   .ignoreRemoteShell(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/integration/net.i2cat.mantychore.tests.commandsKaraf/src/test/java/net/i2cat/mantychore/commandskaraf/QueueCommandsKarafTest.java
+++ b/manticore/tests/integration/net.i2cat.mantychore.tests.commandsKaraf/src/test/java/net/i2cat/mantychore/commandskaraf/QueueCommandsKarafTest.java
@@ -1,8 +1,6 @@
 package net.i2cat.mantychore.commandskaraf;
 
-
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
 
 import static org.ops4j.pax.exam.CoreOptions.maven;
 import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
@@ -127,6 +125,12 @@ public class QueueCommandsKarafTest
 					   .karafVersion("2.2.2")
 					   .name("mantychore")
 					   .unpackDirectory(new File("target/paxexam")),
+					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
+												"featuresBoot",
+												"opennaas-router,nexus-tests-helper"),
+					   configureConsole()
+					   .ignoreLocalConsole()
+					   .ignoreRemoteShell(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/integration/net.i2cat.mantychore.tests.commandsKaraf/src/test/java/net/i2cat/mantychore/commandskaraf/ResourceCommandsKarafTest.java
+++ b/manticore/tests/integration/net.i2cat.mantychore.tests.commandsKaraf/src/test/java/net/i2cat/mantychore/commandskaraf/ResourceCommandsKarafTest.java
@@ -1,8 +1,6 @@
 package net.i2cat.mantychore.commandskaraf;
 
-
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
 
 import static org.ops4j.pax.exam.CoreOptions.maven;
 import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
@@ -131,6 +129,12 @@ public class ResourceCommandsKarafTest
 					   .karafVersion("2.2.2")
 					   .name("mantychore")
 					   .unpackDirectory(new File("target/paxexam")),
+					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
+												"featuresBoot",
+												"opennaas-router,nexus-tests-helper"),
+					   configureConsole()
+					   .ignoreLocalConsole()
+					   .ignoreRemoteShell(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/integration/net.i2cat.mantychore.tests.repository/src/test/java/net/i2cat/mantychore/repository/tests/MantychoreRepositoryIntegrationTest.java
+++ b/manticore/tests/integration/net.i2cat.mantychore.tests.repository/src/test/java/net/i2cat/mantychore/repository/tests/MantychoreRepositoryIntegrationTest.java
@@ -1,7 +1,6 @@
 package net.i2cat.mantychore.repository.tests;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -92,6 +91,12 @@ public class MantychoreRepositoryIntegrationTest
 					   .karafVersion("2.2.2")
 					   .name("mantychore")
 					   .unpackDirectory(new File("target/paxexam")),
+					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
+												"featuresBoot",
+												"opennaas-router,nexus-tests-helper"),
+					   configureConsole()
+					   .ignoreLocalConsole()
+					   .ignoreRemoteShell(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/integration/net.i2cat.mantychore.tests.repository/src/test/java/net/i2cat/mantychore/repository/tests/ResourceManagerIntegrationTest.java
+++ b/manticore/tests/integration/net.i2cat.mantychore.tests.repository/src/test/java/net/i2cat/mantychore/repository/tests/ResourceManagerIntegrationTest.java
@@ -1,7 +1,6 @@
 package net.i2cat.mantychore.repository.tests;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -85,6 +84,12 @@ public class ResourceManagerIntegrationTest
 					   .karafVersion("2.2.2")
 					   .name("mantychore")
 					   .unpackDirectory(new File("target/paxexam")),
+					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
+												"featuresBoot",
+												"opennaas-router"),
+					   configureConsole()
+					   .ignoreLocalConsole()
+					   .ignoreRemoteShell(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/integration/net.i2cat.nexus.tests.events/src/test/java/net/i2cat/nexus/events/tests/SendReceiveEventsTest.java
+++ b/manticore/tests/integration/net.i2cat.nexus.tests.events/src/test/java/net/i2cat/nexus/events/tests/SendReceiveEventsTest.java
@@ -1,7 +1,6 @@
 package net.i2cat.nexus.events.tests;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -78,6 +77,12 @@ public class SendReceiveEventsTest
 					   .karafVersion("2.2.2")
 					   .name("mantychore")
 					   .unpackDirectory(new File("target/paxexam")),
+					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
+												"featuresBoot",
+												"opennaas-core"),
+					   configureConsole()
+					   .ignoreLocalConsole()
+					   .ignoreRemoteShell(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/integration/net.i2cat.nexus.tests.resources/src/test/java/net/i2cat/nexus/resources/tests/ResourcesWithProfileTest.java
+++ b/manticore/tests/integration/net.i2cat.nexus.tests.resources/src/test/java/net/i2cat/nexus/resources/tests/ResourcesWithProfileTest.java
@@ -1,7 +1,6 @@
 package net.i2cat.nexus.resources.tests;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
 
 import java.io.File;
 
@@ -91,6 +90,12 @@ public class ResourcesWithProfileTest {
 					   .karafVersion("2.2.2")
 					   .name("mantychore")
 					   .unpackDirectory(new File("target/paxexam")),
+					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
+												"featuresBoot",
+												"opennaas-router"),
+					   configureConsole()
+					   .ignoreLocalConsole()
+					   .ignoreRemoteShell(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/integration/net.i2cat.nexus.tests.resources/src/test/java/net/i2cat/nexus/resources/tests/UseProfileBundleTest.java
+++ b/manticore/tests/integration/net.i2cat.nexus.tests.resources/src/test/java/net/i2cat/nexus/resources/tests/UseProfileBundleTest.java
@@ -81,8 +81,12 @@ public class UseProfileBundleTest {
 					   .karafVersion("2.2.2")
 					   .name("mantychore")
 					   .unpackDirectory(new File("target/paxexam")),
-					   editConfigurationFileExtend("etc/org.apache.karaf.features.cfg",
-												   "featuresBoot", ",nexus-testprofile"),
+					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
+												"featuresBoot",
+												"opennaas-router,nexus-testprofile"),
+					   configureConsole()
+					   .ignoreLocalConsole()
+					   .ignoreRemoteShell(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/integration/org.opennaas.bod.tests.capability.l2bod/src/test/java/org/opennaas/bod/tests/capability/l2bod/L2BoDCapabilityIntegrationTest.java
+++ b/manticore/tests/integration/org.opennaas.bod.tests.capability.l2bod/src/test/java/org/opennaas/bod/tests/capability/l2bod/L2BoDCapabilityIntegrationTest.java
@@ -1,8 +1,6 @@
 package org.opennaas.bod.tests.capability.l2bod;
 
-
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
 
 import static org.ops4j.pax.exam.CoreOptions.maven;
 import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
@@ -83,6 +81,12 @@ public class L2BoDCapabilityIntegrationTest
 					   .karafVersion("2.2.2")
 					   .name("mantychore")
 					   .unpackDirectory(new File("target/paxexam")),
+					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
+												"featuresBoot",
+												"opennaas-bod,nexus-tests-helper"),
+					   configureConsole()
+					   .ignoreLocalConsole()
+					   .ignoreRemoteShell(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/integration/org.opennaas.bod.tests.repository/src/test/java/org/opennaas/bod/tests/repository/BODRepositoryIntegrationTest.java
+++ b/manticore/tests/integration/org.opennaas.bod.tests.repository/src/test/java/org/opennaas/bod/tests/repository/BODRepositoryIntegrationTest.java
@@ -1,7 +1,6 @@
 package org.opennaas.bod.tests.repository;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
 
 import static org.ops4j.pax.exam.CoreOptions.maven;
 import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
@@ -68,6 +67,12 @@ public class BODRepositoryIntegrationTest
 					   .karafVersion("2.2.2")
 					   .name("mantychore")
 					   .unpackDirectory(new File("target/paxexam")),
+					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
+												"featuresBoot",
+												"opennaas-bod,nexus-tests-helper"),
+					   configureConsole()
+					   .ignoreLocalConsole()
+					   .ignoreRemoteShell(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/integration/org.opennaas.bod.tests/src/test/java/org/opennaas/bod/tests/BoDIntegrationTest.java
+++ b/manticore/tests/integration/org.opennaas.bod.tests/src/test/java/org/opennaas/bod/tests/BoDIntegrationTest.java
@@ -1,7 +1,6 @@
 package org.opennaas.bod.tests;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
 
 import static org.ops4j.pax.exam.CoreOptions.maven;
 import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
@@ -87,6 +86,12 @@ public class BoDIntegrationTest
 					   .karafVersion("2.2.2")
 					   .name("mantychore")
 					   .unpackDirectory(new File("target/paxexam")),
+					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
+												"featuresBoot",
+												"opennaas-bod,nexus-tests-helper"),
+					   configureConsole()
+					   .ignoreLocalConsole()
+					   .ignoreRemoteShell(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/integration/org.opennaas.router.tests.capability.gretunnel/src/test/java/org/opennaas/router/tests/capability/GRETunnelIntegrationTest.java
+++ b/manticore/tests/integration/org.opennaas.router.tests.capability.gretunnel/src/test/java/org/opennaas/router/tests/capability/GRETunnelIntegrationTest.java
@@ -3,8 +3,7 @@
  */
 package org.opennaas.router.tests.capability;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
 
 import static org.ops4j.pax.exam.CoreOptions.maven;
 import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
@@ -105,6 +104,12 @@ public abstract class GRETunnelIntegrationTest
 					   .karafVersion("2.2.2")
 					   .name("mantychore")
 					   .unpackDirectory(new File("target/paxexam")),
+					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
+												"featuresBoot",
+												"opennaas-router"),
+					   configureConsole()
+					   .ignoreLocalConsole()
+					   .ignoreRemoteShell(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/integration/org.opennaas.router.tests.capability.ospf/src/test/java/org/opennaas/router/tests/capability/ospf/OSPFIntegrationTest.java
+++ b/manticore/tests/integration/org.opennaas.router.tests.capability.ospf/src/test/java/org/opennaas/router/tests/capability/ospf/OSPFIntegrationTest.java
@@ -3,8 +3,7 @@
  */
 package org.opennaas.router.tests.capability.ospf;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
 
 import static org.ops4j.pax.exam.CoreOptions.maven;
 import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
@@ -88,6 +87,12 @@ public abstract class OSPFIntegrationTest
 					   .karafVersion("2.2.2")
 					   .name("mantychore")
 					   .unpackDirectory(new File("target/paxexam")),
+					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
+												"featuresBoot",
+												"opennaas-router,nexus-tests-helper"),
+					   configureConsole()
+					   .ignoreLocalConsole()
+					   .ignoreRemoteShell(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/sprints/sprint0_2/src/test/java/luminis/RawSocketAlarmsTest.java
+++ b/manticore/tests/sprints/sprint0_2/src/test/java/luminis/RawSocketAlarmsTest.java
@@ -1,7 +1,6 @@
 package luminis;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
 
 import static org.ops4j.pax.exam.CoreOptions.maven;
 import static org.ops4j.pax.exam.CoreOptions.options;
@@ -91,6 +90,12 @@ public class RawSocketAlarmsTest implements EventHandler {
 					   .karafVersion("2.2.2")
 					   .name("mantychore")
 					   .unpackDirectory(new File("target/paxexam")),
+					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
+												"featuresBoot",
+												"opennaas-luminis"),
+					   configureConsole()
+					   .ignoreLocalConsole()
+					   .ignoreRemoteShell(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/sprints/sprint0_2/src/test/java/mantychore/ConfigureLRTest.java
+++ b/manticore/tests/sprints/sprint0_2/src/test/java/mantychore/ConfigureLRTest.java
@@ -1,7 +1,6 @@
 package mantychore;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
 
 import static org.ops4j.pax.exam.CoreOptions.maven;
 import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
@@ -106,6 +105,12 @@ public class ConfigureLRTest
 					   .karafVersion("2.2.2")
 					   .name("mantychore")
 					   .unpackDirectory(new File("target/paxexam")),
+					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
+												"featuresBoot",
+												"opennaas-router,nexus-tests-helper"),
+					   configureConsole()
+					   .ignoreLocalConsole()
+					   .ignoreRemoteShell(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/sprints/sprint0_2/src/test/java/mantychore/CreateLogicalRouterTest.java
+++ b/manticore/tests/sprints/sprint0_2/src/test/java/mantychore/CreateLogicalRouterTest.java
@@ -1,7 +1,6 @@
 package mantychore;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
 
 import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
 import static org.ops4j.pax.exam.CoreOptions.maven;
@@ -102,6 +101,12 @@ public class CreateLogicalRouterTest
 					   .karafVersion("2.2.2")
 					   .name("mantychore")
 					   .unpackDirectory(new File("target/paxexam")),
+					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
+												"featuresBoot",
+												"opennaas-router,nexus-tests-helper"),
+					   configureConsole()
+					   .ignoreLocalConsole()
+					   .ignoreRemoteShell(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/sprints/sprint0_2/src/test/java/mantychore/RemoveLogicalRouterTest.java
+++ b/manticore/tests/sprints/sprint0_2/src/test/java/mantychore/RemoveLogicalRouterTest.java
@@ -1,7 +1,6 @@
 package mantychore;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
 
 import static org.ops4j.pax.exam.CoreOptions.maven;
 import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
@@ -100,6 +99,12 @@ public class RemoveLogicalRouterTest {
 					   .karafVersion("2.2.2")
 					   .name("mantychore")
 					   .unpackDirectory(new File("target/paxexam")),
+					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
+												"featuresBoot",
+												"opennaas-router,nexus-tests-helper"),
+					   configureConsole()
+					   .ignoreLocalConsole()
+					   .ignoreRemoteShell(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/sprints/sprint0_3/src/test/java/luminis/AlarmsInProtocolSessionManagerTest.java
+++ b/manticore/tests/sprints/sprint0_3/src/test/java/luminis/AlarmsInProtocolSessionManagerTest.java
@@ -1,8 +1,6 @@
 package luminis;
 
-
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
 
 import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
 import static org.ops4j.pax.exam.CoreOptions.maven;
@@ -72,6 +70,12 @@ public class AlarmsInProtocolSessionManagerTest implements EventHandler {
 					   .karafVersion("2.2.2")
 					   .name("mantychore")
 					   .unpackDirectory(new File("target/paxexam")),
+					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
+												"featuresBoot",
+												"opennaas-core"),
+					   configureConsole()
+					   .ignoreLocalConsole()
+					   .ignoreRemoteShell(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/sprints/sprint0_3/src/test/java/luminis/AlarmsRepoTest.java
+++ b/manticore/tests/sprints/sprint0_3/src/test/java/luminis/AlarmsRepoTest.java
@@ -1,7 +1,6 @@
 package luminis;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
 
 import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
 import static org.ops4j.pax.exam.CoreOptions.maven;
@@ -101,6 +100,12 @@ public class AlarmsRepoTest
 					   .karafVersion("2.2.2")
 					   .name("mantychore")
 					   .unpackDirectory(new File("target/paxexam")),
+					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
+												"featuresBoot",
+												"opennaas-alarms,opennaas-cim,opennaas-luminis"),
+					   configureConsole()
+					   .ignoreLocalConsole()
+					   .ignoreRemoteShell(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/sprints/sprint0_3/src/test/java/luminis/CompleteAlarmsWorkflowTest.java
+++ b/manticore/tests/sprints/sprint0_3/src/test/java/luminis/CompleteAlarmsWorkflowTest.java
@@ -1,8 +1,6 @@
 package luminis;
 
-
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
 
 import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
 import static org.ops4j.pax.exam.CoreOptions.maven;
@@ -98,6 +96,12 @@ public class CompleteAlarmsWorkflowTest
 					   .karafVersion("2.2.2")
 					   .name("mantychore")
 					   .unpackDirectory(new File("target/paxexam")),
+					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
+												"featuresBoot",
+												"opennaas-alarms,opennaas-luminis"),
+					   configureConsole()
+					   .ignoreLocalConsole()
+					   .ignoreRemoteShell(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/sprints/sprint0_3/src/test/java/luminis/MonitoringCapabilityTest.java
+++ b/manticore/tests/sprints/sprint0_3/src/test/java/luminis/MonitoringCapabilityTest.java
@@ -1,8 +1,6 @@
 package luminis;
 
-
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
 
 import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
 import static org.ops4j.pax.exam.CoreOptions.maven;
@@ -104,6 +102,12 @@ public class MonitoringCapabilityTest implements EventHandler
 					   .karafVersion("2.2.2")
 					   .name("mantychore")
 					   .unpackDirectory(new File("target/paxexam")),
+					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
+												"featuresBoot",
+												"opennaas-luminis"),
+					   configureConsole()
+					   .ignoreLocalConsole()
+					   .ignoreRemoteShell(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/sprints/sprint0_3/src/test/java/luminis/RawSocketAlarmToResourceAlarmTest.java
+++ b/manticore/tests/sprints/sprint0_3/src/test/java/luminis/RawSocketAlarmToResourceAlarmTest.java
@@ -1,8 +1,6 @@
 package luminis;
 
-
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
 
 import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
 import static org.ops4j.pax.exam.CoreOptions.maven;
@@ -96,6 +94,12 @@ public class RawSocketAlarmToResourceAlarmTest implements EventHandler
 					   .karafVersion("2.2.2")
 					   .name("mantychore")
 					   .unpackDirectory(new File("target/paxexam")),
+					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
+												"featuresBoot",
+												"opennaas-luminis,nexus-tests-helper"),
+					   configureConsole()
+					   .ignoreLocalConsole()
+					   .ignoreRemoteShell(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/sprints/sprint0_4/src/test/java/interfaces/configure/ConfigureSubInterfaceTest.java
+++ b/manticore/tests/sprints/sprint0_4/src/test/java/interfaces/configure/ConfigureSubInterfaceTest.java
@@ -1,7 +1,6 @@
 package interfaces.configure;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
 
 import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
 import static org.ops4j.pax.exam.CoreOptions.maven;
@@ -100,6 +99,12 @@ public class ConfigureSubInterfaceTest
 					   .karafVersion("2.2.2")
 					   .name("mantychore")
 					   .unpackDirectory(new File("target/paxexam")),
+					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
+												"featuresBoot",
+												"opennaas-router,nexus-tests-helper"),
+					   configureConsole()
+					   .ignoreLocalConsole()
+					   .ignoreRemoteShell(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/sprints/sprint0_4/src/test/java/interfaces/setdesc/SetInterfaceDescriptionActionInLRTest.java
+++ b/manticore/tests/sprints/sprint0_4/src/test/java/interfaces/setdesc/SetInterfaceDescriptionActionInLRTest.java
@@ -1,7 +1,6 @@
 package interfaces.setdesc;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
 
 import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
 import static org.ops4j.pax.exam.CoreOptions.maven;
@@ -106,6 +105,12 @@ public class SetInterfaceDescriptionActionInLRTest
 					   .karafVersion("2.2.2")
 					   .name("mantychore")
 					   .unpackDirectory(new File("target/paxexam")),
+					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
+												"featuresBoot",
+												"opennaas-router,nexus-tests-helper"),
+					   configureConsole()
+					   .ignoreLocalConsole()
+					   .ignoreRemoteShell(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/sprints/sprint0_4/src/test/java/interfaces/setdesc/SetInterfaceDescriptionActionTest.java
+++ b/manticore/tests/sprints/sprint0_4/src/test/java/interfaces/setdesc/SetInterfaceDescriptionActionTest.java
@@ -1,7 +1,6 @@
 package interfaces.setdesc;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
 
 import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
 import static org.ops4j.pax.exam.CoreOptions.maven;
@@ -100,6 +99,12 @@ public class SetInterfaceDescriptionActionTest
 					   .karafVersion("2.2.2")
 					   .name("mantychore")
 					   .unpackDirectory(new File("target/paxexam")),
+					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
+												"featuresBoot",
+												"opennaas-router,nexus-tests-helper"),
+					   configureConsole()
+					   .ignoreLocalConsole()
+					   .ignoreRemoteShell(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/sprints/week26/src/test/java/interfaces/InterfacesDownKarafTest.java
+++ b/manticore/tests/sprints/week26/src/test/java/interfaces/InterfacesDownKarafTest.java
@@ -1,7 +1,6 @@
 package interfaces;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
 
 import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
 import static org.ops4j.pax.exam.CoreOptions.maven;
@@ -111,6 +110,12 @@ public class InterfacesDownKarafTest
 					   .karafVersion("2.2.2")
 					   .name("mantychore")
 					   .unpackDirectory(new File("target/paxexam")),
+					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
+												"featuresBoot",
+												"opennaas-router,nexus-tests-helper"),
+					   configureConsole()
+					   .ignoreLocalConsole()
+					   .ignoreRemoteShell(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/sprints/week26/src/test/java/interfaces/InterfacesDownUpKarafTest.java
+++ b/manticore/tests/sprints/week26/src/test/java/interfaces/InterfacesDownUpKarafTest.java
@@ -1,7 +1,6 @@
 package interfaces;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
 
 import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
 import static org.ops4j.pax.exam.CoreOptions.maven;
@@ -102,6 +101,12 @@ public class InterfacesDownUpKarafTest
 					   .karafVersion("2.2.2")
 					   .name("mantychore")
 					   .unpackDirectory(new File("target/paxexam")),
+					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
+												"featuresBoot",
+												"opennaas-router,nexus-tests-helper"),
+					   configureConsole()
+					   .ignoreLocalConsole()
+					   .ignoreRemoteShell(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/sprints/week26/src/test/java/interfaces/InterfacesIPKarafTest.java
+++ b/manticore/tests/sprints/week26/src/test/java/interfaces/InterfacesIPKarafTest.java
@@ -1,7 +1,6 @@
 package interfaces;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
 
 import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
 import static org.ops4j.pax.exam.CoreOptions.maven;
@@ -103,6 +102,12 @@ public class InterfacesIPKarafTest
 					   .karafVersion("2.2.2")
 					   .name("mantychore")
 					   .unpackDirectory(new File("target/paxexam")),
+					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
+												"featuresBoot",
+												"opennaas-router,nexus-tests-helper"),
+					   configureConsole()
+					   .ignoreLocalConsole()
+					   .ignoreRemoteShell(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/sprints/week26/src/test/java/interfaces/InterfacesUPDownLoKarafTest.java
+++ b/manticore/tests/sprints/week26/src/test/java/interfaces/InterfacesUPDownLoKarafTest.java
@@ -1,7 +1,6 @@
 package interfaces;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
 
 import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
 import static org.ops4j.pax.exam.CoreOptions.maven;
@@ -102,6 +101,12 @@ public class InterfacesUPDownLoKarafTest
 					   .karafVersion("2.2.2")
 					   .name("mantychore")
 					   .unpackDirectory(new File("target/paxexam")),
+					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
+												"featuresBoot",
+												"opennaas-router,nexus-tests-helper"),
+					   configureConsole()
+					   .ignoreLocalConsole()
+					   .ignoreRemoteShell(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/sprints/week26/src/test/java/interfaces/InterfacesUpKarafTest.java
+++ b/manticore/tests/sprints/week26/src/test/java/interfaces/InterfacesUpKarafTest.java
@@ -1,7 +1,6 @@
 package interfaces;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
 
 import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
 import static org.ops4j.pax.exam.CoreOptions.maven;
@@ -112,6 +111,12 @@ public class InterfacesUpKarafTest
 					   .karafVersion("2.2.2")
 					   .name("mantychore")
 					   .unpackDirectory(new File("target/paxexam")),
+					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
+												"featuresBoot",
+												"opennaas-router,nexus-tests-helper"),
+					   configureConsole()
+					   .ignoreLocalConsole()
+					   .ignoreRemoteShell(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/sprints/week26/src/test/java/interfaces/InterfacesVLANKarafTest.java
+++ b/manticore/tests/sprints/week26/src/test/java/interfaces/InterfacesVLANKarafTest.java
@@ -1,7 +1,6 @@
 package interfaces;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
 
 import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
 import static org.ops4j.pax.exam.CoreOptions.maven;
@@ -101,6 +100,12 @@ public class InterfacesVLANKarafTest
 					   .karafVersion("2.2.2")
 					   .name("mantychore")
 					   .unpackDirectory(new File("target/paxexam")),
+					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
+												"featuresBoot",
+												"opennaas-router,nexus-tests-helper"),
+					   configureConsole()
+					   .ignoreLocalConsole()
+					   .ignoreRemoteShell(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/sprints/week26/src/test/java/queue/QueueTest.java
+++ b/manticore/tests/sprints/week26/src/test/java/queue/QueueTest.java
@@ -1,7 +1,6 @@
 package queue;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
 
 import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
 import static org.ops4j.pax.exam.CoreOptions.maven;
@@ -105,6 +104,12 @@ public class QueueTest
 					   .karafVersion("2.2.2")
 					   .name("mantychore")
 					   .unpackDirectory(new File("target/paxexam")),
+					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
+												"featuresBoot",
+												"opennaas-cim,opennaas-netconf,nexus-tests-helper"),
+					   configureConsole()
+					   .ignoreLocalConsole()
+					   .ignoreRemoteShell(),
 					   mavenBundle()
 					   .groupId("org.ops4j.base")
 					   .artifactId("ops4j-base-spi")

--- a/manticore/tests/sprints/week35/src/test/java/automaticrefresh/AutomaticRefreshLuminisTest.java
+++ b/manticore/tests/sprints/week35/src/test/java/automaticrefresh/AutomaticRefreshLuminisTest.java
@@ -1,8 +1,6 @@
 package automaticrefresh;
 
-
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
 
 import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
 import static org.ops4j.pax.exam.CoreOptions.maven;
@@ -64,6 +62,12 @@ public class AutomaticRefreshLuminisTest
 					   .karafVersion("2.2.2")
 					   .name("mantychore")
 					   .unpackDirectory(new File("target/paxexam")),
+					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
+												"featuresBoot",
+												"opennaas-luminis,nexus-tests-helper"),
+					   configureConsole()
+					   .ignoreLocalConsole()
+					   .ignoreRemoteShell(),
 					   keepRuntimeFolder());
 	}
 


### PR DESCRIPTION
Until now all integration tests simply relied on Mantychore by
default loading all modules. This leads to unnecessarily slow
tests as they load bundles not related to the test.

This patch changes the integration tests to explicitly specify
which features they test. Other features are not loaded.

This has a significant and positive impact on runtime and also 
means we can adjust the default feature set independently of the
integration tests (eg remove some non-essential features or
maybe add features that would have slowed down integrations
tests significantly).

The patch also adds instructions to prevent the shell
component of Karaf from being loaded. This too speeds up
execution.
