### PR TITLE
Feature/better log4j conf

### DIFF
--- a/manticore/platform/src/main/filtered-resources/etc/org.ops4j.pax.logging.cfg
+++ b/manticore/platform/src/main/filtered-resources/etc/org.ops4j.pax.logging.cfg
@@ -17,6 +17,10 @@
 #
 ################################################################################
 
+opennaas.log.fastPattern = %d{ABSOLUTE} %-5.5p | %10.10t | %-32.32c | %m%n
+opennaas.log.slowPattern = %d{ABSOLUTE} %-5.5p | %10.10t | %-32.32C %4L | %m%n
+opennaas.log.usedPattern = ${opennaas.log.fastPattern}
+
 # Root logger
 log4j.rootLogger= WARN, allout, osgi:VmLogAppender
 
@@ -81,13 +85,13 @@ log4j.logger.org.opennaas.tests = DEBUG, itestsout
 # CONSOLE appender
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%d{ABSOLUTE} | %-5.5p | %-16.16t | %-32.32c{1} | %-32.32C %4L | %m%n
+log4j.appender.stdout.layout.ConversionPattern=${opennaas.log.usedPattern}
 
 # ALL file appender
 log4j.appender.allout=org.apache.log4j.RollingFileAppender
 log4j.appender.allout.MaxFileSize=1000KB
 log4j.appender.allout.layout=org.apache.log4j.PatternLayout
-log4j.appender.allout.layout.ConversionPattern=%d{ABSOLUTE} | %-5.5p | %-16.16t | %-32.32c{1} | %-32.32C %4L | %m%n
+log4j.appender.allout.layout.ConversionPattern=${opennaas.log.usedPattern}
 log4j.appender.allout.file=${karaf.base}/data/log/all.log
 log4j.appender.allout.append=true
 
@@ -95,7 +99,7 @@ log4j.appender.allout.append=true
 log4j.appender.coreout=org.apache.log4j.RollingFileAppender
 log4j.appender.coreout.MaxFileSize=1000KB
 log4j.appender.coreout.layout=org.apache.log4j.PatternLayout
-log4j.appender.coreout.layout.ConversionPattern=%d{ABSOLUTE} | %-5.5p | %-16.16t | %-32.32c{1} | %-32.32C %4L | %m%n
+log4j.appender.coreout.layout.ConversionPattern=${opennaas.log.usedPattern}
 log4j.appender.coreout.file=${karaf.base}/data/log/core.log
 log4j.appender.coreout.append=true
 
@@ -103,7 +107,7 @@ log4j.appender.coreout.append=true
 log4j.appender.routerout=org.apache.log4j.RollingFileAppender
 log4j.appender.routerout.MaxFileSize=1000KB
 log4j.appender.routerout.layout=org.apache.log4j.PatternLayout
-log4j.appender.routerout.layout.ConversionPattern=%d{ABSOLUTE} | %-5.5p | %-16.16t | %-32.32c{1} | %-32.32C %4L | %m%n
+log4j.appender.routerout.layout.ConversionPattern=${opennaas.log.usedPattern}
 log4j.appender.routerout.file=${karaf.base}/data/log/router.log
 log4j.appender.routerout.append=true
 
@@ -111,7 +115,7 @@ log4j.appender.routerout.append=true
 log4j.appender.netconfout=org.apache.log4j.RollingFileAppender
 log4j.appender.netconfout.MaxFileSize=1000KB
 log4j.appender.netconfout.layout=org.apache.log4j.PatternLayout
-log4j.appender.netconfout.layout.ConversionPattern=%d{ABSOLUTE} | %-5.5p | %-16.16t | %-32.32c{1} | %-32.32C %4L | %m%n
+log4j.appender.netconfout.layout.ConversionPattern=${opennaas.log.usedPattern}
 log4j.appender.netconfout.file=${karaf.base}/data/log/router-netconf.log
 log4j.appender.netconfout.append=true
 
@@ -119,7 +123,7 @@ log4j.appender.netconfout.append=true
 log4j.appender.networkout=org.apache.log4j.RollingFileAppender
 log4j.appender.networkout.MaxFileSize=1000KB
 log4j.appender.networkout.layout=org.apache.log4j.PatternLayout
-log4j.appender.networkout.layout.ConversionPattern=%d{ABSOLUTE} | %-5.5p | %-16.16t | %-32.32c{1} | %-32.32C %4L | %m%n
+log4j.appender.networkout.layout.ConversionPattern=${opennaas.log.usedPattern}
 log4j.appender.networkout.file=${karaf.base}/data/log/network.log
 log4j.appender.networkout.append=true
 
