### PR TITLE
Develop

### DIFF
--- a/manticore/bundles/net.i2cat.mantychore.actionsets.junos/src/main/java/net/i2cat/mantychore/actionsets/junos/actions/GetConfigurationAction.java
+++ b/manticore/bundles/net.i2cat.mantychore.actionsets.junos/src/main/java/net/i2cat/mantychore/actionsets/junos/actions/GetConfigurationAction.java
@@ -10,10 +10,10 @@ import net.i2cat.mantychore.commandsets.junos.digester.IPInterfaceParser;
 import net.i2cat.mantychore.commandsets.junos.digester.ListLogicalRoutersParser;
 import net.i2cat.mantychore.commandsets.junos.digester.RoutingOptionsParser;
 import net.i2cat.mantychore.model.ComputerSystem;
-import net.i2cat.mantychore.model.EthernetPort;
 import net.i2cat.mantychore.model.GRETunnelService;
 import net.i2cat.mantychore.model.LogicalTunnelPort;
 import net.i2cat.mantychore.model.ManagedElement;
+import net.i2cat.mantychore.model.NetworkPort;
 import net.i2cat.mantychore.model.System;
 import net.i2cat.netconf.rpc.Reply;
 
@@ -143,7 +143,9 @@ public class GetConfigurationAction extends JunosAction {
 		// TODO implements a better method to merge the elements in model
 		// now are deleted all the existing elements the parser creates
 		// before adding new ones (calling the parser)
-		routerModel.removeAllLogicalDeviceByType(EthernetPort.class);
+		// routerModel.removeAllLogicalDeviceByType(EthernetPort.class);
+
+		routerModel.removeAllLogicalDeviceByType(NetworkPort.class);
 		routerModel.removeAllLogicalDeviceByType(LogicalTunnelPort.class);
 		routerModel.removeAllHostedServicesByType(GRETunnelService.class);
 
@@ -178,16 +180,10 @@ public class GetConfigurationAction extends JunosAction {
 	}
 
 	@Override
-	public boolean checkParams(Object params) throws ActionException {
-		// For this Action params are not allowed
-		return true;
-	}
-
-	@Override
 	public void prepareMessage() throws ActionException {
-		if (template == null || template.equals(""))
-			throw new ActionException("The path to Velocity template in Action " + getActionID() + " is null");
-		checkParams(params);
+
+		validate();
+
 		try {
 			Object velocityParams = params;
 			if (((ComputerSystem) modelToUpdate).getElementName() != null) {
@@ -214,4 +210,27 @@ public class GetConfigurationAction extends JunosAction {
 		}
 	}
 
+	private void validate() throws ActionException {
+		if (!checkTemplate(template)) {
+			throw new ActionException("The path to Velocity template in Action " + getActionID() + " is null");
+		}
+		checkParams(params);
+	}
+
+	private boolean checkTemplate(String template) {
+
+		boolean templateOK = true;
+		// The template can not be null or empty
+		if (template == null || template.equals("")) {
+			templateOK = false;
+		}
+
+		return templateOK;
+
+	}
+
+	public boolean checkParams(Object params) {
+		log.warn("Ignoring parametrs in action " + actionID);
+		return true;
+	}
 }

--- a/manticore/bundles/net.i2cat.mantychore.actionsets.junos/src/test/java/net/i2cat/mantychore/actionsets/junos/actions/test/GetConfigActionTest.java
+++ b/manticore/bundles/net.i2cat.mantychore.actionsets.junos/src/test/java/net/i2cat/mantychore/actionsets/junos/actions/test/GetConfigActionTest.java
@@ -70,11 +70,13 @@ public class GetConfigActionTest {
 
 		for (LogicalDevice device : ld) {
 			LogicalPort lp = (LogicalPort) device;
+
 			if (device instanceof LogicalTunnelPort) {
 				LogicalTunnelPort lt = (LogicalTunnelPort) device;
 				log.info("LogicalTunnelPort: " + lt.getName());
 				log.info("Peer unit " + lt.getPeer_unit());
 				log.info("Unit " + lt.getPortNumber());
+				log.info("Status " + lt.getOperationalStatus());
 			} else if (device instanceof EthernetPort) {
 				EthernetPort ep = (EthernetPort) device;
 				log.info("EthernetPort: " + ep.getName());
@@ -82,6 +84,7 @@ public class GetConfigActionTest {
 			} else {
 				log.info("No such class considered ");
 			}
+			log.info("Status " + device.getOperationalStatus());
 			for (ProtocolEndpoint p : lp.getProtocolEndpoint()) {
 				if (p instanceof IPProtocolEndpoint) {
 					IPProtocolEndpoint ip = (IPProtocolEndpoint) p;
@@ -129,14 +132,10 @@ public class GetConfigActionTest {
 	}
 
 	@Test
-	public void testExecute() {
-		try {
-			ActionResponse response = action.execute(protocolsessionmanager);
-		} catch (ActionException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-			Assert.fail();
-		}
+	public void testExecute() throws ActionException {
+
+		ActionResponse response = action.execute(protocolsessionmanager);
+
 		net.i2cat.mantychore.model.System routerModel = (net.i2cat.mantychore.model.System) action.getModelToUpdate();
 		Assert.assertNotNull(routerModel);
 		printTest(routerModel);

--- a/manticore/bundles/net.i2cat.mantychore.actionsets.junos/src/test/java/net/i2cat/mantychore/actionsets/junos/digester/test/IPInterfaceParserTest.java
+++ b/manticore/bundles/net.i2cat.mantychore.actionsets.junos/src/test/java/net/i2cat/mantychore/actionsets/junos/digester/test/IPInterfaceParserTest.java
@@ -21,16 +21,13 @@ import net.i2cat.mantychore.model.System;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class IPInterfaceParserTest {
 	private final Log	log	= LogFactory.getLog(IPInterfaceParserTest.class);
 
-	@Ignore
 	@Test
 	public void testStatusParserTest() throws Exception {
-		// FIXME http://jira.i2cat.net:8080/browse/OPENNAAS-228
 		System model = createSampleModel();
 		IPInterfaceParser parser = new IPInterfaceParser(model);
 
@@ -47,10 +44,12 @@ public class IPInterfaceParserTest {
 		for (LogicalDevice device : model.getLogicalDevices()) {
 			if (device instanceof EthernetPort) {
 				EthernetPort port = (EthernetPort) device;
-				Assert.assertNotNull("OperationalStatus must be set", port.getOperatingStatus());
+				Assert.assertNotNull("OperationalStatus must be set", port.getOperationalStatus());
 
 				str += "- EthernetPort: " + '\n';
-				str += port.getName() + '\n';
+				str += port.getName() + '.' + port.getPortNumber() + '\n';
+				str += port.getOperationalStatus();
+				str += '\n';
 				for (ProtocolEndpoint protocolEndpoint : port.getProtocolEndpoint()) {
 					if (protocolEndpoint instanceof IPProtocolEndpoint) {
 						IPProtocolEndpoint ipProtocol = (IPProtocolEndpoint)

--- a/manticore/tests/integration/net.i2cat.mantychore.tests.capability/src/test/java/net/i2cat/mantychore/chassiscapability/test/ChassisCapabilityIntegrationTest.java
+++ b/manticore/tests/integration/net.i2cat.mantychore.tests.capability/src/test/java/net/i2cat/mantychore/chassiscapability/test/ChassisCapabilityIntegrationTest.java
@@ -2,13 +2,14 @@ package net.i2cat.mantychore.chassiscapability.test;
 
 import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
 
+
 import static org.ops4j.pax.exam.CoreOptions.maven;
-import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
 import static org.ops4j.pax.exam.CoreOptions.options;
 
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+
 import javax.inject.Inject;
 
 import net.i2cat.mantychore.actionsets.junos.ActionConstants;
@@ -24,8 +25,8 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Test;
 import org.junit.Ignore;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opennaas.core.resources.IModel;
 import org.opennaas.core.resources.ResourceIdentifier;
@@ -44,15 +45,12 @@ import org.opennaas.core.resources.protocol.ProtocolSessionContext;
 import org.opennaas.core.resources.queue.QueueConstants;
 import org.opennaas.core.resources.queue.QueueResponse;
 import org.ops4j.pax.exam.Option;
-import org.ops4j.pax.exam.TestProbeBuilder;
 import org.ops4j.pax.exam.junit.Configuration;
-import org.ops4j.pax.exam.junit.JUnit4TestRunner;
-import org.ops4j.pax.exam.junit.ProbeBuilder;
 import org.ops4j.pax.exam.junit.ExamReactorStrategy;
-import org.ops4j.pax.exam.util.Filter;
+import org.ops4j.pax.exam.junit.JUnit4TestRunner;
 import org.ops4j.pax.exam.spi.reactors.EagerSingleStagedReactorFactory;
+import org.ops4j.pax.exam.util.Filter;
 import org.osgi.framework.BundleContext;
-import org.osgi.framework.Constants;
 import org.osgi.service.blueprint.container.BlueprintContainer;
 
 @RunWith(JUnit4TestRunner.class)
@@ -61,8 +59,8 @@ public class ChassisCapabilityIntegrationTest
 {
 	private final static Log	log			= LogFactory.getLog(ChassisCapabilityIntegrationTest.class);
 
-	private final String		deviceID		= "junos";
-	private final String		queueID			= "queue";
+	private final String		deviceID	= "junos";
+	private final String		queueID		= "queue";
 
 	private MockResource		mockResource;
 	private ICapability			chassisCapability;
@@ -82,9 +80,9 @@ public class ChassisCapabilityIntegrationTest
 	@Filter("(capability=chassis)")
 	private ICapabilityFactory	chassisFactory;
 
-    @Inject
-    @Filter("(osgi.blueprint.container.symbolicname=net.i2cat.mantychore.repository)")
-    private BlueprintContainer	routerService;
+	@Inject
+	@Filter("(osgi.blueprint.container.symbolicname=net.i2cat.mantychore.repository)")
+	private BlueprintContainer	routerService;
 
 	@Configuration
 	public static Option[] configuration() {
@@ -174,6 +172,7 @@ public class ChassisCapabilityIntegrationTest
 
 	@Test
 	@Ignore
+	// FIXME this tests fails because of a vlan-tagging limitation describes at OPENNAAS-95 issue.
 	public void TestChassisAction() throws CapabilityException {
 		log.info("TEST CHASSIS ACTION");
 

--- a/manticore/tests/integration/net.i2cat.mantychore.tests.capability/src/test/java/net/i2cat/mantychore/chassiscapability/test/UpDownTest.java
+++ b/manticore/tests/integration/net.i2cat.mantychore.tests.capability/src/test/java/net/i2cat/mantychore/chassiscapability/test/UpDownTest.java
@@ -14,16 +14,18 @@ import javax.inject.Inject;
 import net.i2cat.mantychore.actionsets.junos.ActionConstants;
 import net.i2cat.mantychore.chassiscapability.test.mock.MockBootstrapper;
 import net.i2cat.mantychore.model.ComputerSystem;
+import net.i2cat.mantychore.model.EthernetPort;
+import net.i2cat.mantychore.model.IPProtocolEndpoint;
 import net.i2cat.mantychore.model.LogicalDevice;
 import net.i2cat.mantychore.model.LogicalPort;
 import net.i2cat.mantychore.model.ManagedSystemElement.OperationalStatus;
+import net.i2cat.mantychore.model.ProtocolEndpoint;
 
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.opennaas.core.resources.ResourceIdentifier;
@@ -192,10 +194,8 @@ public class UpDownTest
 
 	}
 
-	@Ignore
 	@Test
 	public void UpDownActionTest() throws CapabilityException {
-		// FIXME http://jira.i2cat.net:8080/browse/OPENNAAS-228
 		Response resp;
 		QueueResponse queueResponse;
 
@@ -205,6 +205,36 @@ public class UpDownTest
 
 		queueResponse = (QueueResponse) queueCapability.sendMessage(QueueConstants.EXECUTE, null);
 		Assert.assertTrue(queueResponse.isOk());
+
+		String str = "";
+		ComputerSystem model = (ComputerSystem) mockResource.getModel();
+		Assert.assertNotNull(model);
+		for (LogicalDevice device : model.getLogicalDevices()) {
+			if (device instanceof EthernetPort) {
+				EthernetPort port = (EthernetPort) device;
+				Assert.assertNotNull("OperationalStatus must be set", port.getOperationalStatus());
+
+				str += "- EthernetPort: " + '\n';
+				str += port.getName() + '.' + port.getPortNumber() + '\n';
+				str += port.getOperationalStatus();
+				str += '\n';
+				for (ProtocolEndpoint protocolEndpoint : port.getProtocolEndpoint()) {
+					if (protocolEndpoint instanceof IPProtocolEndpoint) {
+						IPProtocolEndpoint ipProtocol = (IPProtocolEndpoint)
+								protocolEndpoint;
+						str += "ipv4: " + ipProtocol.getIPv4Address() + '\n';
+						str += "ipv6: " + ipProtocol.getIPv6Address() + '\n';
+					}
+				}
+
+			}
+			else {
+				str += "not searched device";
+			}
+
+		}
+
+		log.info(str);
 
 		String interfaceName = "fe-0/1/3";
 


### PR DESCRIPTION
The interface parser didin't set the operational status. It was set in a never-called and depracated function.
Actually, when the parser founds a closing <interface> tag, set the operatioanl status of all its subinterfaces.

Issue: OPENNAAS-228
