### PR TITLE
Feature/add base class for integration tests

### DIFF
--- a/manticore/bundles/net.i2cat.nexus.tests.helper/pom.xml
+++ b/manticore/bundles/net.i2cat.nexus.tests.helper/pom.xml
@@ -26,6 +26,22 @@
 			<groupId>org.apache.felix</groupId>
 			<artifactId>org.apache.felix.gogo.runtime</artifactId>
 		</dependency>
+
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<scope>compile</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.ops4j.pax.exam</groupId>
+			<artifactId>pax-exam-junit4</artifactId>
+			<scope>compile</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.openengsb.labs.paxexam.karaf</groupId>
+			<artifactId>paxexam-karaf-container</artifactId>
+			<scope>compile</scope>
+		</dependency>
 	</dependencies>
 
 	<build>
@@ -38,7 +54,14 @@
 					<instructions>
 						<Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
 						<Bundle-Version>${project.version}</Bundle-Version>
+						<!-- Guava and Pax Exam are optional
+						     depedencies because we currently use them
+						     in the context of the JUnitRunner and not
+						     from withing the OSGi based test
+						     container. -->
 						<Import-Package>
+							org.ops4j.pax.exam.junit;resolution:=optional,
+							com.google.common.*;resolution:=optional,
 							org.slf4j,
 							org.osgi.framework,
 							*

--- a/manticore/bundles/net.i2cat.nexus.tests.helper/src/main/java/net/i2cat/nexus/tests/AbstractKarafCommandTest.java
+++ b/manticore/bundles/net.i2cat.nexus.tests.helper/src/main/java/net/i2cat/nexus/tests/AbstractKarafCommandTest.java
@@ -1,0 +1,28 @@
+package net.i2cat.nexus.tests;
+
+import java.util.List;
+import javax.inject.Inject;
+
+import org.ops4j.pax.exam.TestProbeBuilder;
+import org.ops4j.pax.exam.junit.ProbeBuilder;
+
+import org.osgi.framework.Constants;
+
+import org.apache.felix.service.command.CommandProcessor;
+
+public class AbstractKarafCommandTest
+{
+	@Inject
+	protected CommandProcessor commandProcessor;
+
+	@ProbeBuilder
+	public static TestProbeBuilder probeConfiguration(TestProbeBuilder probe) {
+		probe.setHeader(Constants.DYNAMICIMPORT_PACKAGE, "*,org.apache.felix.service.*;status=provisional");
+		return probe;
+	}
+
+	protected List<String> executeCommand(String command) throws Exception
+	{
+		return KarafCommandHelper.executeCommand(command, commandProcessor);
+	}
+}

--- a/manticore/bundles/net.i2cat.nexus.tests.helper/src/main/java/net/i2cat/nexus/tests/OpennaasExamOptions.java
+++ b/manticore/bundles/net.i2cat.nexus.tests.helper/src/main/java/net/i2cat/nexus/tests/OpennaasExamOptions.java
@@ -1,0 +1,71 @@
+package net.i2cat.nexus.tests;
+
+import com.google.common.base.Joiner;
+
+import java.io.File;
+
+import org.ops4j.pax.exam.Option;
+import org.openengsb.labs.paxexam.karaf.options.KarafDistributionBaseConfigurationOption;
+
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
+import static org.ops4j.pax.exam.CoreOptions.*;
+
+public abstract class OpennaasExamOptions
+{
+	public final static KarafDistributionBaseConfigurationOption
+		opennaasDistributionConfiguration()
+	{
+		return
+			karafDistributionConfiguration()
+			.frameworkUrl(maven()
+						  .groupId("net.i2cat.mantychore")
+						  .artifactId("assembly")
+						  .type("zip")
+						  .classifier("bin")
+						  .versionAsInProject())
+			.karafVersion("2.2.2")
+			.name("opennaas")
+			.unpackDirectory(new File("target/paxexam"));
+	}
+
+	public final static Option includeTestHelper()
+	{
+		return composite(mavenBundle()
+						 .groupId("net.i2cat.nexus")
+						 .artifactId("net.i2cat.nexus.tests.helper")
+						 .versionAsInProject());
+	}
+
+	public final static Option includeTestMockProfile()
+	{
+		return
+			mavenBundle()
+			.groupId("org.opennaas")
+			.artifactId("opennaas-core-tests-mockprofile")
+			.versionAsInProject();
+	}
+
+	public final static Option includeSwissboxFramework()
+	{
+		return composite(mavenBundle()
+						 .groupId("org.ops4j.base")
+						 .artifactId("ops4j-base-spi")
+						 .versionAsInProject(),
+						 mavenBundle()
+						 .groupId("org.ops4j.pax.swissbox")
+						 .artifactId("pax-swissbox-framework")
+						 .versionAsInProject());
+	}
+
+	public final static Option includeFeatures(String... features)
+	{
+		return editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
+										"featuresBoot",
+										Joiner.on(",").join(features));
+	}
+
+	public final static Option noConsole()
+	{
+		return configureConsole().ignoreLocalConsole().ignoreRemoteShell();
+	}
+}

