### PR TITLE
Feature/resource manager integration test init

### DIFF
--- a/manticore/tests/integration/net.i2cat.mantychore.tests.repository/src/test/java/net/i2cat/mantychore/repository/tests/ResourceManagerIntegrationTest.java
+++ b/manticore/tests/integration/net.i2cat.mantychore.tests.repository/src/test/java/net/i2cat/mantychore/repository/tests/ResourceManagerIntegrationTest.java
@@ -59,6 +59,10 @@ public class ResourceManagerIntegrationTest
 	private IProtocolManager	protocolManager;
 
     @Inject
+    @Filter("(osgi.blueprint.container.symbolicname=net.i2cat.mantychore.repository)")
+    private BlueprintContainer	repositoryService;
+
+    @Inject
     @Filter("(osgi.blueprint.container.symbolicname=net.i2cat.mantychore.capability.chassis)")
     private BlueprintContainer	chassisService;
 


### PR DESCRIPTION
We have to wait for the router repository bundle to complete startup.
Otherwise there is no guarantee that the router repository was
registered with the resource manager.
