### PR TITLE
Feature/opennaas 162

### DIFF
--- a/manticore/platform/src/main/filtered-resources/bin/mantychore.sh
+++ b/manticore/platform/src/main/filtered-resources/bin/mantychore.sh
@@ -273,6 +273,12 @@ setupDefaults() {
     #DEFAULT_JAVA_DEBUG_OPTS="-Xrunyjpagent"
 }
 
+applyKarafHistoryWorkaround() {
+    if [ ! -f ~/.karaf/karaf.history ]; then
+        echo > ~/.karaf/karaf.history
+    fi
+}
+
 init() {
     # Determine if there is special OS handling we must perform
     detectOS
@@ -304,6 +310,8 @@ init() {
     # Install debug options
     setupDebugOptions
 
+    # Workaround for issue opennaas-162
+    applyKarafHistoryWorkaround
 }
 
 run() {


### PR DESCRIPTION
The patch addresses issue opennaas-162. The problem is that
Karaf throws a NoSuchElementException when entering an
empty command while the Karaf history is empty (ie on first
run until a command has been exexcuted).

The bug is fixed in newer releases of Karaf, however the
fusesource release does not contain the fix yet.

This patch adds a simple workaround: The mantychore.sh script
checks for a missing karaf history file. If no history file
is found, a file with a single empty command is created.

The workaround should be removed once the upstream fix is
merged into the fusesource release.