@@ -127,7 +131,7 @@ log4j.appender.networkout.append=true
 log4j.appender.bodout=org.apache.log4j.RollingFileAppender
 log4j.appender.bodout.MaxFileSize=1000KB
 log4j.appender.bodout.layout=org.apache.log4j.PatternLayout
-log4j.appender.bodout.layout.ConversionPattern=%d{ABSOLUTE} | %-5.5p | %-16.16t | %-32.32c{1} | %-32.32C %4L | %m%n
+log4j.appender.bodout.layout.ConversionPattern=${opennaas.log.usedPattern}
 log4j.appender.bodout.file=${karaf.base}/data/log/bod.log
 log4j.appender.bodout.append=true
 
@@ -135,7 +139,7 @@ log4j.appender.bodout.append=true
 log4j.appender.opticalswitchout=org.apache.log4j.RollingFileAppender
 log4j.appender.opticalswitchout.MaxFileSize=1000KB
 log4j.appender.opticalswitchout.layout=org.apache.log4j.PatternLayout
-log4j.appender.opticalswitchout.layout.ConversionPattern=%d{ABSOLUTE} | %-5.5p | %-16.16t | %-32.32c{1} | %-32.32C %4L | %m%n
+log4j.appender.opticalswitchout.layout.ConversionPattern=${opennaas.log.usedPattern}
 log4j.appender.opticalswitchout.file=${karaf.base}/data/log/opticalswitch.log
 log4j.appender.opticalswitchout.append=true
 
@@ -143,6 +147,6 @@ log4j.appender.opticalswitchout.append=true
 log4j.appender.itestsout=org.apache.log4j.RollingFileAppender
 log4j.appender.itestsout.MaxFileSize=1000KB
 log4j.appender.itestsout.layout=org.apache.log4j.PatternLayout
-log4j.appender.itestsout.layout.ConversionPattern=%d{ABSOLUTE} | %-5.5p | %-16.16t | %-32.32c{1} | %-32.32C %4L | %m%n
+log4j.appender.itestsout.layout.ConversionPattern=${opennaas.log.usedPattern}
 log4j.appender.itestsout.file=${karaf.base}/data/log/itests.log
 log4j.appender.itestsout.append=true

--- a/platform/src/main/filtered-resources/etc/org.ops4j.pax.logging.cfg
+++ b/platform/src/main/filtered-resources/etc/org.ops4j.pax.logging.cfg
@@ -17,6 +17,10 @@
 #
 ################################################################################
 
+opennaas.log.fastPattern = %d{ABSOLUTE} %-5.5p | %10.10t | %-32.32c | %m%n
+opennaas.log.slowPattern = %d{ABSOLUTE} %-5.5p | %10.10t | %-32.32C %4L | %m%n
+opennaas.log.usedPattern = ${opennaas.log.fastPattern}
+
 # Root logger
 log4j.rootLogger= WARN, allout, osgi:VmLogAppender
 
@@ -81,13 +85,13 @@ log4j.logger.org.opennaas.tests = DEBUG, itestsout
 # CONSOLE appender
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%d{ABSOLUTE} | %-5.5p | %-16.16t | %-32.32c{1} | %-32.32C %4L | %m%n
+log4j.appender.stdout.layout.ConversionPattern=${opennaas.log.usedPattern}
 
 # ALL file appender
 log4j.appender.allout=org.apache.log4j.RollingFileAppender
 log4j.appender.allout.MaxFileSize=1000KB
 log4j.appender.allout.layout=org.apache.log4j.PatternLayout
-log4j.appender.allout.layout.ConversionPattern=%d{ABSOLUTE} | %-5.5p | %-16.16t | %-32.32c{1} | %-32.32C %4L | %m%n
+log4j.appender.allout.layout.ConversionPattern=${opennaas.log.usedPattern}
 log4j.appender.allout.file=${karaf.base}/data/log/all.log
 log4j.appender.allout.append=true
 
@@ -95,7 +99,7 @@ log4j.appender.allout.append=true
 log4j.appender.coreout=org.apache.log4j.RollingFileAppender
 log4j.appender.coreout.MaxFileSize=1000KB
 log4j.appender.coreout.layout=org.apache.log4j.PatternLayout
-log4j.appender.coreout.layout.ConversionPattern=%d{ABSOLUTE} | %-5.5p | %-16.16t | %-32.32c{1} | %-32.32C %4L | %m%n
+log4j.appender.coreout.layout.ConversionPattern=${opennaas.log.usedPattern}
 log4j.appender.coreout.file=${karaf.base}/data/log/core.log
 log4j.appender.coreout.append=true
 