--- a/manticore/platform/src/main/filtered-resources/etc/org.apache.karaf.features.cfg
+++ b/manticore/platform/src/main/filtered-resources/etc/org.apache.karaf.features.cfg
@@ -26,4 +26,4 @@ featuresRepositories=mvn:org.apache.karaf.assemblies.features/standard/${karaf.v
 #
 # Comma separated list of features to install at startup
 #
-featuresBoot=config,ssh,management,opennaas,nexus-tests-helper
+featuresBoot=config,ssh,management,opennaas

--- a/manticore/tests/integration/net.i2cat.luminis.tests.actions/src/test/java/net/i2cat/luminis/actions/tests/ConnectionActionsIntegrationTest.java
+++ b/manticore/tests/integration/net.i2cat.luminis.tests.actions/src/test/java/net/i2cat/luminis/actions/tests/ConnectionActionsIntegrationTest.java
@@ -1,7 +1,5 @@
 package net.i2cat.luminis.actions.tests;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
-
 import java.util.HashMap;
 import java.util.List;
 import java.io.File;
@@ -47,9 +45,10 @@ import org.opennaas.core.resources.protocol.ProtocolSessionContext;
 import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.junit.Configuration;
 import org.ops4j.pax.exam.junit.JUnit4TestRunner;
-import static org.ops4j.pax.exam.CoreOptions.maven;
-import static org.ops4j.pax.exam.CoreOptions.options;
 
+import static net.i2cat.nexus.tests.OpennaasExamOptions.*;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
+import static org.ops4j.pax.exam.CoreOptions.*;
 
 @RunWith(JUnit4TestRunner.class)
 public class ConnectionActionsIntegrationTest {
@@ -60,22 +59,9 @@ public class ConnectionActionsIntegrationTest {
 
 	@Configuration
 	public static Option[] configuration() {
-		return options(karafDistributionConfiguration()
-					   .frameworkUrl(maven()
-									 .groupId("net.i2cat.mantychore")
-									 .artifactId("assembly")
-									 .type("zip")
-									 .classifier("bin")
-									 .versionAsInProject())
-					   .karafVersion("2.2.2")
-					   .name("mantychore")
-					   .unpackDirectory(new File("target/paxexam")),
-					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
-												"featuresBoot",
-												"opennaas-luminis"),
-					   configureConsole()
-					   .ignoreLocalConsole()
-					   .ignoreRemoteShell(),
+		return options(opennaasDistributionConfiguration(),
+					   includeFeatures("opennaas-luminis"),
+					   noConsole(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/integration/net.i2cat.luminis.tests.actions/src/test/java/net/i2cat/luminis/actions/tests/LockUnlockCommandsTest.java
+++ b/manticore/tests/integration/net.i2cat.luminis.tests.actions/src/test/java/net/i2cat/luminis/actions/tests/LockUnlockCommandsTest.java
@@ -1,7 +1,5 @@
 package net.i2cat.luminis.actions.tests;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
-
 import net.i2cat.luminis.commandsets.wonesys.WonesysCommand;
 import net.i2cat.luminis.commandsets.wonesys.commands.LockNodeCommand;
 import net.i2cat.luminis.commandsets.wonesys.commands.UnlockNodeCommand;
@@ -30,9 +28,9 @@ import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.junit.Configuration;
 import org.ops4j.pax.exam.junit.JUnit4TestRunner;
 
-import static org.ops4j.pax.exam.CoreOptions.maven;
-import static org.ops4j.pax.exam.CoreOptions.options;
-
+import static net.i2cat.nexus.tests.OpennaasExamOptions.*;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
+import static org.ops4j.pax.exam.CoreOptions.*;
 
 @RunWith(JUnit4TestRunner.class)
 public class LockUnlockCommandsTest {
@@ -46,22 +44,9 @@ public class LockUnlockCommandsTest {
 
 	@Configuration
 	public static Option[] configuration() {
-		return options(karafDistributionConfiguration()
-					   .frameworkUrl(maven()
-									 .groupId("net.i2cat.mantychore")
-									 .artifactId("assembly")
-									 .type("zip")
-									 .classifier("bin")
-									 .versionAsInProject())
-					   .karafVersion("2.2.2")
-					   .name("mantychore")
-					   .unpackDirectory(new File("target/paxexam")),
-					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
-												"featuresBoot",
-												"opennaas-luminis"),
-					   configureConsole()
-					   .ignoreLocalConsole()
-					   .ignoreRemoteShell(),
+		return options(opennaasDistributionConfiguration(),
+					   includeFeatures("opennaas-luminis"),
+					   noConsole(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/integration/net.i2cat.luminis.tests.capability/src/test/java/net/i2cat/luminis/capability/connections/test/ConnectionsCapabilityIntegrationTest.java
+++ b/manticore/tests/integration/net.i2cat.luminis.tests.capability/src/test/java/net/i2cat/luminis/capability/connections/test/ConnectionsCapabilityIntegrationTest.java
@@ -1,12 +1,5 @@
 package net.i2cat.luminis.capability.connections.test;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
-
-import static org.ops4j.pax.exam.CoreOptions.maven;
-import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
-import static org.ops4j.pax.exam.CoreOptions.options;
-
-
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
@@ -45,17 +38,19 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.ops4j.pax.exam.Option;
-import org.ops4j.pax.exam.TestProbeBuilder;
 import org.ops4j.pax.exam.junit.Configuration;
-import org.ops4j.pax.exam.junit.JUnit4TestRunner;
-import org.ops4j.pax.exam.junit.ProbeBuilder;
 import org.ops4j.pax.exam.junit.ExamReactorStrategy;
+import org.ops4j.pax.exam.junit.JUnit4TestRunner;
 import org.ops4j.pax.exam.util.Filter;
 import org.ops4j.pax.exam.spi.reactors.EagerSingleStagedReactorFactory;
 import org.osgi.framework.BundleContext;
-import org.osgi.framework.Constants;
 import org.osgi.service.blueprint.container.BlueprintContainer;
+
+import static net.i2cat.nexus.tests.OpennaasExamOptions.*;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
+import static org.ops4j.pax.exam.CoreOptions.*;
 
 @RunWith(JUnit4TestRunner.class)
 @ExamReactorStrategy(EagerSingleStagedReactorFactory.class)
@@ -90,22 +85,9 @@ public class ConnectionsCapabilityIntegrationTest
 
 	@Configuration
 	public static Option[] configuration() {
-		return options(karafDistributionConfiguration()
-					   .frameworkUrl(maven()
-									 .groupId("net.i2cat.mantychore")
-									 .artifactId("assembly")
-									 .type("zip")
-									 .classifier("bin")
-									 .versionAsInProject())
-					   .karafVersion("2.2.2")
-					   .name("mantychore")
-					   .unpackDirectory(new File("target/paxexam")),
-					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
-												"featuresBoot",
-												"opennaas-luminis"),
-					   configureConsole()
-					   .ignoreLocalConsole()
-					   .ignoreRemoteShell(),
+		return options(opennaasDistributionConfiguration(),
+					   includeFeatures("opennaas-luminis"),
+					   noConsole(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/integration/net.i2cat.luminis.tests.commandsKaraf/src/test/java/net/i2cat/luminis/commandsKaraf/tests/ConnectionsKarafCommandsTest.java
+++ b/manticore/tests/integration/net.i2cat.luminis.tests.commandsKaraf/src/test/java/net/i2cat/luminis/commandsKaraf/tests/ConnectionsKarafCommandsTest.java
@@ -1,20 +1,13 @@
 package net.i2cat.luminis.commandsKaraf.tests;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
-
 import org.ops4j.pax.exam.Option;
-import org.ops4j.pax.exam.TestProbeBuilder;
 import org.ops4j.pax.exam.junit.Configuration;
-import org.ops4j.pax.exam.junit.JUnit4TestRunner;
-import org.ops4j.pax.exam.junit.ProbeBuilder;
 import org.ops4j.pax.exam.junit.ExamReactorStrategy;
+import org.ops4j.pax.exam.junit.JUnit4TestRunner;
 import org.ops4j.pax.exam.util.Filter;
 import org.ops4j.pax.exam.spi.reactors.EagerSingleStagedReactorFactory;
-import static org.ops4j.pax.exam.CoreOptions.maven;
-import static org.ops4j.pax.exam.CoreOptions.options;
 
 import org.osgi.framework.BundleContext;
-import org.osgi.framework.Constants;
 import org.osgi.service.blueprint.container.BlueprintContainer;
 
 import org.junit.Assert;
@@ -35,9 +28,10 @@ import net.i2cat.mantychore.model.opticalSwitch.WDMChannelPlan;
 import net.i2cat.mantychore.model.opticalSwitch.dwdm.proteus.ProteusOpticalSwitch;
 import net.i2cat.mantychore.model.opticalSwitch.dwdm.proteus.cards.ProteusOpticalSwitchCard;
 
+import net.i2cat.nexus.tests.AbstractKarafCommandTest;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.felix.service.command.CommandProcessor;
 import org.apache.felix.service.command.CommandSession;
 import org.opennaas.core.resources.IResource;
 import org.opennaas.core.resources.IResourceRepository;
@@ -48,6 +42,10 @@ import org.opennaas.core.resources.protocol.IProtocolManager;
 import org.opennaas.core.resources.protocol.ProtocolException;
 import org.opennaas.core.resources.protocol.ProtocolSessionContext;
 
+import static net.i2cat.nexus.tests.OpennaasExamOptions.*;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
+import static org.ops4j.pax.exam.CoreOptions.*;
+
 /**
  * Spring week 26 <br/>
  * http://jira.i2cat.net:8080/browse/MANTYCHORE-156
@@ -56,7 +54,7 @@ import org.opennaas.core.resources.protocol.ProtocolSessionContext;
  */
 @RunWith(JUnit4TestRunner.class)
 @ExamReactorStrategy(EagerSingleStagedReactorFactory.class)
-public class ConnectionsKarafCommandsTest
+public class ConnectionsKarafCommandsTest extends AbstractKarafCommandTest
 {
 	static Log log =
 		LogFactory.getLog(ConnectionsKarafCommandsTest.class);
@@ -74,9 +72,6 @@ public class ConnectionsKarafCommandsTest
 	private IProtocolManager    protocolManager;
 
 	@Inject
-	private CommandProcessor    commandProcessor;
-
-	@Inject
 	@Filter("(osgi.blueprint.container.symbolicname=net.i2cat.luminis.capability.connections)")
 	private BlueprintContainer connectionService;
 
@@ -91,6 +86,15 @@ public class ConnectionsKarafCommandsTest
 	String				srcPortNum		= "0";
 	String				dstPortNum		= "129";
 	int					channelNum		= 32;
+
+	@Configuration
+	public static Option[] configuration() {
+		return options(opennaasDistributionConfiguration(),
+					   includeFeatures("opennaas-luminis"),
+					   includeTestHelper(),
+					   noConsole(),
+					   keepRuntimeFolder());
+	}
 
 	@Test
 	public void getInventoryCommandBasicTest() throws Exception
@@ -112,8 +116,8 @@ public class ConnectionsKarafCommandsTest
 			String responseStr;
 
 			// // FIXME refresh should skip the queue
-			// log.debug("executeCommand(connections:getInventory -r " + resourceFriendlyID + ")");
-			// responseStr = (String) executeCommand("connections:getInventory -r " + resourceFriendlyID);
+			// log.debug("executeCommandWithResponse(connections:getInventory -r " + resourceFriendlyID + ")");
+			// responseStr = (String) executeCommandWithResponse("connections:getInventory -r " + resourceFriendlyID);
 			// log.debug(responseStr);
 			// // Assert.assertNotNull(response);
 			// if (responseStr != null)
@@ -133,8 +137,8 @@ public class ConnectionsKarafCommandsTest
 			Assert.assertNotNull(dstCard);
 			Assert.assertNotNull(dstCard.getChannelPlan());
 
-			log.debug("executeCommand(connections:getInventory " + resourceFriendlyID + ")");
-			responseStr = (String) executeCommand("connections:getInventory " + resourceFriendlyID);
+			log.debug("executeCommandWithResponse(connections:getInventory " + resourceFriendlyID + ")");
+			responseStr = (String) executeCommandWithResponse("connections:getInventory " + resourceFriendlyID);
 			log.debug(responseStr);
 			// Assert.assertNotNull(response);
 			if (responseStr != null)
@@ -183,8 +187,8 @@ public class ConnectionsKarafCommandsTest
 
 			// // TODO should refresh manually????
 			// // FIXME refresh should skip the queue
-			// log.info("executeCommand(connections:getInventory " + resourceFriendlyID + ")");
-			// responseStr = (String) executeCommand("connections:getInventory " + resourceFriendlyID);
+			// log.info("executeCommandWithResponse(connections:getInventory " + resourceFriendlyID + ")");
+			// responseStr = (String) executeCommandWithResponse("connections:getInventory " + resourceFriendlyID);
 			// log.debug(responseStr);
 			// // Assert.assertNotNull(response);
 			// if (responseStr != null)
@@ -198,15 +202,15 @@ public class ConnectionsKarafCommandsTest
 			DWDMChannel channel = (DWDMChannel) channelPlan.getChannel(32);
 			double lambda = channel.getLambda();
 
-			log.info("executeCommand(connections:makeConnection " + resourceFriendlyID + " " + srcPortId + " " + lambda + " " + dstPortId + " " + lambda + ")");
-			responseStr = (String) executeCommand("connections:makeConnection " + resourceFriendlyID + " " + srcPortId + " " + lambda + " " + dstPortId + " " + lambda);
+			log.info("executeCommandWithResponse(connections:makeConnection " + resourceFriendlyID + " " + srcPortId + " " + lambda + " " + dstPortId + " " + lambda + ")");
+			responseStr = (String) executeCommandWithResponse("connections:makeConnection " + resourceFriendlyID + " " + srcPortId + " " + lambda + " " + dstPortId + " " + lambda);
 			log.debug(responseStr);
 			// Assert.assertNotNull(response);
 			if (responseStr != null)
 				Assert.fail("Error in the makeConnection command");
 
-			log.info("executeCommand(queue:execute " + resourceFriendlyID + ")");
-			Integer response = (Integer) executeCommand("queue:execute " + resourceFriendlyID);
+			log.info("executeCommandWithResponse(queue:execute " + resourceFriendlyID + ")");
+			Integer response = (Integer) executeCommandWithResponse("queue:execute " + resourceFriendlyID);
 			log.debug(response);
 			// Assert.assertNotNull(response);
 			if (response != null)
@@ -228,8 +232,8 @@ public class ConnectionsKarafCommandsTest
 			}
 			Assert.assertTrue(found);
 
-			log.info("executeCommand(connections:list " + resourceFriendlyID);
-			responseStr = (String) executeCommand("connections:list " + resourceFriendlyID);
+			log.info("executeCommandWithResponse(connections:list " + resourceFriendlyID);
+			responseStr = (String) executeCommandWithResponse("connections:list " + resourceFriendlyID);
 			if (responseStr != null)
 				Assert.fail("Error in the listConnections command");
 
@@ -261,8 +265,8 @@ public class ConnectionsKarafCommandsTest
 			String responseStr;
 			// // TODO should refresh manually????
 			// // FIXME refresh should skip the queue
-			// log.info("executeCommand(connections:getInventory -r " + resourceFriendlyID + ")");
-			// responseStr = (String) executeCommand("connections:getInventory -r " + resourceFriendlyID);
+			// log.info("executeCommandWithResponse(connections:getInventory -r " + resourceFriendlyID + ")");
+			// responseStr = (String) executeCommandWithResponse("connections:getInventory -r " + resourceFriendlyID);
 			// log.debug(responseStr);
 			// // Assert.assertNotNull(response);
 			// if (responseStr != null)
@@ -276,28 +280,28 @@ public class ConnectionsKarafCommandsTest
 			DWDMChannel channel = (DWDMChannel) channelPlan.getChannel(32);
 			double lambda = channel.getLambda();
 
-			log.info("executeCommand(connections:makeConnection " + resourceFriendlyID + " " + srcPortId + " " + lambda + " " + dstPortId + " " + lambda + ")");
-			responseStr = (String) executeCommand("connections:makeConnection " + resourceFriendlyID + " " + srcPortId + " " + lambda + " " + dstPortId + " " + lambda);
+			log.info("executeCommandWithResponse(connections:makeConnection " + resourceFriendlyID + " " + srcPortId + " " + lambda + " " + dstPortId + " " + lambda + ")");
+			responseStr = (String) executeCommandWithResponse("connections:makeConnection " + resourceFriendlyID + " " + srcPortId + " " + lambda + " " + dstPortId + " " + lambda);
 			log.debug(responseStr);
 			// Assert.assertNotNull(response);
 			if (responseStr != null)
 				Assert.fail("Error in the makeConnection command");
 
 			// should print out of date information
-			log.info("executeCommand(connections:list " + resourceFriendlyID);
-			responseStr = (String) executeCommand("connections:list " + resourceFriendlyID);
+			log.info("executeCommandWithResponse(connections:list " + resourceFriendlyID);
+			responseStr = (String) executeCommandWithResponse("connections:list " + resourceFriendlyID);
 			if (responseStr != null)
 				Assert.fail("Error in the listConnections command");
 
-			log.info("executeCommand(connections:removeConnection " + resourceFriendlyID + " " + srcPortId + " " + lambda + " " + dstPortId + " " + lambda + ")");
-			responseStr = (String) executeCommand("connections:removeConnection " + resourceFriendlyID + " " + srcPortId + " " + lambda + " " + dstPortId + " " + lambda);
+			log.info("executeCommandWithResponse(connections:removeConnection " + resourceFriendlyID + " " + srcPortId + " " + lambda + " " + dstPortId + " " + lambda + ")");
+			responseStr = (String) executeCommandWithResponse("connections:removeConnection " + resourceFriendlyID + " " + srcPortId + " " + lambda + " " + dstPortId + " " + lambda);
 			log.debug(responseStr);
 			// Assert.assertNotNull(response);
 			if (responseStr != null)
 				Assert.fail("Error in the removeConnection command");
 
-			log.info("executeCommand(queue:execute " + resourceFriendlyID + ")");
-			Integer response = (Integer) executeCommand("queue:execute " + resourceFriendlyID);
+			log.info("executeCommandWithResponse(queue:execute " + resourceFriendlyID + ")");
+			Integer response = (Integer) executeCommandWithResponse("queue:execute " + resourceFriendlyID);
 			log.debug(response);
 			// Assert.assertNotNull(response);
 			if (response != null)
@@ -349,8 +353,8 @@ public class ConnectionsKarafCommandsTest
 			String responseStr;
 
 			// // FIXME refresh should skip the queue
-			// log.debug("executeCommand(connections:getInventory " + resourceFriendlyID + ")");
-			// responseStr = (String) executeCommand("connections:getInventory " + resourceFriendlyID);
+			// log.debug("executeCommandWithResponse(connections:getInventory " + resourceFriendlyID + ")");
+			// responseStr = (String) executeCommandWithResponse("connections:getInventory " + resourceFriendlyID);
 			// log.debug(responseStr);
 			// // Assert.assertNotNull(response);
 			// if (responseStr != null)
@@ -370,8 +374,8 @@ public class ConnectionsKarafCommandsTest
 			Assert.assertNotNull(dstCard);
 			Assert.assertNotNull(dstCard.getChannelPlan());
 
-			log.debug("executeCommand(connections:getInventory " + resourceFriendlyID + ")");
-			responseStr = (String) executeCommand("connections:getInventory " + resourceFriendlyID);
+			log.debug("executeCommandWithResponse(connections:getInventory " + resourceFriendlyID + ")");
+			responseStr = (String) executeCommandWithResponse("connections:getInventory " + resourceFriendlyID);
 			log.debug(responseStr);
 			// Assert.assertNotNull(response);
 			if (responseStr != null)
@@ -398,22 +402,22 @@ public class ConnectionsKarafCommandsTest
 			DWDMChannel channel = (DWDMChannel) channelPlan.getChannel(32);
 			double lambda = channel.getLambda();
 
-			log.info("executeCommand(connections:makeConnection " + resourceFriendlyID + " " + srcPortId + " " + lambda + " " + dstPortId + " " + lambda + ")");
-			responseStr = (String) executeCommand("connections:makeConnection " + resourceFriendlyID + " " + srcPortId + " " + lambda + " " + dstPortId + " " + lambda);
+			log.info("executeCommandWithResponse(connections:makeConnection " + resourceFriendlyID + " " + srcPortId + " " + lambda + " " + dstPortId + " " + lambda + ")");
+			responseStr = (String) executeCommandWithResponse("connections:makeConnection " + resourceFriendlyID + " " + srcPortId + " " + lambda + " " + dstPortId + " " + lambda);
 			log.debug(responseStr);
 			// Assert.assertNotNull(response);
 			if (responseStr != null)
 				Assert.fail("Error in the makeConnection command");
 
-			log.debug("executeCommand(queue:execute " + resourceFriendlyID + ")");
-			Integer response = (Integer) executeCommand("queue:execute " + resourceFriendlyID);
+			log.debug("executeCommandWithResponse(queue:execute " + resourceFriendlyID + ")");
+			Integer response = (Integer) executeCommandWithResponse("queue:execute " + resourceFriendlyID);
 			log.debug(response);
 			// Assert.assertNotNull(response);
 			if (response != null)
 				Assert.fail("Error in the execute queue command");
 
-			log.debug("executeCommand(connections:getInventory " + resourceFriendlyID + ")");
-			responseStr = (String) executeCommand("connections:getInventory " + resourceFriendlyID);
+			log.debug("executeCommandWithResponse(connections:getInventory " + resourceFriendlyID + ")");
+			responseStr = (String) executeCommandWithResponse("connections:getInventory " + resourceFriendlyID);
 			log.debug(responseStr);
 			// Assert.assertNotNull(response);
 			if (responseStr != null)
@@ -438,33 +442,6 @@ public class ConnectionsKarafCommandsTest
 		}
 	}
 
-    @ProbeBuilder
-    public TestProbeBuilder probeConfiguration(TestProbeBuilder probe) {
-        probe.setHeader(Constants.DYNAMICIMPORT_PACKAGE, "*,org.apache.felix.service.*;status=provisional");
-        return probe;
-    }
-
-	@Configuration
-	public static Option[] configuration() {
-		return options(karafDistributionConfiguration()
-					   .frameworkUrl(maven()
-									 .groupId("net.i2cat.mantychore")
-									 .artifactId("assembly")
-									 .type("zip")
-									 .classifier("bin")
-									 .versionAsInProject())
-					   .karafVersion("2.2.2")
-					   .name("mantychore")
-					   .unpackDirectory(new File("target/paxexam")),
-					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
-												"featuresBoot",
-												"opennaas-luminis"),
-					   configureConsole()
-					   .ignoreLocalConsole()
-					   .ignoreRemoteShell(),
-					   keepRuntimeFolder());
-	}
-
 	public void createProtocolForResource(String resourceId) throws ProtocolException {
 		protocolManager.getProtocolSessionManagerWithContext(resourceId, newWonesysSessionContext());
 
@@ -486,7 +463,7 @@ public class ConnectionsKarafCommandsTest
 		return protocolSessionContext;
 	}
 
-	public Object executeCommand(String command) throws Exception {
+	public Object executeCommandWithResponse(String command) throws Exception {
 		// Run some commands to make sure they are installed properly
 		ByteArrayOutputStream outputError = new ByteArrayOutputStream();
 		PrintStream psE = new PrintStream(outputError);
@@ -502,9 +479,9 @@ public class ConnectionsKarafCommandsTest
 		} catch (NoSuchMethodException a) {
 			log.error("Method for command not found: " + a.getLocalizedMessage());
 			Assert.fail("Method for command not found.");
+		} finally {
+			cs.close();
 		}
-
-		cs.close();
 		return commandOutput;
 	}
 }

--- a/manticore/tests/integration/net.i2cat.luminis.tests.protocols.wonesys/src/test/java/net/i2cat/luminis/protocols/wonesys/tests/ReceiveAlarmsTest.java
+++ b/manticore/tests/integration/net.i2cat.luminis.tests.protocols.wonesys/src/test/java/net/i2cat/luminis/protocols/wonesys/tests/ReceiveAlarmsTest.java
@@ -1,21 +1,9 @@
 package net.i2cat.luminis.protocols.wonesys.tests;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
-
-import static org.ops4j.pax.exam.CoreOptions.maven;
-import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
-import static org.ops4j.pax.exam.CoreOptions.options;
-import static org.ops4j.pax.exam.OptionUtils.combine;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import javax.inject.Inject;
 
 import org.junit.Test;
@@ -38,11 +26,9 @@ import org.osgi.service.event.Event;
 import org.osgi.service.event.EventHandler;
 
 import org.ops4j.pax.exam.Option;
-import org.ops4j.pax.exam.TestProbeBuilder;
 import org.ops4j.pax.exam.junit.Configuration;
-import org.ops4j.pax.exam.junit.JUnit4TestRunner;
-import org.ops4j.pax.exam.junit.ProbeBuilder;
 import org.ops4j.pax.exam.junit.ExamReactorStrategy;
+import org.ops4j.pax.exam.junit.JUnit4TestRunner;
 import org.ops4j.pax.exam.spi.reactors.EagerSingleStagedReactorFactory;
 import org.ops4j.pax.exam.util.Filter;
 
@@ -63,9 +49,15 @@ import net.i2cat.luminis.protocols.wonesys.alarms.WonesysAlarm;
 import net.i2cat.luminis.protocols.wonesys.alarms.WonesysAlarmEvent;
 import net.i2cat.luminis.protocols.wonesys.alarms.WonesysAlarmEventFilter;
 
-@RunWith(JUnit4TestRunner.class)
-public class ReceiveAlarmsTest implements EventHandler {
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static net.i2cat.nexus.tests.OpennaasExamOptions.*;
+import static org.junit.Assert.*;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
+import static org.ops4j.pax.exam.CoreOptions.*;
 
+@RunWith(JUnit4TestRunner.class)
+public class ReceiveAlarmsTest implements EventHandler
+{
 	private static Log log = LogFactory.getLog(ReceiveAlarmsTest.class);
 
 	@Inject
@@ -95,22 +87,9 @@ public class ReceiveAlarmsTest implements EventHandler {
 
 	@Configuration
 	public static Option[] configuration() {
-		return options(karafDistributionConfiguration()
-					   .frameworkUrl(maven()
-									 .groupId("net.i2cat.mantychore")
-									 .artifactId("assembly")
-									 .type("zip")
-									 .classifier("bin")
-									 .versionAsInProject())
-					   .karafVersion("2.2.2")
-					   .name("mantychore")
-					   .unpackDirectory(new File("target/paxexam")),
-					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
-												"featuresBoot",
-												"opennaas-luminis"),
-					   configureConsole()
-					   .ignoreLocalConsole()
-					   .ignoreRemoteShell(),
+		return options(opennaasDistributionConfiguration(),
+					   includeFeatures("opennaas-luminis"),
+					   noConsole(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/integration/net.i2cat.luminis.tests.protocols.wonesys/src/test/java/net/i2cat/luminis/protocols/wonesys/tests/SendCommandTest.java
+++ b/manticore/tests/integration/net.i2cat.luminis.tests.protocols.wonesys/src/test/java/net/i2cat/luminis/protocols/wonesys/tests/SendCommandTest.java
@@ -1,12 +1,5 @@
 package net.i2cat.luminis.protocols.wonesys.tests;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
-
-import static org.ops4j.pax.exam.CoreOptions.maven;
-import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
-import static org.ops4j.pax.exam.CoreOptions.options;
-import static org.ops4j.pax.exam.OptionUtils.combine;
-
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
@@ -28,11 +21,9 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import org.ops4j.pax.exam.Option;
-import org.ops4j.pax.exam.TestProbeBuilder;
 import org.ops4j.pax.exam.junit.Configuration;
-import org.ops4j.pax.exam.junit.JUnit4TestRunner;
-import org.ops4j.pax.exam.junit.ProbeBuilder;
 import org.ops4j.pax.exam.junit.ExamReactorStrategy;
+import org.ops4j.pax.exam.junit.JUnit4TestRunner;
 import org.ops4j.pax.exam.spi.reactors.EagerSingleStagedReactorFactory;
 import org.ops4j.pax.exam.util.Filter;
 
@@ -58,6 +49,10 @@ import org.opennaas.core.events.IEventManager;
 
 import org.osgi.service.blueprint.container.BlueprintContainer;
 
+import static net.i2cat.nexus.tests.OpennaasExamOptions.*;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
+import static org.ops4j.pax.exam.CoreOptions.*;
+
 @RunWith(JUnit4TestRunner.class)
 public class SendCommandTest {
 
@@ -75,40 +70,15 @@ public class SendCommandTest {
 
 	private String			resourceId		= "Proteus-Pedrosa";
 	private String			hostIpAddress	= "10.10.80.11";
-	private String			hostPort	 		= "27773";
+	private String			hostPort 		= "27773";
 
 	@Configuration
 	public static Option[] configuration() {
-		return options(karafDistributionConfiguration()
-					   .frameworkUrl(maven()
-									 .groupId("net.i2cat.mantychore")
-									 .artifactId("assembly")
-									 .type("zip")
-									 .classifier("bin")
-									 .versionAsInProject())
-					   .karafVersion("2.2.2")
-					   .name("mantychore")
-					   .unpackDirectory(new File("target/paxexam")),
-					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
-												"featuresBoot",
-												"opennaas-luminis"),
-					   configureConsole()
-					   .ignoreLocalConsole()
-					   .ignoreRemoteShell(),
+		return options(opennaasDistributionConfiguration(),
+					   includeFeatures("opennaas-luminis"),
+					   noConsole(),
 					   keepRuntimeFolder());
 	}
-
-	/*
-	public void loadBundles() {
-
-		assertNotNull(bundleContext);
-
-		// Wait for the activation of all the bundles
-		IntegrationTestsHelper.waitForAllBundlesActive(bundleContext);
-
-		//IProtocolManager protocolManager = getOsgiService(IProtocolManager.class, 20000);
-		assertNotNull(protocolManager);
-	}*/
 
 	@Test
 	public void testSendMultipleMessages() throws ProtocolException {

--- a/manticore/tests/integration/net.i2cat.luminis.tests.protocols.wonesys/src/test/java/net/i2cat/luminis/transports/wonesys/tests/WonesysTransportTest.java
+++ b/manticore/tests/integration/net.i2cat.luminis.tests.protocols.wonesys/src/test/java/net/i2cat/luminis/transports/wonesys/tests/WonesysTransportTest.java
@@ -1,12 +1,5 @@
 package net.i2cat.luminis.transports.wonesys.tests;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
-
-import static org.ops4j.pax.exam.CoreOptions.maven;
-import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
-import static org.ops4j.pax.exam.CoreOptions.options;
-import static org.ops4j.pax.exam.OptionUtils.combine;
-
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -42,9 +35,13 @@ import org.ops4j.pax.exam.junit.JUnit4TestRunner;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.event.Event;
 
-@RunWith(JUnit4TestRunner.class)
-public class WonesysTransportTest implements ITransportListener {
+import static net.i2cat.nexus.tests.OpennaasExamOptions.*;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
+import static org.ops4j.pax.exam.CoreOptions.*;
 
+@RunWith(JUnit4TestRunner.class)
+public class WonesysTransportTest implements ITransportListener
+{
 	Log	log	= LogFactory.getLog(WonesysTransportTest.class);
 
 	@Inject
@@ -61,22 +58,9 @@ public class WonesysTransportTest implements ITransportListener {
 
 	@Configuration
 	public static Option[] configuration() {
-		return options(karafDistributionConfiguration()
-					   .frameworkUrl(maven()
-									 .groupId("net.i2cat.mantychore")
-									 .artifactId("assembly")
-									 .type("zip")
-									 .classifier("bin")
-									 .versionAsInProject())
-					   .karafVersion("2.2.2")
-					   .name("mantychore")
-					   .unpackDirectory(new File("target/paxexam")),
-					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
-												"featuresBoot",
-												"opennaas-luminis"),
-					   configureConsole()
-					   .ignoreLocalConsole()
-					   .ignoreRemoteShell(),
+		return options(opennaasDistributionConfiguration(),
+					   includeFeatures("opennaas-luminis"),
+					   noConsole(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/integration/net.i2cat.luminis.tests.repository/src/test/java/net/i2cat/luminis/ROADM/repository/tests/ROADMRespositoryIntegrationTest.java
+++ b/manticore/tests/integration/net.i2cat.luminis.tests.repository/src/test/java/net/i2cat/luminis/ROADM/repository/tests/ROADMRespositoryIntegrationTest.java
@@ -1,11 +1,5 @@
 package net.i2cat.luminis.ROADM.repository.tests;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
-
-import static org.ops4j.pax.exam.CoreOptions.maven;
-import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
-import static org.ops4j.pax.exam.CoreOptions.options;
-
 import java.io.File;
 import java.util.List;
 import javax.inject.Inject;
@@ -28,6 +22,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.opennaas.core.resources.ILifecycle.State;
 import org.opennaas.core.resources.IResource;
 import org.opennaas.core.resources.IResourceManager;
@@ -44,17 +39,19 @@ import org.opennaas.core.resources.protocol.ProtocolException;
 import org.opennaas.core.resources.protocol.ProtocolSessionContext;
 import org.opennaas.core.resources.queue.QueueConstants;
 import org.opennaas.core.resources.queue.QueueResponse;
+
 import org.ops4j.pax.exam.Option;
-import org.ops4j.pax.exam.TestProbeBuilder;
 import org.ops4j.pax.exam.junit.Configuration;
-import org.ops4j.pax.exam.junit.JUnit4TestRunner;
-import org.ops4j.pax.exam.junit.ProbeBuilder;
 import org.ops4j.pax.exam.junit.ExamReactorStrategy;
+import org.ops4j.pax.exam.junit.JUnit4TestRunner;
 import org.ops4j.pax.exam.util.Filter;
 import org.ops4j.pax.exam.spi.reactors.EagerSingleStagedReactorFactory;
 import org.osgi.framework.BundleContext;
-import org.osgi.framework.Constants;
 import org.osgi.service.blueprint.container.BlueprintContainer;
+
+import static net.i2cat.nexus.tests.OpennaasExamOptions.*;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
+import static org.ops4j.pax.exam.CoreOptions.*;
 
 @RunWith(JUnit4TestRunner.class)
 @ExamReactorStrategy(EagerSingleStagedReactorFactory.class)
@@ -85,22 +82,10 @@ public class ROADMRespositoryIntegrationTest
 
 	@Configuration
 	public static Option[] configuration() {
-		return options(karafDistributionConfiguration()
-					   .frameworkUrl(maven()
-									 .groupId("net.i2cat.mantychore")
-									 .artifactId("assembly")
-									 .type("zip")
-									 .classifier("bin")
-									 .versionAsInProject())
-					   .karafVersion("2.2.2")
-					   .name("mantychore")
-					   .unpackDirectory(new File("target/paxexam")),
-					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
-												"featuresBoot",
-												"opennaas-luminis,nexus-tests-helper"),
-					   configureConsole()
-					   .ignoreLocalConsole()
-					   .ignoreRemoteShell(),
+		return options(opennaasDistributionConfiguration(),
+					   includeFeatures("opennaas-luminis"),
+					   includeTestHelper(),
+					   noConsole(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/integration/net.i2cat.mantychore.tests.capability.queue/src/test/java/net/i2cat/mantychore/queuemanager/tests/PrepareCommitRollbackTest.java
+++ b/manticore/tests/integration/net.i2cat.mantychore.tests.capability.queue/src/test/java/net/i2cat/mantychore/queuemanager/tests/PrepareCommitRollbackTest.java
@@ -1,11 +1,5 @@
 package net.i2cat.mantychore.queuemanager.tests;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
-
-import static org.ops4j.pax.exam.CoreOptions.maven;
-import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
-import static org.ops4j.pax.exam.CoreOptions.options;
-
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.InputStream;
@@ -15,7 +9,6 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.inject.Inject;
 
-import junit.framework.Assert;
 import net.i2cat.mantychore.model.ComputerSystem;
 import net.i2cat.mantychore.model.EthernetPort;
 import net.i2cat.mantychore.model.IPProtocolEndpoint;
@@ -42,19 +35,23 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.Assert;
 import org.junit.runner.RunWith;
+
 import org.ops4j.pax.exam.Option;
-import org.ops4j.pax.exam.TestProbeBuilder;
 import org.ops4j.pax.exam.junit.Configuration;
-import org.ops4j.pax.exam.junit.JUnit4TestRunner;
-import org.ops4j.pax.exam.junit.ProbeBuilder;
 import org.ops4j.pax.exam.junit.ExamReactorStrategy;
+import org.ops4j.pax.exam.junit.JUnit4TestRunner;
 import org.ops4j.pax.exam.util.Filter;
 import org.ops4j.pax.exam.spi.reactors.EagerSingleStagedReactorFactory;
-import static org.ops4j.pax.swissbox.framework.ServiceLookup.getService;
+
 import org.osgi.framework.BundleContext;
-import org.osgi.framework.Constants;
 import org.osgi.service.blueprint.container.BlueprintContainer;
+
+import static net.i2cat.nexus.tests.OpennaasExamOptions.*;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
+import static org.ops4j.pax.exam.CoreOptions.*;
+import static org.ops4j.pax.swissbox.framework.ServiceLookup.getService;
 
 @RunWith(JUnit4TestRunner.class)
 public class PrepareCommitRollbackTest
@@ -87,30 +84,10 @@ public class PrepareCommitRollbackTest
 
 	@Configuration
 	public static Option[] configuration() {
-		return options(karafDistributionConfiguration()
-					   .frameworkUrl(maven()
-									 .groupId("net.i2cat.mantychore")
-									 .artifactId("assembly")
-									 .type("zip")
-									 .classifier("bin")
-									 .versionAsInProject())
-					   .karafVersion("2.2.2")
-					   .name("mantychore")
-					   .unpackDirectory(new File("target/paxexam")),
-					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
-												"featuresBoot",
-												"opennaas-router"),
-					   configureConsole()
-					   .ignoreLocalConsole()
-					   .ignoreRemoteShell(),
-					   mavenBundle()
-					   .groupId("org.ops4j.base")
-					   .artifactId("ops4j-base-spi")
-					   .versionAsInProject(),
-					   mavenBundle()
-					   .groupId("org.ops4j.pax.swissbox")
-					   .artifactId("pax-swissbox-framework")
-					   .versionAsInProject(),
+		return options(opennaasDistributionConfiguration(),
+					   includeFeatures("opennaas-router"),
+					   includeSwissboxFramework(),
+					   noConsole(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/integration/net.i2cat.mantychore.tests.capability.queue/src/test/java/net/i2cat/mantychore/queuemanager/tests/QueuemanagerTest.java
+++ b/manticore/tests/integration/net.i2cat.mantychore.tests.capability.queue/src/test/java/net/i2cat/mantychore/queuemanager/tests/QueuemanagerTest.java
@@ -1,15 +1,13 @@
 package net.i2cat.mantychore.queuemanager.tests;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
-
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import javax.inject.Inject;
 
-import junit.framework.Assert;
 import net.i2cat.mantychore.model.ComputerSystem;
 import net.i2cat.mantychore.queuemanager.IQueueManagerService;
+
 import org.opennaas.core.resources.action.IAction;
 import org.opennaas.core.resources.capability.CapabilityException;
 import org.opennaas.core.resources.capability.ICapability;
@@ -25,27 +23,28 @@ import org.opennaas.core.resources.protocol.ProtocolSessionContext;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.ops4j.pax.exam.Option;
-import org.ops4j.pax.exam.TestProbeBuilder;
-import static org.ops4j.pax.exam.CoreOptions.maven;
-import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
-import static org.ops4j.pax.exam.CoreOptions.options;
 import org.ops4j.pax.exam.junit.Configuration;
-import org.ops4j.pax.exam.junit.JUnit4TestRunner;
-import org.ops4j.pax.exam.junit.ProbeBuilder;
 import org.ops4j.pax.exam.junit.ExamReactorStrategy;
+import org.ops4j.pax.exam.junit.JUnit4TestRunner;
 import org.ops4j.pax.exam.util.Filter;
 import org.ops4j.pax.exam.spi.reactors.EagerSingleStagedReactorFactory;
-import static org.ops4j.pax.swissbox.framework.ServiceLookup.getService;
+
 import org.osgi.framework.BundleContext;
-import org.osgi.framework.Constants;
 import org.osgi.service.blueprint.container.BlueprintContainer;
 
-@RunWith(JUnit4TestRunner.class)
+import static net.i2cat.nexus.tests.OpennaasExamOptions.*;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
+import static org.ops4j.pax.exam.CoreOptions.*;
+import static org.ops4j.pax.swissbox.framework.ServiceLookup.getService;
+
 @ExamReactorStrategy(EagerSingleStagedReactorFactory.class)
+@RunWith(JUnit4TestRunner.class)
 public class QueuemanagerTest
 {
 	private final static Log		log				= LogFactory.getLog(QueuemanagerTest.class);
@@ -75,30 +74,10 @@ public class QueuemanagerTest
 
 	@Configuration
 	public static Option[] configuration() {
-		return options(karafDistributionConfiguration()
-					   .frameworkUrl(maven()
-									 .groupId("net.i2cat.mantychore")
-									 .artifactId("assembly")
-									 .type("zip")
-									 .classifier("bin")
-									 .versionAsInProject())
-					   .karafVersion("2.2.2")
-					   .name("mantychore")
-					   .unpackDirectory(new File("target/paxexam")),
-					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
-												"featuresBoot",
-												"opennaas-router"),
-					   configureConsole()
-					   .ignoreLocalConsole()
-					   .ignoreRemoteShell(),
-					   mavenBundle()
-					   .groupId("org.ops4j.base")
-					   .artifactId("ops4j-base-spi")
-					   .versionAsInProject(),
-					   mavenBundle()
-					   .groupId("org.ops4j.pax.swissbox")
-					   .artifactId("pax-swissbox-framework")
-					   .versionAsInProject(),
+		return options(opennaasDistributionConfiguration(),
+					   includeFeatures("opennaas-router"),
+					   includeSwissboxFramework(),
+					   noConsole(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/integration/net.i2cat.mantychore.tests.capability/src/test/java/net/i2cat/mantychore/chassiscapability/test/ChassisCapabilityIntegrationTest.java
+++ b/manticore/tests/integration/net.i2cat.mantychore.tests.capability/src/test/java/net/i2cat/mantychore/chassiscapability/test/ChassisCapabilityIntegrationTest.java
@@ -1,11 +1,5 @@
 package net.i2cat.mantychore.chassiscapability.test;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
-
-import static org.ops4j.pax.exam.CoreOptions.maven;
-import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
-import static org.ops4j.pax.exam.CoreOptions.options;
-
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
@@ -27,6 +21,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.Ignore;
 import org.junit.runner.RunWith;
+
 import org.opennaas.core.resources.IModel;
 import org.opennaas.core.resources.ResourceIdentifier;
 import org.opennaas.core.resources.action.ActionResponse;
@@ -43,17 +38,20 @@ import org.opennaas.core.resources.protocol.IProtocolManager;
 import org.opennaas.core.resources.protocol.ProtocolSessionContext;
 import org.opennaas.core.resources.queue.QueueConstants;
 import org.opennaas.core.resources.queue.QueueResponse;
+
 import org.ops4j.pax.exam.Option;
-import org.ops4j.pax.exam.TestProbeBuilder;
 import org.ops4j.pax.exam.junit.Configuration;
 import org.ops4j.pax.exam.junit.JUnit4TestRunner;
-import org.ops4j.pax.exam.junit.ProbeBuilder;
 import org.ops4j.pax.exam.junit.ExamReactorStrategy;
 import org.ops4j.pax.exam.util.Filter;
 import org.ops4j.pax.exam.spi.reactors.EagerSingleStagedReactorFactory;
+
 import org.osgi.framework.BundleContext;
-import org.osgi.framework.Constants;
 import org.osgi.service.blueprint.container.BlueprintContainer;
+
+import static net.i2cat.nexus.tests.OpennaasExamOptions.*;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
+import static org.ops4j.pax.exam.CoreOptions.*;
 
 @RunWith(JUnit4TestRunner.class)
 @ExamReactorStrategy(EagerSingleStagedReactorFactory.class)
@@ -88,22 +86,9 @@ public class ChassisCapabilityIntegrationTest
 
 	@Configuration
 	public static Option[] configuration() {
-		return options(karafDistributionConfiguration()
-					   .frameworkUrl(maven()
-									 .groupId("net.i2cat.mantychore")
-									 .artifactId("assembly")
-									 .type("zip")
-									 .classifier("bin")
-									 .versionAsInProject())
-					   .karafVersion("2.2.2")
-					   .name("mantychore")
-					   .unpackDirectory(new File("target/paxexam")),
-					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
-												"featuresBoot",
-												"opennaas-router"),
-					   configureConsole()
-					   .ignoreLocalConsole()
-					   .ignoreRemoteShell(),
+		return options(opennaasDistributionConfiguration(),
+					   includeFeatures("opennaas-router"),
+					   noConsole(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/integration/net.i2cat.mantychore.tests.capability/src/test/java/net/i2cat/mantychore/chassiscapability/test/UpDownTest.java
+++ b/manticore/tests/integration/net.i2cat.mantychore.tests.capability/src/test/java/net/i2cat/mantychore/chassiscapability/test/UpDownTest.java
@@ -1,9 +1,5 @@
 package net.i2cat.mantychore.chassiscapability.test;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
-import static org.ops4j.pax.exam.CoreOptions.maven;
-import static org.ops4j.pax.exam.CoreOptions.options;
-
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -26,6 +22,7 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.opennaas.core.resources.ResourceIdentifier;
 import org.opennaas.core.resources.action.IAction;
 import org.opennaas.core.resources.capability.CapabilityException;
@@ -40,14 +37,21 @@ import org.opennaas.core.resources.protocol.IProtocolManager;
 import org.opennaas.core.resources.protocol.ProtocolSessionContext;
 import org.opennaas.core.resources.queue.QueueConstants;
 import org.opennaas.core.resources.queue.QueueResponse;
+
 import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.junit.Configuration;
+
 import org.ops4j.pax.exam.junit.ExamReactorStrategy;
 import org.ops4j.pax.exam.junit.JUnit4TestRunner;
 import org.ops4j.pax.exam.spi.reactors.EagerSingleStagedReactorFactory;
 import org.ops4j.pax.exam.util.Filter;
+
 import org.osgi.framework.BundleContext;
 import org.osgi.service.blueprint.container.BlueprintContainer;
+
+import static net.i2cat.nexus.tests.OpennaasExamOptions.*;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
+import static org.ops4j.pax.exam.CoreOptions.*;
 
 @RunWith(JUnit4TestRunner.class)
 @ExamReactorStrategy(EagerSingleStagedReactorFactory.class)
@@ -82,23 +86,10 @@ public class UpDownTest
 
 	@Configuration
 	public static Option[] configuration() {
-		return options(karafDistributionConfiguration()
-				.frameworkUrl(maven()
-						.groupId("net.i2cat.mantychore")
-						.artifactId("assembly")
-						.type("zip")
-						.classifier("bin")
-						.versionAsInProject())
-				.karafVersion("2.2.2")
-				.name("mantychore")
-				.unpackDirectory(new File("target/paxexam")),
-					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
-												"featuresBoot",
-												"opennaas-router"),
-					   configureConsole()
-					   .ignoreLocalConsole()
-					   .ignoreRemoteShell(),
-				keepRuntimeFolder());
+		return options(opennaasDistributionConfiguration(),
+					   includeFeatures("opennaas-router"),
+					   noConsole(),
+					   keepRuntimeFolder());
 	}
 
 	public void initResource() {

--- a/manticore/tests/integration/net.i2cat.mantychore.tests.capability/src/test/java/net/i2cat/mantychore/ipcapability/test/IPCapabilityIntegrationTest.java
+++ b/manticore/tests/integration/net.i2cat.mantychore.tests.capability/src/test/java/net/i2cat/mantychore/ipcapability/test/IPCapabilityIntegrationTest.java
@@ -1,11 +1,5 @@
 package net.i2cat.mantychore.ipcapability.test;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
-
-import static org.ops4j.pax.exam.CoreOptions.maven;
-import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
-import static org.ops4j.pax.exam.CoreOptions.options;
-
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
@@ -25,6 +19,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.opennaas.core.resources.IModel;
 import org.opennaas.core.resources.ResourceIdentifier;
 import org.opennaas.core.resources.action.ActionResponse;
@@ -41,17 +36,20 @@ import org.opennaas.core.resources.protocol.IProtocolManager;
 import org.opennaas.core.resources.protocol.ProtocolSessionContext;
 import org.opennaas.core.resources.queue.QueueConstants;
 import org.opennaas.core.resources.queue.QueueResponse;
+
 import org.ops4j.pax.exam.Option;
-import org.ops4j.pax.exam.TestProbeBuilder;
 import org.ops4j.pax.exam.junit.Configuration;
 import org.ops4j.pax.exam.junit.JUnit4TestRunner;
-import org.ops4j.pax.exam.junit.ProbeBuilder;
 import org.ops4j.pax.exam.junit.ExamReactorStrategy;
 import org.ops4j.pax.exam.util.Filter;
 import org.ops4j.pax.exam.spi.reactors.EagerSingleStagedReactorFactory;
+
 import org.osgi.framework.BundleContext;
-import org.osgi.framework.Constants;
 import org.osgi.service.blueprint.container.BlueprintContainer;
+
+import static net.i2cat.nexus.tests.OpennaasExamOptions.*;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
+import static org.ops4j.pax.exam.CoreOptions.*;
 
 @RunWith(JUnit4TestRunner.class)
 @ExamReactorStrategy(EagerSingleStagedReactorFactory.class)
@@ -85,22 +83,9 @@ public class IPCapabilityIntegrationTest
 
 	@Configuration
 	public static Option[] configuration() {
-		return options(karafDistributionConfiguration()
-					   .frameworkUrl(maven()
-									 .groupId("net.i2cat.mantychore")
-									 .artifactId("assembly")
-									 .type("zip")
-									 .classifier("bin")
-									 .versionAsInProject())
-					   .karafVersion("2.2.2")
-					   .name("mantychore")
-					   .unpackDirectory(new File("target/paxexam")),
-					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
-												"featuresBoot",
-												"opennaas-router"),
-					   configureConsole()
-					   .ignoreLocalConsole()
-					   .ignoreRemoteShell(),
+		return options(opennaasDistributionConfiguration(),
+					   includeFeatures("opennaas-router"),
+					   noConsole(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/integration/net.i2cat.mantychore.tests.commandsKaraf/pom.xml
+++ b/manticore/tests/integration/net.i2cat.mantychore.tests.commandsKaraf/pom.xml
@@ -18,10 +18,6 @@
 			<groupId>org.opennaas</groupId>
 			<artifactId>opennaas-core-resources</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.apache.felix</groupId>
-			<artifactId>org.apache.felix.gogo.runtime</artifactId>
-		</dependency>
 		<!--  		<dependency>
 				<groupId>commons-logging</groupId>
 				<artifactId>commons-logging</artifactId>

--- a/manticore/tests/integration/net.i2cat.mantychore.tests.commandsKaraf/src/test/java/net/i2cat/mantychore/commandskaraf/QueueCommandsKarafTest.java
+++ b/manticore/tests/integration/net.i2cat.mantychore.tests.commandsKaraf/src/test/java/net/i2cat/mantychore/commandskaraf/QueueCommandsKarafTest.java
@@ -1,12 +1,5 @@
 package net.i2cat.mantychore.commandskaraf;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
-
-import static org.ops4j.pax.exam.CoreOptions.maven;
-import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
-import static org.ops4j.pax.exam.CoreOptions.options;
-
-import javax.inject.Inject;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
@@ -15,15 +8,16 @@ import java.io.InputStreamReader;
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.List;
+import javax.inject.Inject;
 
-import net.i2cat.nexus.tests.KarafCommandHelper;
+import net.i2cat.nexus.tests.AbstractKarafCommandTest;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.felix.service.command.CommandProcessor;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.opennaas.core.resources.IResource;
 import org.opennaas.core.resources.IResourceRepository;
 import org.opennaas.core.resources.descriptor.ResourceDescriptor;
@@ -31,21 +25,22 @@ import org.opennaas.core.resources.helpers.ResourceDescriptorFactory;
 import org.opennaas.core.resources.protocol.IProtocolManager;
 import org.opennaas.core.resources.protocol.ProtocolException;
 import org.opennaas.core.resources.protocol.ProtocolSessionContext;
-import org.ops4j.pax.exam.Customizer;
+
 import org.ops4j.pax.exam.Option;
-import org.ops4j.pax.exam.TestProbeBuilder;
 import org.ops4j.pax.exam.junit.Configuration;
-import org.ops4j.pax.exam.junit.ExamReactorStrategy;
 import org.ops4j.pax.exam.junit.JUnit4TestRunner;
-import org.ops4j.pax.exam.junit.ProbeBuilder;
+import org.ops4j.pax.exam.junit.ExamReactorStrategy;
 import org.ops4j.pax.exam.spi.reactors.EagerSingleStagedReactorFactory;
 import org.ops4j.pax.exam.util.Filter;
-import org.osgi.framework.Constants;
 import org.osgi.service.blueprint.container.BlueprintContainer;
+
+import static net.i2cat.nexus.tests.OpennaasExamOptions.*;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
+import static org.ops4j.pax.exam.CoreOptions.*;
 
 @RunWith(JUnit4TestRunner.class)
 @ExamReactorStrategy(EagerSingleStagedReactorFactory.class)
-public class QueueCommandsKarafTest
+public class QueueCommandsKarafTest extends AbstractKarafCommandTest
 {
 	static Log					log	=
 		LogFactory.getLog(ResourceCommandsKarafTest.class);
@@ -53,9 +48,6 @@ public class QueueCommandsKarafTest
 	@Inject
 	@Filter("(type=router)")
 	private IResourceRepository	repository;
-
-	@Inject
-	private CommandProcessor	commandprocessor;
 
 	@Inject
 	private IProtocolManager	protocolManager;
@@ -72,15 +64,13 @@ public class QueueCommandsKarafTest
     @Filter("(osgi.blueprint.container.symbolicname=net.i2cat.mantychore.queuemanager)")
     private BlueprintContainer	queueService;
 
-	public String capture() throws IOException {
-		StringWriter sw = new StringWriter();
-		BufferedReader rdr = new BufferedReader(new InputStreamReader(System.in));
-		String s = rdr.readLine();
-		while (s != null) {
-			sw.write(s);
-			s = rdr.readLine();
-		}
-		return sw.toString();
+	@Configuration
+	public static Option[] configuration() {
+		return options(opennaasDistributionConfiguration(),
+					   includeFeatures("opennaas-router"),
+					   includeTestHelper(),
+					   noConsole(),
+					   keepRuntimeFolder());
 	}
 
 	/**
@@ -107,33 +97,6 @@ public class QueueCommandsKarafTest
 
 	}
 
-    @ProbeBuilder
-    public TestProbeBuilder probeConfiguration(TestProbeBuilder probe) {
-        probe.setHeader(Constants.DYNAMICIMPORT_PACKAGE, "*,org.apache.felix.service.*;status=provisional");
-        return probe;
-    }
-
-	@Configuration
-	public static Option[] configuration() {
-		return options(karafDistributionConfiguration()
-					   .frameworkUrl(maven()
-									 .groupId("net.i2cat.mantychore")
-									 .artifactId("assembly")
-									 .type("zip")
-									 .classifier("bin")
-									 .versionAsInProject())
-					   .karafVersion("2.2.2")
-					   .name("mantychore")
-					   .unpackDirectory(new File("target/paxexam")),
-					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
-												"featuresBoot",
-												"opennaas-router,nexus-tests-helper"),
-					   configureConsole()
-					   .ignoreLocalConsole()
-					   .ignoreRemoteShell(),
-					   keepRuntimeFolder());
-	}
-
 	@Test
 	public void SetAndGetInterfacesCommandTest() {
 		List<String> capabilities = new ArrayList<String>();
@@ -149,16 +112,16 @@ public class QueueCommandsKarafTest
 			createProtocolForResource(resource.getResourceIdentifier().getId());
 			repository.startResource(resource.getResourceDescriptor().getId());
 
-			ArrayList<String> response = KarafCommandHelper.executeCommand(
-					"ipv4:setIP  " + resourceFriendlyID + " fe-0/1/2.0 192.168.1.1 255.255.255.0", commandprocessor);
+			List<String> response = executeCommand(
+					"ipv4:setIP  " + resourceFriendlyID + " fe-0/1/2.0 192.168.1.1 255.255.255.0");
 			// assert command output does not contain ERROR tag
 			Assert.assertTrue(response.get(1).isEmpty());
 
-			response = KarafCommandHelper.executeCommand("queue:listActions  " + resourceFriendlyID, commandprocessor);
+			response = executeCommand("queue:listActions  " + resourceFriendlyID);
 			// assert command output does not contain ERROR tag
 			Assert.assertTrue(response.get(1).isEmpty());
 
-			response = KarafCommandHelper.executeCommand("queue:execute  " + resourceFriendlyID, commandprocessor);
+			response = executeCommand("queue:execute  " + resourceFriendlyID);
 			// assert command output does not contain ERROR tag
 			Assert.assertTrue(response.get(1).isEmpty());
 

--- a/manticore/tests/integration/net.i2cat.mantychore.tests.repository/src/test/java/net/i2cat/mantychore/repository/tests/MantychoreRepositoryIntegrationTest.java
+++ b/manticore/tests/integration/net.i2cat.mantychore.tests.repository/src/test/java/net/i2cat/mantychore/repository/tests/MantychoreRepositoryIntegrationTest.java
@@ -1,12 +1,7 @@
 package net.i2cat.mantychore.repository.tests;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
-import static org.ops4j.pax.exam.CoreOptions.maven;
-import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
-import static org.ops4j.pax.exam.CoreOptions.options;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -25,6 +20,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.opennaas.core.resources.ILifecycle.State;
 import org.opennaas.core.resources.IResource;
 import org.opennaas.core.resources.IResourceIdentifier;
@@ -44,17 +40,20 @@ import org.opennaas.core.resources.protocol.ProtocolException;
 import org.opennaas.core.resources.protocol.ProtocolSessionContext;
 import org.opennaas.core.resources.queue.QueueConstants;
 import org.opennaas.core.resources.queue.QueueResponse;
+
 import org.ops4j.pax.exam.Option;
-import org.ops4j.pax.exam.TestProbeBuilder;
 import org.ops4j.pax.exam.junit.Configuration;
 import org.ops4j.pax.exam.junit.JUnit4TestRunner;
-import org.ops4j.pax.exam.junit.ProbeBuilder;
 import org.ops4j.pax.exam.junit.ExamReactorStrategy;
 import org.ops4j.pax.exam.util.Filter;
 import org.ops4j.pax.exam.spi.reactors.EagerSingleStagedReactorFactory;
+
 import org.osgi.framework.BundleContext;
-import org.osgi.framework.Constants;
 import org.osgi.service.blueprint.container.BlueprintContainer;
+
+import static net.i2cat.nexus.tests.OpennaasExamOptions.*;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
+import static org.ops4j.pax.exam.CoreOptions.*;
 
 @RunWith(JUnit4TestRunner.class)
 @ExamReactorStrategy(EagerSingleStagedReactorFactory.class)
@@ -81,22 +80,10 @@ public class MantychoreRepositoryIntegrationTest
 
 	@Configuration
 	public static Option[] configuration() {
-		return options(karafDistributionConfiguration()
-					   .frameworkUrl(maven()
-									 .groupId("net.i2cat.mantychore")
-									 .artifactId("assembly")
-									 .type("zip")
-									 .classifier("bin")
-									 .versionAsInProject())
-					   .karafVersion("2.2.2")
-					   .name("mantychore")
-					   .unpackDirectory(new File("target/paxexam")),
-					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
-												"featuresBoot",
-												"opennaas-router,nexus-tests-helper"),
-					   configureConsole()
-					   .ignoreLocalConsole()
-					   .ignoreRemoteShell(),
+		return options(opennaasDistributionConfiguration(),
+					   includeFeatures("opennaas-router"),
+					   includeTestHelper(),
+					   noConsole(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/integration/net.i2cat.mantychore.tests.repository/src/test/java/net/i2cat/mantychore/repository/tests/ResourceManagerIntegrationTest.java
+++ b/manticore/tests/integration/net.i2cat.mantychore.tests.repository/src/test/java/net/i2cat/mantychore/repository/tests/ResourceManagerIntegrationTest.java
@@ -1,19 +1,10 @@
 package net.i2cat.mantychore.repository.tests;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-import static org.ops4j.pax.exam.CoreOptions.maven;
-import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
-import static org.ops4j.pax.exam.CoreOptions.options;
-
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import javax.inject.Inject;
 
-import junit.framework.Assert;
 import org.opennaas.core.resources.IResource;
 import org.opennaas.core.resources.IResourceManager;
 import org.opennaas.core.resources.IResourceRepository;
@@ -26,20 +17,27 @@ import org.opennaas.core.resources.protocol.ProtocolSessionContext;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.ops4j.pax.exam.Option;
-import org.ops4j.pax.exam.TestProbeBuilder;
 import org.ops4j.pax.exam.junit.Configuration;
 import org.ops4j.pax.exam.junit.JUnit4TestRunner;
-import org.ops4j.pax.exam.junit.ProbeBuilder;
 import org.ops4j.pax.exam.junit.ExamReactorStrategy;
 import org.ops4j.pax.exam.util.Filter;
 import org.ops4j.pax.exam.spi.reactors.EagerSingleStagedReactorFactory;
+
 import org.osgi.framework.BundleContext;
-import org.osgi.framework.Constants;
 import org.osgi.service.blueprint.container.BlueprintContainer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static net.i2cat.nexus.tests.OpennaasExamOptions.*;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
+import static org.ops4j.pax.exam.CoreOptions.*;
 
 @RunWith(JUnit4TestRunner.class)
 @ExamReactorStrategy(EagerSingleStagedReactorFactory.class)
@@ -74,22 +72,9 @@ public class ResourceManagerIntegrationTest
 
 	@Configuration
 	public static Option[] configuration() {
-		return options(karafDistributionConfiguration()
-					   .frameworkUrl(maven()
-									 .groupId("net.i2cat.mantychore")
-									 .artifactId("assembly")
-									 .type("zip")
-									 .classifier("bin")
-									 .versionAsInProject())
-					   .karafVersion("2.2.2")
-					   .name("mantychore")
-					   .unpackDirectory(new File("target/paxexam")),
-					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
-												"featuresBoot",
-												"opennaas-router"),
-					   configureConsole()
-					   .ignoreLocalConsole()
-					   .ignoreRemoteShell(),
+		return options(opennaasDistributionConfiguration(),
+					   includeFeatures("opennaas-router"),
+					   noConsole(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/integration/net.i2cat.nexus.tests.events/src/test/java/net/i2cat/nexus/events/tests/SendReceiveEventsTest.java
+++ b/manticore/tests/integration/net.i2cat.nexus.tests.events/src/test/java/net/i2cat/nexus/events/tests/SendReceiveEventsTest.java
@@ -1,12 +1,5 @@
 package net.i2cat.nexus.events.tests;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
-
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.ops4j.pax.exam.CoreOptions.maven;
-import static org.ops4j.pax.exam.CoreOptions.options;
-
 import java.io.File;
 import java.io.InputStream;
 import java.util.Dictionary;
@@ -19,24 +12,30 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.opennaas.core.events.EventFilter;
 import org.opennaas.core.events.IEventManager;
-import org.ops4j.pax.exam.Customizer;
+
 import org.ops4j.pax.exam.Option;
-import org.ops4j.pax.exam.TestProbeBuilder;
 import org.ops4j.pax.exam.junit.Configuration;
 import org.ops4j.pax.exam.junit.JUnit4TestRunner;
-import org.ops4j.pax.exam.junit.ProbeBuilder;
 import org.ops4j.pax.exam.junit.ExamReactorStrategy;
 import org.ops4j.pax.exam.spi.reactors.EagerSingleStagedReactorFactory;
+
 import org.osgi.framework.BundleContext;
-import org.osgi.framework.Constants;
 import org.osgi.service.blueprint.container.BlueprintContainer;
 import org.osgi.service.event.Event;
 import org.osgi.service.event.EventAdmin;
 import org.osgi.service.event.EventHandler;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static net.i2cat.nexus.tests.OpennaasExamOptions.*;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
+import static org.ops4j.pax.exam.CoreOptions.*;
 
 @RunWith(JUnit4TestRunner.class)
 public class SendReceiveEventsTest
@@ -59,30 +58,11 @@ public class SendReceiveEventsTest
 	@Inject
 	private IEventManager	eventManager;
 
-    @ProbeBuilder
-    public TestProbeBuilder probeConfiguration(TestProbeBuilder probe) {
-        probe.setHeader(Constants.DYNAMICIMPORT_PACKAGE, "*,org.apache.felix.service.*;status=provisional");
-        return probe;
-    }
-
 	@Configuration
 	public static Option[] configuration() {
-		return options(karafDistributionConfiguration()
-					   .frameworkUrl(maven()
-									 .groupId("net.i2cat.mantychore")
-									 .artifactId("assembly")
-									 .type("zip")
-									 .classifier("bin")
-									 .versionAsInProject())
-					   .karafVersion("2.2.2")
-					   .name("mantychore")
-					   .unpackDirectory(new File("target/paxexam")),
-					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
-												"featuresBoot",
-												"opennaas-core"),
-					   configureConsole()
-					   .ignoreLocalConsole()
-					   .ignoreRemoteShell(),
+		return options(opennaasDistributionConfiguration(),
+					   includeFeatures("opennaas-core"),
+					   noConsole(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/integration/net.i2cat.nexus.tests.resources/src/test/java/net/i2cat/nexus/resources/tests/ResourcesWithProfileTest.java
+++ b/manticore/tests/integration/net.i2cat.nexus.tests.resources/src/test/java/net/i2cat/nexus/resources/tests/ResourcesWithProfileTest.java
@@ -1,7 +1,5 @@
 package net.i2cat.nexus.resources.tests;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
-
 import java.io.File;
 
 import java.util.ArrayList;
@@ -15,10 +13,12 @@ import javax.inject.Inject;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.After;
 import org.junit.runner.RunWith;
+
 import org.opennaas.core.resources.ILifecycle.State;
 import org.opennaas.core.resources.IResource;
 import org.opennaas.core.resources.IResourceManager;
@@ -35,23 +35,26 @@ import org.opennaas.core.resources.profile.ProfileDescriptor;
 import org.opennaas.core.resources.protocol.IProtocolManager;
 import org.opennaas.core.resources.protocol.ProtocolException;
 import org.opennaas.core.resources.protocol.ProtocolSessionContext;
+
 import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.junit.Configuration;
-import org.ops4j.pax.exam.junit.ExamReactorStrategy;
 import org.ops4j.pax.exam.junit.JUnit4TestRunner;
+import org.ops4j.pax.exam.junit.ExamReactorStrategy;
 import org.ops4j.pax.exam.spi.reactors.EagerSingleStagedReactorFactory;
 import org.ops4j.pax.exam.util.Filter;
+
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.blueprint.container.BlueprintContainer;
-import static org.ops4j.pax.exam.CoreOptions.maven;
-import static org.ops4j.pax.exam.CoreOptions.options;
+
+import static net.i2cat.nexus.tests.OpennaasExamOptions.*;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
+import static org.ops4j.pax.exam.CoreOptions.*;
 
 @RunWith(JUnit4TestRunner.class)
 @ExamReactorStrategy(EagerSingleStagedReactorFactory.class)
-public class ResourcesWithProfileTest {
-	// import static org.ops4j.pax.exam.container.def.PaxRunnerOptions.vmOption;
-
+public class ResourcesWithProfileTest
+{
 	static Log log = LogFactory.getLog(ResourcesWithProfileTest.class);
 
 	@Inject
@@ -80,22 +83,9 @@ public class ResourcesWithProfileTest {
 
 	@Configuration
 	public static Option[] configuration() {
-		return options(karafDistributionConfiguration()
-					   .frameworkUrl(maven()
-									 .groupId("net.i2cat.mantychore")
-									 .artifactId("assembly")
-									 .type("zip")
-									 .classifier("bin")
-									 .versionAsInProject())
-					   .karafVersion("2.2.2")
-					   .name("mantychore")
-					   .unpackDirectory(new File("target/paxexam")),
-					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
-												"featuresBoot",
-												"opennaas-router"),
-					   configureConsole()
-					   .ignoreLocalConsole()
-					   .ignoreRemoteShell(),
+		return options(opennaasDistributionConfiguration(),
+					   includeFeatures("opennaas-router"),
+					   noConsole(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/integration/net.i2cat.nexus.tests.resources/src/test/java/net/i2cat/nexus/resources/tests/UseProfileBundleTest.java
+++ b/manticore/tests/integration/net.i2cat.nexus.tests.resources/src/test/java/net/i2cat/nexus/resources/tests/UseProfileBundleTest.java
@@ -10,10 +10,12 @@ import javax.inject.Inject;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.After;
 import org.junit.runner.RunWith;
+
 import org.opennaas.core.resources.ILifecycle.State;
 import org.opennaas.core.resources.IResource;
 import org.opennaas.core.resources.IResourceManager;
@@ -26,23 +28,26 @@ import org.opennaas.core.resources.profile.ProfileDescriptor;
 import org.opennaas.core.resources.protocol.IProtocolManager;
 import org.opennaas.core.resources.protocol.ProtocolException;
 import org.opennaas.core.resources.protocol.ProtocolSessionContext;
+
 import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.junit.Configuration;
-import org.ops4j.pax.exam.junit.ExamReactorStrategy;
 import org.ops4j.pax.exam.junit.JUnit4TestRunner;
+import org.ops4j.pax.exam.junit.ExamReactorStrategy;
 import org.ops4j.pax.exam.spi.reactors.EagerSingleStagedReactorFactory;
 import org.ops4j.pax.exam.util.Filter;
+
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.blueprint.container.BlueprintContainer;
-import static org.ops4j.pax.exam.CoreOptions.maven;
-import static org.ops4j.pax.exam.CoreOptions.options;
+
+import static net.i2cat.nexus.tests.OpennaasExamOptions.*;
 import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
+import static org.ops4j.pax.exam.CoreOptions.*;
 
 @RunWith(JUnit4TestRunner.class)
 @ExamReactorStrategy(EagerSingleStagedReactorFactory.class)
-public class UseProfileBundleTest {
-
+public class UseProfileBundleTest
+{
 	static Log log = LogFactory.getLog(UseProfileBundleTest.class);
 
 	@Inject
@@ -71,22 +76,10 @@ public class UseProfileBundleTest {
 
 	@Configuration
 	public static Option[] configuration() {
-		return options(karafDistributionConfiguration()
-					   .frameworkUrl(maven()
-									 .groupId("net.i2cat.mantychore")
-									 .artifactId("assembly")
-									 .type("zip")
-									 .classifier("bin")
-									 .versionAsInProject())
-					   .karafVersion("2.2.2")
-					   .name("mantychore")
-					   .unpackDirectory(new File("target/paxexam")),
-					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
-												"featuresBoot",
-												"opennaas-router,nexus-testprofile"),
-					   configureConsole()
-					   .ignoreLocalConsole()
-					   .ignoreRemoteShell(),
+		return options(opennaasDistributionConfiguration(),
+					   includeFeatures("opennaas-router"),
+					   includeTestMockProfile(),
+					   noConsole(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/integration/org.opennaas.bod.tests.capability.l2bod/src/test/java/org/opennaas/bod/tests/capability/l2bod/L2BoDCapabilityIntegrationTest.java
+++ b/manticore/tests/integration/org.opennaas.bod.tests.capability.l2bod/src/test/java/org/opennaas/bod/tests/capability/l2bod/L2BoDCapabilityIntegrationTest.java
@@ -1,11 +1,5 @@
 package org.opennaas.bod.tests.capability.l2bod;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
-
-import static org.ops4j.pax.exam.CoreOptions.maven;
-import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
-import static org.ops4j.pax.exam.CoreOptions.options;
-
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
@@ -15,10 +9,12 @@ import net.i2cat.nexus.tests.ResourceHelper;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.opennaas.core.resources.ILifecycle.State;
 import org.opennaas.core.resources.IResource;
 import org.opennaas.core.resources.IResourceManager;
@@ -26,20 +22,24 @@ import org.opennaas.core.resources.ResourceException;
 import org.opennaas.core.resources.capability.ICapability;
 import org.opennaas.core.resources.descriptor.CapabilityDescriptor;
 import org.opennaas.core.resources.descriptor.ResourceDescriptor;
+
 import org.ops4j.pax.exam.Option;
-import org.ops4j.pax.exam.TestProbeBuilder;
 import org.ops4j.pax.exam.junit.Configuration;
 import org.ops4j.pax.exam.junit.JUnit4TestRunner;
-import org.ops4j.pax.exam.junit.ProbeBuilder;
 import org.ops4j.pax.exam.junit.ExamReactorStrategy;
 import org.ops4j.pax.exam.spi.reactors.EagerSingleStagedReactorFactory;
 import org.ops4j.pax.exam.util.Filter;
+
 import org.osgi.framework.BundleContext;
-import org.osgi.framework.Constants;
 import org.osgi.service.blueprint.container.BlueprintContainer;
+
 import org.osgi.service.event.Event;
 import org.osgi.service.event.EventAdmin;
 import org.osgi.service.event.EventHandler;
+
+import static net.i2cat.nexus.tests.OpennaasExamOptions.*;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
+import static org.ops4j.pax.exam.CoreOptions.*;
 
 @RunWith(JUnit4TestRunner.class)
 public class L2BoDCapabilityIntegrationTest
@@ -68,25 +68,12 @@ public class L2BoDCapabilityIntegrationTest
 
 	private ICapability			l2bodCapability;
 
-
 	@Configuration
 	public static Option[] configuration() {
-		return options(karafDistributionConfiguration()
-					   .frameworkUrl(maven()
-									 .groupId("net.i2cat.mantychore")
-									 .artifactId("assembly")
-									 .type("zip")
-									 .classifier("bin")
-									 .versionAsInProject())
-					   .karafVersion("2.2.2")
-					   .name("mantychore")
-					   .unpackDirectory(new File("target/paxexam")),
-					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
-												"featuresBoot",
-												"opennaas-bod,nexus-tests-helper"),
-					   configureConsole()
-					   .ignoreLocalConsole()
-					   .ignoreRemoteShell(),
+		return options(opennaasDistributionConfiguration(),
+					   includeFeatures("opennaas-bod"),
+					   includeTestHelper(),
+					   noConsole(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/integration/org.opennaas.bod.tests.repository/src/test/java/org/opennaas/bod/tests/repository/BODRepositoryIntegrationTest.java
+++ b/manticore/tests/integration/org.opennaas.bod.tests.repository/src/test/java/org/opennaas/bod/tests/repository/BODRepositoryIntegrationTest.java
@@ -1,11 +1,5 @@
 package org.opennaas.bod.tests.repository;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
-
-import static org.ops4j.pax.exam.CoreOptions.maven;
-import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
-import static org.ops4j.pax.exam.CoreOptions.options;
-
 import java.io.File;
 import java.util.List;
 import javax.inject.Inject;
@@ -14,31 +8,37 @@ import net.i2cat.nexus.tests.ResourceHelper;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.opennaas.core.resources.ILifecycle.State;
 import org.opennaas.core.resources.IResource;
 import org.opennaas.core.resources.IResourceManager;
 import org.opennaas.core.resources.IResourceRepository;
 import org.opennaas.core.resources.ResourceException;
 import org.opennaas.core.resources.descriptor.ResourceDescriptor;
+
 import org.ops4j.pax.exam.Option;
-import org.ops4j.pax.exam.TestProbeBuilder;
 import org.ops4j.pax.exam.junit.Configuration;
 import org.ops4j.pax.exam.junit.JUnit4TestRunner;
-import org.ops4j.pax.exam.junit.ProbeBuilder;
 import org.ops4j.pax.exam.junit.ExamReactorStrategy;
 import org.ops4j.pax.exam.spi.reactors.EagerSingleStagedReactorFactory;
 import org.ops4j.pax.exam.util.Filter;
+
 import org.osgi.framework.BundleContext;
-import org.osgi.framework.Constants;
 import org.osgi.service.blueprint.container.BlueprintContainer;
+
 import org.osgi.service.event.Event;
 import org.osgi.service.event.EventAdmin;
 import org.osgi.service.event.EventHandler;
+
+import static net.i2cat.nexus.tests.OpennaasExamOptions.*;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
+import static org.ops4j.pax.exam.CoreOptions.*;
 
 @RunWith(JUnit4TestRunner.class)
 public class BODRepositoryIntegrationTest
@@ -57,29 +57,17 @@ public class BODRepositoryIntegrationTest
 
 	@Configuration
 	public static Option[] configuration() {
-		return options(karafDistributionConfiguration()
-					   .frameworkUrl(maven()
-									 .groupId("net.i2cat.mantychore")
-									 .artifactId("assembly")
-									 .type("zip")
-									 .classifier("bin")
-									 .versionAsInProject())
-					   .karafVersion("2.2.2")
-					   .name("mantychore")
-					   .unpackDirectory(new File("target/paxexam")),
-					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
-												"featuresBoot",
-												"opennaas-bod,nexus-tests-helper"),
-					   configureConsole()
-					   .ignoreLocalConsole()
-					   .ignoreRemoteShell(),
+		return options(opennaasDistributionConfiguration(),
+					   includeFeatures("opennaas-bod"),
+					   includeTestHelper(),
+					   noConsole(),
 					   keepRuntimeFolder());
 	}
 
-	@Test
 	/**
 	 * Test to create and remove the resource.
 	 */
+	@Test
 	public void createAndRemoveResourceTest() throws Exception {
 
 		// BoD Resource Descriptor
@@ -120,10 +108,10 @@ public class BODRepositoryIntegrationTest
 		Assert.assertTrue(repository.listResources().isEmpty());
 	}
 
-	@Test
 	/**
 	 * Test to check if repostitory is accessible from Resource Manager
 	 */
+	@Test
 	public void isResourceAccessibleFromRM() throws Exception {
 
 		/* init services */

--- a/manticore/tests/integration/org.opennaas.bod.tests/src/test/java/org/opennaas/bod/tests/BoDIntegrationTest.java
+++ b/manticore/tests/integration/org.opennaas.bod.tests/src/test/java/org/opennaas/bod/tests/BoDIntegrationTest.java
@@ -1,11 +1,5 @@
 package org.opennaas.bod.tests;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
-
-import static org.ops4j.pax.exam.CoreOptions.maven;
-import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
-import static org.ops4j.pax.exam.CoreOptions.options;
-
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
@@ -15,11 +9,13 @@ import net.i2cat.nexus.tests.ResourceHelper;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.opennaas.bod.capability.l2bod.L2BoDCapability;
 import org.opennaas.core.protocols.sessionmanager.impl.ProtocolSessionManager;
 import org.opennaas.core.resources.ILifecycle.State;
@@ -33,20 +29,24 @@ import org.opennaas.core.resources.action.IActionSet;
 import org.opennaas.core.resources.capability.ICapability;
 import org.opennaas.core.resources.descriptor.CapabilityDescriptor;
 import org.opennaas.core.resources.descriptor.ResourceDescriptor;
+
 import org.ops4j.pax.exam.Option;
-import org.ops4j.pax.exam.TestProbeBuilder;
 import org.ops4j.pax.exam.junit.Configuration;
 import org.ops4j.pax.exam.junit.JUnit4TestRunner;
-import org.ops4j.pax.exam.junit.ProbeBuilder;
 import org.ops4j.pax.exam.junit.ExamReactorStrategy;
 import org.ops4j.pax.exam.spi.reactors.EagerSingleStagedReactorFactory;
 import org.ops4j.pax.exam.util.Filter;
+
 import org.osgi.framework.BundleContext;
-import org.osgi.framework.Constants;
 import org.osgi.service.blueprint.container.BlueprintContainer;
+
 import org.osgi.service.event.Event;
 import org.osgi.service.event.EventAdmin;
 import org.osgi.service.event.EventHandler;
+
+import static net.i2cat.nexus.tests.OpennaasExamOptions.*;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
+import static org.ops4j.pax.exam.CoreOptions.*;
 
 @RunWith(JUnit4TestRunner.class)
 public class BoDIntegrationTest
@@ -76,22 +76,10 @@ public class BoDIntegrationTest
 
 	@Configuration
 	public static Option[] configuration() {
-		return options(karafDistributionConfiguration()
-					   .frameworkUrl(maven()
-									 .groupId("net.i2cat.mantychore")
-									 .artifactId("assembly")
-									 .type("zip")
-									 .classifier("bin")
-									 .versionAsInProject())
-					   .karafVersion("2.2.2")
-					   .name("mantychore")
-					   .unpackDirectory(new File("target/paxexam")),
-					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
-												"featuresBoot",
-												"opennaas-bod,nexus-tests-helper"),
-					   configureConsole()
-					   .ignoreLocalConsole()
-					   .ignoreRemoteShell(),
+		return options(opennaasDistributionConfiguration(),
+					   includeFeatures("opennaas-bod"),
+					   includeTestHelper(),
+					   noConsole(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/integration/pom.xml
+++ b/manticore/tests/integration/pom.xml
@@ -36,14 +36,6 @@
 			<artifactId>junit</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.openengsb.labs.paxexam.karaf</groupId>
-			<artifactId>paxexam-karaf-container</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.ops4j.pax.exam</groupId>
-			<artifactId>pax-exam-junit4</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>net.i2cat.mantychore</groupId>
 			<artifactId>assembly</artifactId>
 			<type>zip</type>

--- a/manticore/tests/sprints/sprint0_2/src/test/java/luminis/RawSocketAlarmsTest.java
+++ b/manticore/tests/sprints/sprint0_2/src/test/java/luminis/RawSocketAlarmsTest.java
@@ -1,10 +1,5 @@
 package luminis;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
-
-import static org.ops4j.pax.exam.CoreOptions.maven;
-import static org.ops4j.pax.exam.CoreOptions.options;
-
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Date;
@@ -49,6 +44,10 @@ import org.osgi.service.blueprint.container.BlueprintContainer;
 import org.osgi.service.event.Event;
 import org.osgi.service.event.EventHandler;
 
+import static net.i2cat.nexus.tests.OpennaasExamOptions.*;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
+import static org.ops4j.pax.exam.CoreOptions.*;
+
 @RunWith(JUnit4TestRunner.class)
 @ExamReactorStrategy(EagerSingleStagedReactorFactory.class)
 public class RawSocketAlarmsTest implements EventHandler {
@@ -80,22 +79,9 @@ public class RawSocketAlarmsTest implements EventHandler {
 
 	@Configuration
 	public static Option[] configuration() {
-		return options(karafDistributionConfiguration()
-					   .frameworkUrl(maven()
-									 .groupId("net.i2cat.mantychore")
-									 .artifactId("assembly")
-									 .type("zip")
-									 .classifier("bin")
-									 .versionAsInProject())
-					   .karafVersion("2.2.2")
-					   .name("mantychore")
-					   .unpackDirectory(new File("target/paxexam")),
-					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
-												"featuresBoot",
-												"opennaas-luminis"),
-					   configureConsole()
-					   .ignoreLocalConsole()
-					   .ignoreRemoteShell(),
+		return options(opennaasDistributionConfiguration(),
+					   includeFeatures("opennaas-luminis"),
+					   noConsole(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/sprints/sprint0_2/src/test/java/mantychore/ConfigureLRTest.java
+++ b/manticore/tests/sprints/sprint0_2/src/test/java/mantychore/ConfigureLRTest.java
@@ -1,11 +1,5 @@
 package mantychore;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
-
-import static org.ops4j.pax.exam.CoreOptions.maven;
-import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
-import static org.ops4j.pax.exam.CoreOptions.options;
-
 import javax.inject.Inject;
 import java.io.File;
 import java.io.InputStream;
@@ -47,6 +41,10 @@ import org.ops4j.pax.exam.spi.reactors.EagerSingleStagedReactorFactory;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
 import org.osgi.service.blueprint.container.BlueprintContainer;
+
+import static net.i2cat.nexus.tests.OpennaasExamOptions.*;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
+import static org.ops4j.pax.exam.CoreOptions.*;
 
 @RunWith(JUnit4TestRunner.class)
 @ExamReactorStrategy(EagerSingleStagedReactorFactory.class)
@@ -95,22 +93,10 @@ public class ConfigureLRTest
 
 	@Configuration
 	public static Option[] configuration() {
-		return options(karafDistributionConfiguration()
-					   .frameworkUrl(maven()
-									 .groupId("net.i2cat.mantychore")
-									 .artifactId("assembly")
-									 .type("zip")
-									 .classifier("bin")
-									 .versionAsInProject())
-					   .karafVersion("2.2.2")
-					   .name("mantychore")
-					   .unpackDirectory(new File("target/paxexam")),
-					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
-												"featuresBoot",
-												"opennaas-router,nexus-tests-helper"),
-					   configureConsole()
-					   .ignoreLocalConsole()
-					   .ignoreRemoteShell(),
+		return options(opennaasDistributionConfiguration(),
+					   includeFeatures("opennaas-router"),
+					   includeTestHelper(),
+					   noConsole(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/sprints/sprint0_2/src/test/java/mantychore/CreateLogicalRouterTest.java
+++ b/manticore/tests/sprints/sprint0_2/src/test/java/mantychore/CreateLogicalRouterTest.java
@@ -1,11 +1,5 @@
 package mantychore;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
-
-import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
-import static org.ops4j.pax.exam.CoreOptions.maven;
-import static org.ops4j.pax.exam.CoreOptions.options;
-
 import java.io.File;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -46,6 +40,10 @@ import org.ops4j.pax.exam.spi.reactors.EagerSingleStagedReactorFactory;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
 import org.osgi.service.blueprint.container.BlueprintContainer;
+
+import static net.i2cat.nexus.tests.OpennaasExamOptions.*;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
+import static org.ops4j.pax.exam.CoreOptions.*;
 
 @RunWith(JUnit4TestRunner.class)
 @ExamReactorStrategy(EagerSingleStagedReactorFactory.class)
@@ -91,22 +89,10 @@ public class CreateLogicalRouterTest
 
 	@Configuration
 	public static Option[] configuration() {
-		return options(karafDistributionConfiguration()
-					   .frameworkUrl(maven()
-									 .groupId("net.i2cat.mantychore")
-									 .artifactId("assembly")
-									 .type("zip")
-									 .classifier("bin")
-									 .versionAsInProject())
-					   .karafVersion("2.2.2")
-					   .name("mantychore")
-					   .unpackDirectory(new File("target/paxexam")),
-					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
-												"featuresBoot",
-												"opennaas-router,nexus-tests-helper"),
-					   configureConsole()
-					   .ignoreLocalConsole()
-					   .ignoreRemoteShell(),
+		return options(opennaasDistributionConfiguration(),
+					   includeFeatures("opennaas-router"),
+					   includeTestHelper(),
+					   noConsole(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/sprints/sprint0_2/src/test/java/mantychore/RemoveLogicalRouterTest.java
+++ b/manticore/tests/sprints/sprint0_2/src/test/java/mantychore/RemoveLogicalRouterTest.java
@@ -1,11 +1,5 @@
 package mantychore;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
-
-import static org.ops4j.pax.exam.CoreOptions.maven;
-import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
-import static org.ops4j.pax.exam.CoreOptions.options;
-
 import java.io.File;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -48,6 +42,10 @@ import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
 import org.osgi.service.blueprint.container.BlueprintContainer;
 
+import static net.i2cat.nexus.tests.OpennaasExamOptions.*;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
+import static org.ops4j.pax.exam.CoreOptions.*;
+
 @RunWith(JUnit4TestRunner.class)
 @ExamReactorStrategy(EagerSingleStagedReactorFactory.class)
 public class RemoveLogicalRouterTest {
@@ -89,22 +87,10 @@ public class RemoveLogicalRouterTest {
 
 	@Configuration
 	public static Option[] configuration() {
-		return options(karafDistributionConfiguration()
-					   .frameworkUrl(maven()
-									 .groupId("net.i2cat.mantychore")
-									 .artifactId("assembly")
-									 .type("zip")
-									 .classifier("bin")
-									 .versionAsInProject())
-					   .karafVersion("2.2.2")
-					   .name("mantychore")
-					   .unpackDirectory(new File("target/paxexam")),
-					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
-												"featuresBoot",
-												"opennaas-router,nexus-tests-helper"),
-					   configureConsole()
-					   .ignoreLocalConsole()
-					   .ignoreRemoteShell(),
+		return options(opennaasDistributionConfiguration(),
+					   includeFeatures("opennaas-router"),
+					   includeTestHelper(),
+					   noConsole(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/sprints/sprint0_3/src/test/java/luminis/AlarmsInProtocolSessionManagerTest.java
+++ b/manticore/tests/sprints/sprint0_3/src/test/java/luminis/AlarmsInProtocolSessionManagerTest.java
@@ -1,11 +1,5 @@
 package luminis;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
-
-import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
-import static org.ops4j.pax.exam.CoreOptions.maven;
-import static org.ops4j.pax.exam.CoreOptions.options;
-
 import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -43,6 +37,10 @@ import org.osgi.service.event.EventHandler;
 import org.osgi.framework.Constants;
 import org.osgi.service.blueprint.container.BlueprintContainer;
 
+import static net.i2cat.nexus.tests.OpennaasExamOptions.*;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
+import static org.ops4j.pax.exam.CoreOptions.*;
+
 @RunWith(JUnit4TestRunner.class)
 @ExamReactorStrategy(EagerSingleStagedReactorFactory.class)
 public class AlarmsInProtocolSessionManagerTest implements EventHandler {
@@ -60,22 +58,9 @@ public class AlarmsInProtocolSessionManagerTest implements EventHandler {
 
 	@Configuration
 	public static Option[] configuration() {
-		return options(karafDistributionConfiguration()
-					   .frameworkUrl(maven()
-									 .groupId("net.i2cat.mantychore")
-									 .artifactId("assembly")
-									 .type("zip")
-									 .classifier("bin")
-									 .versionAsInProject())
-					   .karafVersion("2.2.2")
-					   .name("mantychore")
-					   .unpackDirectory(new File("target/paxexam")),
-					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
-												"featuresBoot",
-												"opennaas-core"),
-					   configureConsole()
-					   .ignoreLocalConsole()
-					   .ignoreRemoteShell(),
+		return options(opennaasDistributionConfiguration(),
+					   includeFeatures("opennaas-core"),
+					   noConsole(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/sprints/sprint0_3/src/test/java/luminis/AlarmsRepoTest.java
+++ b/manticore/tests/sprints/sprint0_3/src/test/java/luminis/AlarmsRepoTest.java
@@ -1,11 +1,5 @@
 package luminis;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
-
-import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
-import static org.ops4j.pax.exam.CoreOptions.maven;
-import static org.ops4j.pax.exam.CoreOptions.options;
-
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Date;
@@ -47,6 +41,10 @@ import org.ops4j.pax.exam.util.Filter;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
 import org.osgi.service.blueprint.container.BlueprintContainer;
+
+import static net.i2cat.nexus.tests.OpennaasExamOptions.*;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
+import static org.ops4j.pax.exam.CoreOptions.*;
 
 @RunWith(JUnit4TestRunner.class)
 @ExamReactorStrategy(EagerSingleStagedReactorFactory.class)
@@ -90,22 +88,9 @@ public class AlarmsRepoTest
 
 	@Configuration
 	public static Option[] configuration() {
-		return options(karafDistributionConfiguration()
-					   .frameworkUrl(maven()
-									 .groupId("net.i2cat.mantychore")
-									 .artifactId("assembly")
-									 .type("zip")
-									 .classifier("bin")
-									 .versionAsInProject())
-					   .karafVersion("2.2.2")
-					   .name("mantychore")
-					   .unpackDirectory(new File("target/paxexam")),
-					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
-												"featuresBoot",
-												"opennaas-alarms,opennaas-cim,opennaas-luminis"),
-					   configureConsole()
-					   .ignoreLocalConsole()
-					   .ignoreRemoteShell(),
+		return options(opennaasDistributionConfiguration(),
+					   includeFeatures("opennaas-alarms", "opennaas-cim", "opennaas-luminis"),
+					   noConsole(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/sprints/sprint0_3/src/test/java/luminis/CompleteAlarmsWorkflowTest.java
+++ b/manticore/tests/sprints/sprint0_3/src/test/java/luminis/CompleteAlarmsWorkflowTest.java
@@ -1,11 +1,5 @@
 package luminis;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
-
-import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
-import static org.ops4j.pax.exam.CoreOptions.maven;
-import static org.ops4j.pax.exam.CoreOptions.options;
-
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Date;
@@ -48,6 +42,10 @@ import org.osgi.framework.Constants;
 import org.osgi.service.blueprint.container.BlueprintContainer;
 import org.osgi.service.event.Event;
 
+import static net.i2cat.nexus.tests.OpennaasExamOptions.*;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
+import static org.ops4j.pax.exam.CoreOptions.*;
+
 @RunWith(JUnit4TestRunner.class)
 @ExamReactorStrategy(EagerSingleStagedReactorFactory.class)
 public class CompleteAlarmsWorkflowTest
@@ -86,22 +84,9 @@ public class CompleteAlarmsWorkflowTest
 
 	@Configuration
 	public static Option[] configuration() {
-		return options(karafDistributionConfiguration()
-					   .frameworkUrl(maven()
-									 .groupId("net.i2cat.mantychore")
-									 .artifactId("assembly")
-									 .type("zip")
-									 .classifier("bin")
-									 .versionAsInProject())
-					   .karafVersion("2.2.2")
-					   .name("mantychore")
-					   .unpackDirectory(new File("target/paxexam")),
-					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
-												"featuresBoot",
-												"opennaas-alarms,opennaas-luminis"),
-					   configureConsole()
-					   .ignoreLocalConsole()
-					   .ignoreRemoteShell(),
+		return options(opennaasDistributionConfiguration(),
+					   includeFeatures("opennaas-alarms", "opennaas-luminis"),
+					   noConsole(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/sprints/sprint0_3/src/test/java/luminis/MonitoringCapabilityTest.java
+++ b/manticore/tests/sprints/sprint0_3/src/test/java/luminis/MonitoringCapabilityTest.java
@@ -1,11 +1,5 @@
 package luminis;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
-
-import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
-import static org.ops4j.pax.exam.CoreOptions.maven;
-import static org.ops4j.pax.exam.CoreOptions.options;
-
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Date;
@@ -51,6 +45,10 @@ import org.osgi.service.blueprint.container.BlueprintContainer;
 import org.osgi.service.event.Event;
 import org.osgi.service.event.EventHandler;
 
+import static net.i2cat.nexus.tests.OpennaasExamOptions.*;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
+import static org.ops4j.pax.exam.CoreOptions.*;
+
 @RunWith(JUnit4TestRunner.class)
 @ExamReactorStrategy(EagerSingleStagedReactorFactory.class)
 public class MonitoringCapabilityTest implements EventHandler
@@ -92,22 +90,9 @@ public class MonitoringCapabilityTest implements EventHandler
 
 	@Configuration
 	public static Option[] configuration() {
-		return options(karafDistributionConfiguration()
-					   .frameworkUrl(maven()
-									 .groupId("net.i2cat.mantychore")
-									 .artifactId("assembly")
-									 .type("zip")
-									 .classifier("bin")
-									 .versionAsInProject())
-					   .karafVersion("2.2.2")
-					   .name("mantychore")
-					   .unpackDirectory(new File("target/paxexam")),
-					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
-												"featuresBoot",
-												"opennaas-luminis"),
-					   configureConsole()
-					   .ignoreLocalConsole()
-					   .ignoreRemoteShell(),
+		return options(opennaasDistributionConfiguration(),
+					   includeFeatures("opennaas-luminis"),
+					   noConsole(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/sprints/sprint0_3/src/test/java/luminis/RawSocketAlarmToResourceAlarmTest.java
+++ b/manticore/tests/sprints/sprint0_3/src/test/java/luminis/RawSocketAlarmToResourceAlarmTest.java
@@ -1,11 +1,5 @@
 package luminis;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
-
-import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
-import static org.ops4j.pax.exam.CoreOptions.maven;
-import static org.ops4j.pax.exam.CoreOptions.options;
-
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Date;
@@ -49,6 +43,10 @@ import org.osgi.service.blueprint.container.BlueprintContainer;
 import org.osgi.service.event.Event;
 import org.osgi.service.event.EventHandler;
 
+import static net.i2cat.nexus.tests.OpennaasExamOptions.*;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
+import static org.ops4j.pax.exam.CoreOptions.*;
+
 @RunWith(JUnit4TestRunner.class)
 @ExamReactorStrategy(EagerSingleStagedReactorFactory.class)
 public class RawSocketAlarmToResourceAlarmTest implements EventHandler
@@ -84,22 +82,10 @@ public class RawSocketAlarmToResourceAlarmTest implements EventHandler
 
 	@Configuration
 	public static Option[] configuration() {
-		return options(karafDistributionConfiguration()
-					   .frameworkUrl(maven()
-									 .groupId("net.i2cat.mantychore")
-									 .artifactId("assembly")
-									 .type("zip")
-									 .classifier("bin")
-									 .versionAsInProject())
-					   .karafVersion("2.2.2")
-					   .name("mantychore")
-					   .unpackDirectory(new File("target/paxexam")),
-					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
-												"featuresBoot",
-												"opennaas-luminis,nexus-tests-helper"),
-					   configureConsole()
-					   .ignoreLocalConsole()
-					   .ignoreRemoteShell(),
+		return options(opennaasDistributionConfiguration(),
+					   includeFeatures("opennaas-luminis"),
+					   includeTestHelper(),
+					   noConsole(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/sprints/sprint0_4/src/test/java/interfaces/configure/ConfigureSubInterfaceTest.java
+++ b/manticore/tests/sprints/sprint0_4/src/test/java/interfaces/configure/ConfigureSubInterfaceTest.java
@@ -1,11 +1,5 @@
 package interfaces.configure;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
-
-import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
-import static org.ops4j.pax.exam.CoreOptions.maven;
-import static org.ops4j.pax.exam.CoreOptions.options;
-
 import helpers.CheckParametersHelper;
 import helpers.ParamCreationHelper;
 
@@ -45,6 +39,10 @@ import org.ops4j.pax.exam.spi.reactors.EagerSingleStagedReactorFactory;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
 import org.osgi.service.blueprint.container.BlueprintContainer;
+
+import static net.i2cat.nexus.tests.OpennaasExamOptions.*;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
+import static org.ops4j.pax.exam.CoreOptions.*;
 
 /**
  * These tests check the subinterface configurations
@@ -89,22 +87,10 @@ public class ConfigureSubInterfaceTest
 
 	@Configuration
 	public static Option[] configuration() {
-		return options(karafDistributionConfiguration()
-					   .frameworkUrl(maven()
-									 .groupId("net.i2cat.mantychore")
-									 .artifactId("assembly")
-									 .type("zip")
-									 .classifier("bin")
-									 .versionAsInProject())
-					   .karafVersion("2.2.2")
-					   .name("mantychore")
-					   .unpackDirectory(new File("target/paxexam")),
-					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
-												"featuresBoot",
-												"opennaas-router,nexus-tests-helper"),
-					   configureConsole()
-					   .ignoreLocalConsole()
-					   .ignoreRemoteShell(),
+		return options(opennaasDistributionConfiguration(),
+					   includeFeatures("opennaas-router"),
+					   includeTestHelper(),
+					   noConsole(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/sprints/sprint0_4/src/test/java/interfaces/setdesc/SetInterfaceDescriptionActionInLRTest.java
+++ b/manticore/tests/sprints/sprint0_4/src/test/java/interfaces/setdesc/SetInterfaceDescriptionActionInLRTest.java
@@ -1,11 +1,5 @@
 package interfaces.setdesc;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
-
-import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
-import static org.ops4j.pax.exam.CoreOptions.maven;
-import static org.ops4j.pax.exam.CoreOptions.options;
-
 import helpers.CheckParametersHelper;
 
 import java.io.File;
@@ -48,6 +42,10 @@ import org.ops4j.pax.exam.spi.reactors.EagerSingleStagedReactorFactory;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
 import org.osgi.service.blueprint.container.BlueprintContainer;
+
+import static net.i2cat.nexus.tests.OpennaasExamOptions.*;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
+import static org.ops4j.pax.exam.CoreOptions.*;
 
 @RunWith(JUnit4TestRunner.class)
 @ExamReactorStrategy(EagerSingleStagedReactorFactory.class)
@@ -95,22 +93,10 @@ public class SetInterfaceDescriptionActionInLRTest
 
 	@Configuration
 	public static Option[] configuration() {
-		return options(karafDistributionConfiguration()
-					   .frameworkUrl(maven()
-									 .groupId("net.i2cat.mantychore")
-									 .artifactId("assembly")
-									 .type("zip")
-									 .classifier("bin")
-									 .versionAsInProject())
-					   .karafVersion("2.2.2")
-					   .name("mantychore")
-					   .unpackDirectory(new File("target/paxexam")),
-					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
-												"featuresBoot",
-												"opennaas-router,nexus-tests-helper"),
-					   configureConsole()
-					   .ignoreLocalConsole()
-					   .ignoreRemoteShell(),
+		return options(opennaasDistributionConfiguration(),
+					   includeFeatures("opennaas-router"),
+					   includeTestHelper(),
+					   noConsole(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/sprints/sprint0_4/src/test/java/interfaces/setdesc/SetInterfaceDescriptionActionTest.java
+++ b/manticore/tests/sprints/sprint0_4/src/test/java/interfaces/setdesc/SetInterfaceDescriptionActionTest.java
@@ -1,11 +1,5 @@
 package interfaces.setdesc;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
-
-import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
-import static org.ops4j.pax.exam.CoreOptions.maven;
-import static org.ops4j.pax.exam.CoreOptions.options;
-
 import helpers.CheckParametersHelper;
 
 import java.io.File;
@@ -49,6 +43,10 @@ import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
 import org.osgi.service.blueprint.container.BlueprintContainer;
 
+import static net.i2cat.nexus.tests.OpennaasExamOptions.*;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
+import static org.ops4j.pax.exam.CoreOptions.*;
+
 @RunWith(JUnit4TestRunner.class)
 @ExamReactorStrategy(EagerSingleStagedReactorFactory.class)
 public class SetInterfaceDescriptionActionTest
@@ -89,22 +87,10 @@ public class SetInterfaceDescriptionActionTest
 
 	@Configuration
 	public static Option[] configuration() {
-		return options(karafDistributionConfiguration()
-					   .frameworkUrl(maven()
-									 .groupId("net.i2cat.mantychore")
-									 .artifactId("assembly")
-									 .type("zip")
-									 .classifier("bin")
-									 .versionAsInProject())
-					   .karafVersion("2.2.2")
-					   .name("mantychore")
-					   .unpackDirectory(new File("target/paxexam")),
-					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
-												"featuresBoot",
-												"opennaas-router,nexus-tests-helper"),
-					   configureConsole()
-					   .ignoreLocalConsole()
-					   .ignoreRemoteShell(),
+		return options(opennaasDistributionConfiguration(),
+					   includeFeatures("opennaas-router"),
+					   includeTestHelper(),
+					   noConsole(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/sprints/week26/src/test/java/interfaces/InterfacesDownKarafTest.java
+++ b/manticore/tests/sprints/week26/src/test/java/interfaces/InterfacesDownKarafTest.java
@@ -1,11 +1,5 @@
 package interfaces;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
-
-import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
-import static org.ops4j.pax.exam.CoreOptions.maven;
-import static org.ops4j.pax.exam.CoreOptions.options;
-
 import java.io.File;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -48,6 +42,10 @@ import org.ops4j.pax.exam.spi.reactors.EagerSingleStagedReactorFactory;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
 import org.osgi.service.blueprint.container.BlueprintContainer;
+
+import static net.i2cat.nexus.tests.OpennaasExamOptions.*;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
+import static org.ops4j.pax.exam.CoreOptions.*;
 
 /**
  * Tests new chassis operations in interface. In this feature it is necessary to create two operations to configure the status interface. The
@@ -100,22 +98,10 @@ public class InterfacesDownKarafTest
 
 	@Configuration
 	public static Option[] configuration() {
-		return options(karafDistributionConfiguration()
-					   .frameworkUrl(maven()
-									 .groupId("net.i2cat.mantychore")
-									 .artifactId("assembly")
-									 .type("zip")
-									 .classifier("bin")
-									 .versionAsInProject())
-					   .karafVersion("2.2.2")
-					   .name("mantychore")
-					   .unpackDirectory(new File("target/paxexam")),
-					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
-												"featuresBoot",
-												"opennaas-router,nexus-tests-helper"),
-					   configureConsole()
-					   .ignoreLocalConsole()
-					   .ignoreRemoteShell(),
+		return options(opennaasDistributionConfiguration(),
+					   includeFeatures("opennaas-router"),
+					   includeTestHelper(),
+					   noConsole(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/sprints/week26/src/test/java/interfaces/InterfacesDownUpKarafTest.java
+++ b/manticore/tests/sprints/week26/src/test/java/interfaces/InterfacesDownUpKarafTest.java
@@ -1,11 +1,5 @@
 package interfaces;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
-
-import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
-import static org.ops4j.pax.exam.CoreOptions.maven;
-import static org.ops4j.pax.exam.CoreOptions.options;
-
 import java.io.File;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -49,6 +43,10 @@ import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
 import org.osgi.service.blueprint.container.BlueprintContainer;
 
+import static net.i2cat.nexus.tests.OpennaasExamOptions.*;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
+import static org.ops4j.pax.exam.CoreOptions.*;
+
 @SuppressWarnings("unused")
 @RunWith(JUnit4TestRunner.class)
 @ExamReactorStrategy(EagerSingleStagedReactorFactory.class)
@@ -91,22 +89,10 @@ public class InterfacesDownUpKarafTest
 
 	@Configuration
 	public static Option[] configuration() {
-		return options(karafDistributionConfiguration()
-					   .frameworkUrl(maven()
-									 .groupId("net.i2cat.mantychore")
-									 .artifactId("assembly")
-									 .type("zip")
-									 .classifier("bin")
-									 .versionAsInProject())
-					   .karafVersion("2.2.2")
-					   .name("mantychore")
-					   .unpackDirectory(new File("target/paxexam")),
-					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
-												"featuresBoot",
-												"opennaas-router,nexus-tests-helper"),
-					   configureConsole()
-					   .ignoreLocalConsole()
-					   .ignoreRemoteShell(),
+		return options(opennaasDistributionConfiguration(),
+					   includeFeatures("opennaas-router"),
+					   includeTestHelper(),
+					   noConsole(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/sprints/week26/src/test/java/interfaces/InterfacesIPKarafTest.java
+++ b/manticore/tests/sprints/week26/src/test/java/interfaces/InterfacesIPKarafTest.java
@@ -1,11 +1,5 @@
 package interfaces;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
-
-import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
-import static org.ops4j.pax.exam.CoreOptions.maven;
-import static org.ops4j.pax.exam.CoreOptions.options;
-
 import java.io.File;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -51,6 +45,10 @@ import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
 import org.osgi.service.blueprint.container.BlueprintContainer;
 
+import static net.i2cat.nexus.tests.OpennaasExamOptions.*;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
+import static org.ops4j.pax.exam.CoreOptions.*;
+
 @RunWith(JUnit4TestRunner.class)
 @ExamReactorStrategy(EagerSingleStagedReactorFactory.class)
 public class InterfacesIPKarafTest
@@ -92,22 +90,10 @@ public class InterfacesIPKarafTest
 
 	@Configuration
 	public static Option[] configuration() {
-		return options(karafDistributionConfiguration()
-					   .frameworkUrl(maven()
-									 .groupId("net.i2cat.mantychore")
-									 .artifactId("assembly")
-									 .type("zip")
-									 .classifier("bin")
-									 .versionAsInProject())
-					   .karafVersion("2.2.2")
-					   .name("mantychore")
-					   .unpackDirectory(new File("target/paxexam")),
-					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
-												"featuresBoot",
-												"opennaas-router,nexus-tests-helper"),
-					   configureConsole()
-					   .ignoreLocalConsole()
-					   .ignoreRemoteShell(),
+		return options(opennaasDistributionConfiguration(),
+					   includeFeatures("opennaas-router"),
+					   includeTestHelper(),
+					   noConsole(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/sprints/week26/src/test/java/interfaces/InterfacesUPDownLoKarafTest.java
+++ b/manticore/tests/sprints/week26/src/test/java/interfaces/InterfacesUPDownLoKarafTest.java
@@ -1,11 +1,5 @@
 package interfaces;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
-
-import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
-import static org.ops4j.pax.exam.CoreOptions.maven;
-import static org.ops4j.pax.exam.CoreOptions.options;
-
 import java.io.File;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -49,6 +43,10 @@ import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
 import org.osgi.service.blueprint.container.BlueprintContainer;
 
+import static net.i2cat.nexus.tests.OpennaasExamOptions.*;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
+import static org.ops4j.pax.exam.CoreOptions.*;
+
 @SuppressWarnings("unused")
 @RunWith(JUnit4TestRunner.class)
 @ExamReactorStrategy(EagerSingleStagedReactorFactory.class)
@@ -91,22 +89,10 @@ public class InterfacesUPDownLoKarafTest
 
 	@Configuration
 	public static Option[] configuration() {
-		return options(karafDistributionConfiguration()
-					   .frameworkUrl(maven()
-									 .groupId("net.i2cat.mantychore")
-									 .artifactId("assembly")
-									 .type("zip")
-									 .classifier("bin")
-									 .versionAsInProject())
-					   .karafVersion("2.2.2")
-					   .name("mantychore")
-					   .unpackDirectory(new File("target/paxexam")),
-					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
-												"featuresBoot",
-												"opennaas-router,nexus-tests-helper"),
-					   configureConsole()
-					   .ignoreLocalConsole()
-					   .ignoreRemoteShell(),
+		return options(opennaasDistributionConfiguration(),
+					   includeFeatures("opennaas-router"),
+					   includeTestHelper(),
+					   noConsole(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/sprints/week26/src/test/java/interfaces/InterfacesUpKarafTest.java
+++ b/manticore/tests/sprints/week26/src/test/java/interfaces/InterfacesUpKarafTest.java
@@ -1,11 +1,5 @@
 package interfaces;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
-
-import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
-import static org.ops4j.pax.exam.CoreOptions.maven;
-import static org.ops4j.pax.exam.CoreOptions.options;
-
 import java.io.File;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -48,6 +42,10 @@ import org.ops4j.pax.exam.util.Filter;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
 import org.osgi.service.blueprint.container.BlueprintContainer;
+
+import static net.i2cat.nexus.tests.OpennaasExamOptions.*;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
+import static org.ops4j.pax.exam.CoreOptions.*;
 
 /**
  * Tests new chassis operations in interface. In this feature it is necessary to create two operations to configure the status interface. The
@@ -101,22 +99,10 @@ public class InterfacesUpKarafTest
 
 	@Configuration
 	public static Option[] configuration() {
-		return options(karafDistributionConfiguration()
-					   .frameworkUrl(maven()
-									 .groupId("net.i2cat.mantychore")
-									 .artifactId("assembly")
-									 .type("zip")
-									 .classifier("bin")
-									 .versionAsInProject())
-					   .karafVersion("2.2.2")
-					   .name("mantychore")
-					   .unpackDirectory(new File("target/paxexam")),
-					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
-												"featuresBoot",
-												"opennaas-router,nexus-tests-helper"),
-					   configureConsole()
-					   .ignoreLocalConsole()
-					   .ignoreRemoteShell(),
+		return options(opennaasDistributionConfiguration(),
+					   includeFeatures("opennaas-router"),
+					   includeTestHelper(),
+					   noConsole(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/sprints/week26/src/test/java/interfaces/InterfacesVLANKarafTest.java
+++ b/manticore/tests/sprints/week26/src/test/java/interfaces/InterfacesVLANKarafTest.java
@@ -1,11 +1,5 @@
 package interfaces;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
-
-import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
-import static org.ops4j.pax.exam.CoreOptions.maven;
-import static org.ops4j.pax.exam.CoreOptions.options;
-
 import java.io.File;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -51,6 +45,10 @@ import org.ops4j.pax.exam.spi.reactors.EagerSingleStagedReactorFactory;
 import org.osgi.framework.Constants;
 import org.osgi.service.blueprint.container.BlueprintContainer;
 
+import static net.i2cat.nexus.tests.OpennaasExamOptions.*;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
+import static org.ops4j.pax.exam.CoreOptions.*;
+
 @RunWith(JUnit4TestRunner.class)
 @ExamReactorStrategy(EagerSingleStagedReactorFactory.class)
 public class InterfacesVLANKarafTest
@@ -90,22 +88,10 @@ public class InterfacesVLANKarafTest
 
 	@Configuration
 	public static Option[] configuration() {
-		return options(karafDistributionConfiguration()
-					   .frameworkUrl(maven()
-									 .groupId("net.i2cat.mantychore")
-									 .artifactId("assembly")
-									 .type("zip")
-									 .classifier("bin")
-									 .versionAsInProject())
-					   .karafVersion("2.2.2")
-					   .name("mantychore")
-					   .unpackDirectory(new File("target/paxexam")),
-					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
-												"featuresBoot",
-												"opennaas-router,nexus-tests-helper"),
-					   configureConsole()
-					   .ignoreLocalConsole()
-					   .ignoreRemoteShell(),
+		return options(opennaasDistributionConfiguration(),
+					   includeFeatures("opennaas-router"),
+					   includeTestHelper(),
+					   noConsole(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/sprints/week26/src/test/java/queue/QueueTest.java
+++ b/manticore/tests/sprints/week26/src/test/java/queue/QueueTest.java
@@ -1,11 +1,5 @@
 package queue;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
-
-import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
-import static org.ops4j.pax.exam.CoreOptions.maven;
-import static org.ops4j.pax.exam.CoreOptions.options;
-
 import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -47,10 +41,14 @@ import org.ops4j.pax.exam.junit.JUnit4TestRunner;
 import org.ops4j.pax.exam.util.Filter;
 import org.ops4j.pax.exam.spi.reactors.EagerSingleStagedReactorFactory;
 import org.ops4j.pax.exam.spi.reactors.AllConfinedStagedReactorFactory;
-import static org.ops4j.pax.swissbox.framework.ServiceLookup.getService;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
 import org.osgi.service.blueprint.container.BlueprintContainer;
+
+import static net.i2cat.nexus.tests.OpennaasExamOptions.*;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
+import static org.ops4j.pax.exam.CoreOptions.*;
+import static org.ops4j.pax.swissbox.framework.ServiceLookup.getService;
 
 /**
  * Tests new queue operations. In the sprint for the week 26, it is planned to add new features in the queue.
@@ -94,30 +92,11 @@ public class QueueTest
 
 	@Configuration
 	public static Option[] configuration() {
-		return options(karafDistributionConfiguration()
-					   .frameworkUrl(maven()
-									 .groupId("net.i2cat.mantychore")
-									 .artifactId("assembly")
-									 .type("zip")
-									 .classifier("bin")
-									 .versionAsInProject())
-					   .karafVersion("2.2.2")
-					   .name("mantychore")
-					   .unpackDirectory(new File("target/paxexam")),
-					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
-												"featuresBoot",
-												"opennaas-cim,opennaas-netconf,nexus-tests-helper"),
-					   configureConsole()
-					   .ignoreLocalConsole()
-					   .ignoreRemoteShell(),
-					   mavenBundle()
-					   .groupId("org.ops4j.base")
-					   .artifactId("ops4j-base-spi")
-					   .versionAsInProject(),
-					   mavenBundle()
-					   .groupId("org.ops4j.pax.swissbox")
-					   .artifactId("pax-swissbox-framework")
-					   .versionAsInProject(),
+		return options(opennaasDistributionConfiguration(),
+					   includeFeatures("opennaas-cim", "opennaas-netconf"),
+					   includeTestHelper(),
+					   includeSwissboxFramework(),
+					   noConsole(),
 					   keepRuntimeFolder());
 	}
 

--- a/manticore/tests/sprints/week35/src/test/java/automaticrefresh/AutomaticRefreshLuminisTest.java
+++ b/manticore/tests/sprints/week35/src/test/java/automaticrefresh/AutomaticRefreshLuminisTest.java
@@ -1,11 +1,5 @@
 package automaticrefresh;
 
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
-
-import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
-import static org.ops4j.pax.exam.CoreOptions.maven;
-import static org.ops4j.pax.exam.CoreOptions.options;
-
 import java.io.File;
 import java.util.List;
 import javax.inject.Inject;
@@ -32,6 +26,10 @@ import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
 import org.osgi.service.blueprint.container.BlueprintContainer;
 
+import static net.i2cat.nexus.tests.OpennaasExamOptions.*;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
+import static org.ops4j.pax.exam.CoreOptions.*;
+
 @RunWith(JUnit4TestRunner.class)
 @ExamReactorStrategy(EagerSingleStagedReactorFactory.class)
 public class AutomaticRefreshLuminisTest
@@ -52,22 +50,10 @@ public class AutomaticRefreshLuminisTest
 
 	@Configuration
 	public static Option[] configuration() {
-		return options(karafDistributionConfiguration()
-					   .frameworkUrl(maven()
-									 .groupId("net.i2cat.mantychore")
-									 .artifactId("assembly")
-									 .type("zip")
-									 .classifier("bin")
-									 .versionAsInProject())
-					   .karafVersion("2.2.2")
-					   .name("mantychore")
-					   .unpackDirectory(new File("target/paxexam")),
-					   editConfigurationFilePut("etc/org.apache.karaf.features.cfg",
-												"featuresBoot",
-												"opennaas-luminis,nexus-tests-helper"),
-					   configureConsole()
-					   .ignoreLocalConsole()
-					   .ignoreRemoteShell(),
+		return options(opennaasDistributionConfiguration(),
+					   includeFeatures("opennaas-luminis"),
+					   includeTestHelper(),
+					   noConsole(),
 					   keepRuntimeFolder());
 	}
 

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
 		<oro.version>2.0.8_4</oro.version>
 		<osgi.version>4.2.0</osgi.version>
 		<pax.exam2.version>2.3.0</pax.exam2.version>
-		<paxexam-karaf-container.version>0.5.0</paxexam-karaf-container.version>
+		<paxexam-karaf-container.version>0.5.1</paxexam-karaf-container.version>
 		<pax.logging.version>1.6.2</pax.logging.version>
 		<plexus.api.version>1.0-alpha-32</plexus.api.version>
 		<plexus.utils.version>2.0.5</plexus.utils.version>


### PR DESCRIPTION
All integration tests repeat more or less the same
pax exam configuration. This is a clear violation of
DRY.

This patch introduces OpennaasExamOptions. It contains
static methods for generating configuration fragments
used by many tests.

The patch also introduces the AbstractKarafCommandTest
base class for those tests that primarily test Karaf
commands.
