### PR TITLE
Feature/opennaas 231

### DIFF
--- a/core/opennaas-core-resources/src/main/java/org/opennaas/core/resources/ResourceRepository.java
+++ b/core/opennaas-core-resources/src/main/java/org/opennaas/core/resources/ResourceRepository.java
@@ -191,21 +191,11 @@ public class ResourceRepository implements IResourceRepository {
 	}
 
 	public void removeResource(String identifier) throws ResourceException {
-		// logger.debug("Removing resource runtime object for ID #"
-		// + identifier);
-		// stopResource(identifier);
-		// logger.debug("Removing resource configuration for ID #"
-		// + identifier);
-
 		logger.info("Removing resource with ID #" + identifier);
 
 		IResource resource = getResource(identifier);
-		unpersistResourceDescriptor(resource.getResourceDescriptor());
-
-		logger.info("Resource shutdown");
 		shutdownResource(identifier);
-
-		logger.info("Unpersisted and removed resource");
+		unpersistResourceDescriptor(resource.getResourceDescriptor());
 	}
 
 	public IResource modifyResource(String identifier, ResourceDescriptor descriptor) throws ResourceException {


### PR DESCRIPTION
The following steps lead to inconsistent state:
1. Create resource
2. Start resource
3. Remove resource (it launches an error, as expected)
4. Stop resource
5. Remove resource -> ERROR.

The expected behaviour in 5) is that the resource can be removed.

The problem is caused by OpenNaaS removing the database entry
for the resource before checking whether the resource is active.
This means the resource is partially removed in step 3 even though
it is active. Step 5 fails because the resource cannot be removed
from the database as it was already deleted once.

Ideally the complete remove operation would be a single database
transaction, but implementing this would require quite a number
of changes to how we deal with persistence.

Instead this patch simply reorders the code:
1. Check that resource is INACTIVE
2. Remove from internal data structures
3. Remove from database