@@ -103,7 +107,7 @@ log4j.appender.coreout.append=true
 log4j.appender.routerout=org.apache.log4j.RollingFileAppender
 log4j.appender.routerout.MaxFileSize=1000KB
 log4j.appender.routerout.layout=org.apache.log4j.PatternLayout
-log4j.appender.routerout.layout.ConversionPattern=%d{ABSOLUTE} | %-5.5p | %-16.16t | %-32.32c{1} | %-32.32C %4L | %m%n
+log4j.appender.routerout.layout.ConversionPattern=${opennaas.log.usedPattern}
 log4j.appender.routerout.file=${karaf.base}/data/log/router.log
 log4j.appender.routerout.append=true
 
@@ -111,7 +115,7 @@ log4j.appender.routerout.append=true
 log4j.appender.netconfout=org.apache.log4j.RollingFileAppender
 log4j.appender.netconfout.MaxFileSize=1000KB
 log4j.appender.netconfout.layout=org.apache.log4j.PatternLayout
-log4j.appender.netconfout.layout.ConversionPattern=%d{ABSOLUTE} | %-5.5p | %-16.16t | %-32.32c{1} | %-32.32C %4L | %m%n
+log4j.appender.netconfout.layout.ConversionPattern=${opennaas.log.usedPattern}
 log4j.appender.netconfout.file=${karaf.base}/data/log/router-netconf.log
 log4j.appender.netconfout.append=true
 
@@ -119,7 +123,7 @@ log4j.appender.netconfout.append=true
 log4j.appender.networkout=org.apache.log4j.RollingFileAppender
 log4j.appender.networkout.MaxFileSize=1000KB
 log4j.appender.networkout.layout=org.apache.log4j.PatternLayout
-log4j.appender.networkout.layout.ConversionPattern=%d{ABSOLUTE} | %-5.5p | %-16.16t | %-32.32c{1} | %-32.32C %4L | %m%n
+log4j.appender.networkout.layout.ConversionPattern=${opennaas.log.usedPattern}
 log4j.appender.networkout.file=${karaf.base}/data/log/network.log
 log4j.appender.networkout.append=true
 
@@ -127,7 +131,7 @@ log4j.appender.networkout.append=true
 log4j.appender.bodout=org.apache.log4j.RollingFileAppender
 log4j.appender.bodout.MaxFileSize=1000KB
 log4j.appender.bodout.layout=org.apache.log4j.PatternLayout
-log4j.appender.bodout.layout.ConversionPattern=%d{ABSOLUTE} | %-5.5p | %-16.16t | %-32.32c{1} | %-32.32C %4L | %m%n
+log4j.appender.bodout.layout.ConversionPattern=${opennaas.log.usedPattern}
 log4j.appender.bodout.file=${karaf.base}/data/log/bod.log
 log4j.appender.bodout.append=true
 
@@ -135,7 +139,7 @@ log4j.appender.bodout.append=true
 log4j.appender.opticalswitchout=org.apache.log4j.RollingFileAppender
 log4j.appender.opticalswitchout.MaxFileSize=1000KB
 log4j.appender.opticalswitchout.layout=org.apache.log4j.PatternLayout
-log4j.appender.opticalswitchout.layout.ConversionPattern=%d{ABSOLUTE} | %-5.5p | %-16.16t | %-32.32c{1} | %-32.32C %4L | %m%n
+log4j.appender.opticalswitchout.layout.ConversionPattern=${opennaas.log.usedPattern}
 log4j.appender.opticalswitchout.file=${karaf.base}/data/log/opticalswitch.log
 log4j.appender.opticalswitchout.append=true
 
@@ -143,6 +147,6 @@ log4j.appender.opticalswitchout.append=true
 log4j.appender.itestsout=org.apache.log4j.RollingFileAppender
 log4j.appender.itestsout.MaxFileSize=1000KB
 log4j.appender.itestsout.layout=org.apache.log4j.PatternLayout
-log4j.appender.itestsout.layout.ConversionPattern=%d{ABSOLUTE} | %-5.5p | %-16.16t | %-32.32c{1} | %-32.32C %4L | %m%n
+log4j.appender.itestsout.layout.ConversionPattern=${opennaas.log.usedPattern}
 log4j.appender.itestsout.file=${karaf.base}/data/log/itests.log
 log4j.appender.itestsout.append=true


### PR DESCRIPTION
Modified platform logging configuration in order to:
- catch all packages
- saner and faster output
- different output files according to functional module, not package.

Due to tests being scattered among several packages with amazing creativity, it is impossible to separate them from the rest of the code.
