### PR TITLE
Feature/bod capability integration test init

### DIFF
--- a/manticore/tests/integration/org.opennaas.bod.tests.capability.l2bod/src/test/java/org/opennaas/bod/tests/capability/l2bod/L2BoDCapabilityIntegrationTest.java
+++ b/manticore/tests/integration/org.opennaas.bod.tests.capability.l2bod/src/test/java/org/opennaas/bod/tests/capability/l2bod/L2BoDCapabilityIntegrationTest.java
@@ -66,6 +66,18 @@ public class L2BoDCapabilityIntegrationTest
 	@Inject
 	private IResourceManager	resourceManager;
 
+    @Inject
+    @Filter("(osgi.blueprint.container.symbolicname=org.opennaas.bod.actionsets)")
+    private BlueprintContainer	actionSetService;
+
+    @Inject
+    @Filter("(osgi.blueprint.container.symbolicname=org.opennaas.bod.capability.l2bod)")
+    private BlueprintContainer	l2bodService;
+
+    @Inject
+    @Filter("(osgi.blueprint.container.symbolicname=org.opennaas.bod.repository)")
+    private BlueprintContainer	repositoryService;
+
 	private ICapability			l2bodCapability;
 
 	@Configuration


### PR DESCRIPTION
The test didn't wait for the initialisation of components it is testing to finish.

The patch should resolve this failure: http://jira.i2cat.net:8085/download/MANTYCHORE-OPENNAASDEV-ONSINSTALLDEVELOP/build_logs/MANTYCHORE-OPENNAASDEV-ONSINSTALLDEVELOP-6.log
