### PR TITLE
OPENNAAS-177 exported topology uses correct resource names

### DIFF
--- a/core/opennaas-core-resources/src/main/java/org/opennaas/core/resources/descriptor/network/Device.java
+++ b/core/opennaas-core-resources/src/main/java/org/opennaas/core/resources/descriptor/network/Device.java
@@ -3,13 +3,10 @@ package org.opennaas.core.resources.descriptor.network;
 import java.util.List;
 
 import javax.persistence.Basic;
-import javax.persistence.CascadeType;
-
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
-import javax.persistence.OneToMany;
 import javax.xml.bind.annotation.XmlElement;
 
 @Entity
@@ -17,13 +14,13 @@ public class Device {
 
 	@Id
 	@GeneratedValue
-	private long 					id;
+	private long		id;
 
 	@Basic
-	String name;
+	String				name;
 
 	@ElementCollection
-	List<InterfaceId> hasInterfaces;
+	List<InterfaceId>	hasInterfaces;
 
 	@XmlElement(name = "name", namespace = "http://www.science.uva.nl/research/sne/ndl#")
 	public String getName() {
@@ -43,11 +40,40 @@ public class Device {
 		this.hasInterfaces = hasInterfaces;
 	}
 
-
 	@Override
 	public String toString() {
 		return "Device [name=" + name + ", hasInterfaces=" + hasInterfaces
 				+ "]";
 	}
 
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((hasInterfaces == null) ? 0 : hasInterfaces.hashCode());
+		result = prime * result + ((name == null) ? 0 : name.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		Device other = (Device) obj;
+		if (hasInterfaces == null) {
+			if (other.hasInterfaces != null)
+				return false;
+		} else if (!hasInterfaces.equals(other.hasInterfaces))
+			return false;
+		if (name == null) {
+			if (other.name != null)
+				return false;
+		} else if (!name.equals(other.name))
+			return false;
+		return true;
+	}
 }

--- a/core/opennaas-core-resources/src/main/java/org/opennaas/core/resources/descriptor/network/DeviceId.java
+++ b/core/opennaas-core-resources/src/main/java/org/opennaas/core/resources/descriptor/network/DeviceId.java
@@ -4,14 +4,12 @@ import javax.persistence.Basic;
 import javax.persistence.Embeddable;
 import javax.xml.bind.annotation.XmlAttribute;
 
-
 @Embeddable
 public class DeviceId {
 	@Basic
-	private String resource;
+	private String	resource;
 
-
-	@XmlAttribute(name="resource", namespace = "http://www.w3.org/1999/02/22-rdf-syntax-ns#")
+	@XmlAttribute(name = "resource", namespace = "http://www.w3.org/1999/02/22-rdf-syntax-ns#")
 	public String getResource() {
 		return resource;
 	}
@@ -20,8 +18,33 @@ public class DeviceId {
 		this.resource = resource;
 	}
 
-    @Override
+	@Override
 	public String toString() {
 		return "DeviceId [resource=" + resource + "]";
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((resource == null) ? 0 : resource.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		DeviceId other = (DeviceId) obj;
+		if (resource == null) {
+			if (other.resource != null)
+				return false;
+		} else if (!resource.equals(other.resource))
+			return false;
+		return true;
 	}
 }

--- a/core/opennaas-core-resources/src/main/java/org/opennaas/core/resources/descriptor/network/Interface.java
+++ b/core/opennaas-core-resources/src/main/java/org/opennaas/core/resources/descriptor/network/Interface.java
@@ -1,39 +1,36 @@
 package org.opennaas.core.resources.descriptor.network;
 
 import javax.persistence.Basic;
-import javax.persistence.Embeddable;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.xml.bind.annotation.XmlElement;
 
-
 @Entity
 public class Interface {
 
 	@Id
 	@GeneratedValue
-	private long 					id;
+	private long	id;
 
 	@Basic
-	private String nameInterface;
+	private String	nameInterface;
 
 	@Embedded
-	private Link linkTo;
+	private Link	linkTo;
 
 	@Basic
-	private String 	capacity;
-
+	private String	capacity;
 
 	@XmlElement(name = "name", namespace = "http://www.science.uva.nl/research/sne/ndl#")
 	public String getName() {
 		return nameInterface;
 	}
+
 	public void setName(String name) {
 		this.nameInterface = name;
 	}
-
 
 	@XmlElement(name = "linkTo", namespace = "http://www.science.uva.nl/research/sne/ndl#")
 	public Link getLinkTo() {
@@ -44,16 +41,14 @@ public class Interface {
 		this.linkTo = linkTo;
 	}
 
-
 	@XmlElement(name = "capacity", namespace = "http://www.science.uva.nl/research/sne/ndl#")
 	public String getCapacity() {
 		return capacity;
 	}
+
 	public void setCapacity(String capacity) {
 		this.capacity = capacity;
 	}
-
-
 
 	@Override
 	public String toString() {
@@ -61,4 +56,40 @@ public class Interface {
 				+ capacity + "]";
 	}
 
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((capacity == null) ? 0 : capacity.hashCode());
+		result = prime * result + ((linkTo == null) ? 0 : linkTo.hashCode());
+		result = prime * result + ((nameInterface == null) ? 0 : nameInterface.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		Interface other = (Interface) obj;
+		if (capacity == null) {
+			if (other.capacity != null)
+				return false;
+		} else if (!capacity.equals(other.capacity))
+			return false;
+		if (linkTo == null) {
+			if (other.linkTo != null)
+				return false;
+		} else if (!linkTo.equals(other.linkTo))
+			return false;
+		if (nameInterface == null) {
+			if (other.nameInterface != null)
+				return false;
+		} else if (!nameInterface.equals(other.nameInterface))
+			return false;
+		return true;
+	}
 }

--- a/core/opennaas-core-resources/src/main/java/org/opennaas/core/resources/descriptor/network/InterfaceId.java
+++ b/core/opennaas-core-resources/src/main/java/org/opennaas/core/resources/descriptor/network/InterfaceId.java
@@ -1,18 +1,16 @@
 package org.opennaas.core.resources.descriptor.network;
+
 import javax.persistence.Basic;
 import javax.persistence.Embeddable;
-import javax.persistence.Entity;
 import javax.xml.bind.annotation.XmlAttribute;
 
 @Embeddable
 public class InterfaceId {
 
-
 	@Basic
-	private String resource;
+	private String	resource;
 
-
-	@XmlAttribute(name="resource", namespace = "http://www.w3.org/1999/02/22-rdf-syntax-ns#")
+	@XmlAttribute(name = "resource", namespace = "http://www.w3.org/1999/02/22-rdf-syntax-ns#")
 	public String getResource() {
 		return resource;
 	}
@@ -21,8 +19,33 @@ public class InterfaceId {
 		this.resource = resource;
 	}
 
-    @Override
+	@Override
 	public String toString() {
 		return "InterfaceId [resource=" + resource + "]";
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((resource == null) ? 0 : resource.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		InterfaceId other = (InterfaceId) obj;
+		if (resource == null) {
+			if (other.resource != null)
+				return false;
+		} else if (!resource.equals(other.resource))
+			return false;
+		return true;
 	}
 }

--- a/core/opennaas-core-resources/src/main/java/org/opennaas/core/resources/descriptor/network/Link.java
+++ b/core/opennaas-core-resources/src/main/java/org/opennaas/core/resources/descriptor/network/Link.java
@@ -2,13 +2,12 @@ package org.opennaas.core.resources.descriptor.network;
 
 import javax.persistence.Basic;
 import javax.persistence.Embeddable;
-import javax.persistence.Entity;
 import javax.xml.bind.annotation.XmlAttribute;
 
 @Embeddable
 public class Link {
 	@Basic
-	private String name;
+	private String	name;
 
 	@XmlAttribute(name = "resource", namespace = "http://www.w3.org/1999/02/22-rdf-syntax-ns#")
 	public String getName() {
@@ -24,6 +23,28 @@ public class Link {
 		return "Link [name=" + name + "]";
 	}
 
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((name == null) ? 0 : name.hashCode());
+		return result;
+	}
 
-
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		Link other = (Link) obj;
+		if (name == null) {
+			if (other.name != null)
+				return false;
+		} else if (!name.equals(other.name))
+			return false;
+		return true;
+	}
 }

--- a/core/opennaas-core-resources/src/main/java/org/opennaas/core/resources/descriptor/network/NetworkDomain.java
+++ b/core/opennaas-core-resources/src/main/java/org/opennaas/core/resources/descriptor/network/NetworkDomain.java
@@ -45,4 +45,35 @@ public class NetworkDomain {
 		return "Device [name=" + name + ", hasDevices=" + hasDevices
 				+ "]";
 	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((hasDevices == null) ? 0 : hasDevices.hashCode());
+		result = prime * result + ((name == null) ? 0 : name.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		NetworkDomain other = (NetworkDomain) obj;
+		if (hasDevices == null) {
+			if (other.hasDevices != null)
+				return false;
+		} else if (!hasDevices.equals(other.hasDevices))
+			return false;
+		if (name == null) {
+			if (other.name != null)
+				return false;
+		} else if (!name.equals(other.name))
+			return false;
+		return true;
+	}
 }

--- a/core/opennaas-core-resources/src/main/java/org/opennaas/core/resources/descriptor/network/NetworkTopology.java
+++ b/core/opennaas-core-resources/src/main/java/org/opennaas/core/resources/descriptor/network/NetworkTopology.java
@@ -4,9 +4,6 @@ import java.util.List;
 
 import javax.persistence.Basic;
 import javax.persistence.CascadeType;
-import javax.persistence.ElementCollection;
-import javax.persistence.Embeddable;
-import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
@@ -14,28 +11,25 @@ import javax.persistence.OneToMany;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
-
 @Entity
-@XmlRootElement(name="RDF", namespace = "http://www.w3.org/1999/02/22-rdf-syntax-ns#")
+@XmlRootElement(name = "RDF", namespace = "http://www.w3.org/1999/02/22-rdf-syntax-ns#")
 public class NetworkTopology {
 
 	@Id
 	@GeneratedValue
-	private long 					id;
+	private long				id;
 
 	@Basic
-	private String location;
-
-
-	@OneToMany(cascade = CascadeType.ALL)
-	private List<NetworkDomain> networkDomains;
-
+	private String				location;
 
 	@OneToMany(cascade = CascadeType.ALL)
-	private List<Device> devices;
+	private List<NetworkDomain>	networkDomains;
 
 	@OneToMany(cascade = CascadeType.ALL)
-	private	List<Interface> interfaces;
+	private List<Device>		devices;
+
+	@OneToMany(cascade = CascadeType.ALL)
+	private List<Interface>		interfaces;
 
 	public String getLocation() {
 		return location;
@@ -74,8 +68,51 @@ public class NetworkTopology {
 
 	@Override
 	public String toString() {
-		return "RDF [Location=" + location+ ", NetworkDomain=" + networkDomains + ", devices=" + devices
+		return "RDF [Location=" + location + ", NetworkDomain=" + networkDomains + ", devices=" + devices
 				+ ", interfaces=" + interfaces + "]";
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((devices == null) ? 0 : devices.hashCode());
+		result = prime * result + ((interfaces == null) ? 0 : interfaces.hashCode());
+		result = prime * result + ((location == null) ? 0 : location.hashCode());
+		result = prime * result + ((networkDomains == null) ? 0 : networkDomains.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		NetworkTopology other = (NetworkTopology) obj;
+		if (devices == null) {
+			if (other.devices != null)
+				return false;
+		} else if (!devices.equals(other.devices))
+			return false;
+		if (interfaces == null) {
+			if (other.interfaces != null)
+				return false;
+		} else if (!interfaces.equals(other.interfaces))
+			return false;
+		if (location == null) {
+			if (other.location != null)
+				return false;
+		} else if (!location.equals(other.location))
+			return false;
+		if (networkDomains == null) {
+			if (other.networkDomains != null)
+				return false;
+		} else if (!networkDomains.equals(other.networkDomains))
+			return false;
+		return true;
 	}
 
 }

--- a/core/opennaas-core-resources/src/main/java/org/opennaas/core/resources/helpers/MockNetworkDescriptor.java
+++ b/core/opennaas-core-resources/src/main/java/org/opennaas/core/resources/helpers/MockNetworkDescriptor.java
@@ -84,7 +84,7 @@ public class MockNetworkDescriptor {
 		rdfDescriptor.setDevices(devices);
 
 		List<Interface> interfaces = new ArrayList<Interface>();
-		interfaces.add(newInterface("router:R-AS2-1:lt-1/2/0.51", "#router:R1:lt-1/2/0.50", "1.2E+9"));
+		interfaces.add(newInterface("router:R-AS2-1:lt-1/2/0.51", "#router:R1:lt-1/2/0.50", "1.2E+9")); // link to external interface
 		interfaces.add(newInterface("router:R-AS2-1:lt-1/2/0.100", "#router:R-AS2-2:lt-1/2/0.101", "1.2E+9"));
 		interfaces.add(newInterface("router:R-AS2-1:lo0.1"));
 

--- a/extensions/bundles/net.i2cat.mantychore.network.model/src/main/java/net/i2cat/mantychore/network/model/MockNetworkModel.java
+++ b/extensions/bundles/net.i2cat.mantychore.network.model/src/main/java/net/i2cat/mantychore/network/model/MockNetworkModel.java
@@ -44,7 +44,7 @@ public class MockNetworkModel {
 	public static List<NetworkElement> createDevices(List<NetworkElement> networkElements) {
 		List<NetworkElement> listDevices = new ArrayList<NetworkElement>();
 
-		Device device = createDevice("#router:R-AS2-1");
+		Device device = createDevice("router:R-AS2-1");
 		List<ConnectionPoint> interfaces = new ArrayList<ConnectionPoint>();
 		interfaces.add((ConnectionPoint) networkElements.get(0));
 		interfaces.add((ConnectionPoint) networkElements.get(1));
@@ -52,7 +52,7 @@ public class MockNetworkModel {
 		device.setInterfaces(interfaces);
 		listDevices.add(device);
 
-		Device device2 = createDevice("#router:R-AS2-2");
+		Device device2 = createDevice("router:R-AS2-2");
 		List<ConnectionPoint> interfaces2 = new ArrayList<ConnectionPoint>();
 		interfaces2.add((ConnectionPoint) networkElements.get(3));
 		interfaces2.add((ConnectionPoint) networkElements.get(4));
@@ -60,7 +60,7 @@ public class MockNetworkModel {
 		device2.setInterfaces(interfaces2);
 		listDevices.add(device2);
 
-		Device device3 = createDevice("#router:R-AS2-3");
+		Device device3 = createDevice("router:R-AS2-3");
 		List<ConnectionPoint> interfaces3 = new ArrayList<ConnectionPoint>();
 		interfaces3.add((ConnectionPoint) networkElements.get(6));
 		interfaces3.add((ConnectionPoint) networkElements.get(7));
@@ -74,17 +74,17 @@ public class MockNetworkModel {
 
 	public static List<NetworkElement> createInterfaces(List<NetworkElement> networkElements) {
 		List<NetworkElement> listInterfaces = new ArrayList<NetworkElement>();
-		listInterfaces.add(createInterface("#router:R-AS2-1:lt-1/2/0.51"));
-		listInterfaces.add(createInterface("#router:R-AS2-1:lt-1/2/0.100"));
-		listInterfaces.add(createInterface("#router:R-AS2-1:lo0.1"));
-		listInterfaces.add(createInterface("#router:R-AS2-2:lt-1/2/0.102"));
-		listInterfaces.add(createInterface("#router:R-AS2-2:lt-1/2/0.101"));
-		listInterfaces.add(createInterface("#router:R-AS2-2:lo0.3"));
-		listInterfaces.add(createInterface("#router:R-AS2-3:lt-1/2/0.103"));
-		listInterfaces.add(createInterface("#router:R-AS2-3:lo0.4"));
+		listInterfaces.add(createInterface("router:R-AS2-1:lt-1/2/0.51"));
+		listInterfaces.add(createInterface("router:R-AS2-1:lt-1/2/0.100"));
+		listInterfaces.add(createInterface("router:R-AS2-1:lo0.1"));
+		listInterfaces.add(createInterface("router:R-AS2-2:lt-1/2/0.102"));
+		listInterfaces.add(createInterface("router:R-AS2-2:lt-1/2/0.101"));
+		listInterfaces.add(createInterface("router:R-AS2-2:lo0.3"));
+		listInterfaces.add(createInterface("router:R-AS2-3:lt-1/2/0.103"));
+		listInterfaces.add(createInterface("router:R-AS2-3:lo0.4"));
 
 		/* external network */
-		listInterfaces.add(createInterface("#router:R1:lt-1/2/0.50"));
+		listInterfaces.add(createInterface("router:R1:lt-1/2/0.50"));
 
 		networkElements.addAll(listInterfaces);
 		return networkElements;
@@ -139,9 +139,6 @@ public class MockNetworkModel {
 	}
 
 	private static int getInterface(String name, List<ConnectionPoint> listInterfaces) {
-		// format name to search
-		name = cleanName(name);
-
 		int pos = 0;
 		for (ConnectionPoint connectionPoint : listInterfaces) {
 			if (connectionPoint.getName().equals(name))
@@ -161,17 +158,4 @@ public class MockNetworkModel {
 		}
 		return -1;
 	}
-
-	private static String cleanName(String name) {
-		if (name.startsWith("#")) {
-			int lastIndex = name.lastIndexOf("#");
-			if (lastIndex != -1) {
-				return name.substring(lastIndex + 1);
-
-			}
-		}
-		return name;
-
-	}
-
 }

--- a/extensions/bundles/net.i2cat.mantychore.network.model/src/main/java/net/i2cat/mantychore/network/model/NetworkModelHelper.java
+++ b/extensions/bundles/net.i2cat.mantychore.network.model/src/main/java/net/i2cat/mantychore/network/model/NetworkModelHelper.java
@@ -159,6 +159,22 @@ public class NetworkModelHelper {
 		return -1;
 	}
 
+	/**
+	 * Return all elements in networkElements being of class clazz.
+	 * 
+	 * @param clazz
+	 * @param networkElements
+	 * @return
+	 */
+	public static List<NetworkElement> getNetworkElementsByClassName(Class clazz, List<NetworkElement> networkElements) {
+		List<NetworkElement> matchingElements = new ArrayList<NetworkElement>();
+		for (NetworkElement networkElement : networkElements) {
+			if (networkElement.getClass().equals(clazz))
+				matchingElements.add(networkElement);
+		}
+		return matchingElements;
+	}
+
 	public static Link linkInterfaces(Interface src, Interface dst, boolean bidiLink) {
 		Link link = new Link();
 		link.setSource(src);

--- a/extensions/bundles/net.i2cat.mantychore.network.repository/src/main/java/net/i2cat/mantychore/network/repository/NetworkMapperModelToDescriptor.java
+++ b/extensions/bundles/net.i2cat.mantychore.network.repository/src/main/java/net/i2cat/mantychore/network/repository/NetworkMapperModelToDescriptor.java
@@ -69,9 +69,9 @@ public class NetworkMapperModelToDescriptor {
 			if (interf.getLinkTo() != null) {
 				String toLinkName = "";
 				if (interf.getLinkTo().getSource().getName().equals(interf.getName())) {
-					toLinkName = interf.getLinkTo().getSink().getName();
+					toLinkName = newInterfaceId(interf.getLinkTo().getSink().getName()).getResource();
 				} else {
-					toLinkName = interf.getLinkTo().getSource().getName();
+					toLinkName = newInterfaceId(interf.getLinkTo().getSource().getName()).getResource();
 				}
 				interfaceDescriptor.setLinkTo(newLink(toLinkName));
 			}
@@ -86,13 +86,21 @@ public class NetworkMapperModelToDescriptor {
 		return networkTopology;
 	}
 
-	private static String addNumberSign(String name) {
+	private static String addHashCharacter(String name) {
 		if (!name.startsWith("#"))
 			return "#" + name;
 		else
 			return name;
 	}
 
+	/**
+	 * 
+	 * @param name
+	 *            Name of the NetworkDomain in network model to get
+	 * @param existingDomains
+	 *            List of NetworkDomains in descriptor topology.
+	 * @return Position inside existingDomains of the NetworkDomain to get, or -1 if existingDomains does not contain desired domain.
+	 */
 	private static int getNetworkDomain(String name, List<org.opennaas.core.resources.descriptor.network.NetworkDomain> existingDomains) {
 		int pos = 0;
 		for (org.opennaas.core.resources.descriptor.network.NetworkDomain networkDomain : existingDomains) {
@@ -105,10 +113,18 @@ public class NetworkMapperModelToDescriptor {
 
 	private static DeviceId newDeviceId(String name) {
 		DeviceId deviceId = new DeviceId();
-		deviceId.setResource(name);
+		deviceId.setResource(addHashCharacter(name));
 		return deviceId;
 	}
 
+	/**
+	 * 
+	 * @param name
+	 *            Name of the Device in network model to get
+	 * @param existingDevices
+	 *            List of Interfaces in descriptor topology.
+	 * @return Position inside existingDevices of the Device to get, or -1 if existingDevices does not contain desired device.
+	 */
 	private static int getDevice(String name, List<org.opennaas.core.resources.descriptor.network.Device> existingDevices) {
 		int pos = 0;
 		for (org.opennaas.core.resources.descriptor.network.Device device : existingDevices) {
@@ -122,7 +138,7 @@ public class NetworkMapperModelToDescriptor {
 
 	private static InterfaceId newInterfaceId(String name) {
 		InterfaceId interfaceId = new InterfaceId();
-		interfaceId.setResource(name);
+		interfaceId.setResource(addHashCharacter(name));
 		return interfaceId;
 	}
 
@@ -150,6 +166,14 @@ public class NetworkMapperModelToDescriptor {
 		return device;
 	}
 
+	/**
+	 * 
+	 * @param name
+	 *            Name of the Interface in network model to get
+	 * @param interfaces
+	 *            List of Interfaces in descriptor topology.
+	 * @return Position inside interfaces of the Interface to get, or -1 if interfaces does not contain desired interface.
+	 */
 	private static int getInterface(String name, List<org.opennaas.core.resources.descriptor.network.Interface> interfaces) {
 		int pos = 0;
 		for (org.opennaas.core.resources.descriptor.network.Interface interf : interfaces) {

--- a/extensions/bundles/net.i2cat.mantychore.network.repository/src/test/java/net/i2cat/mantychore/network/repository/tests/NetworkDescriptorToMapperModelTest.java
+++ b/extensions/bundles/net.i2cat.mantychore.network.repository/src/test/java/net/i2cat/mantychore/network/repository/tests/NetworkDescriptorToMapperModelTest.java
@@ -2,16 +2,26 @@ package net.i2cat.mantychore.network.repository.tests;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+
+import java.util.List;
+
+import junit.framework.Assert;
 import net.i2cat.mantychore.network.model.MockNetworkModel;
+import net.i2cat.mantychore.network.model.NetworkModel;
+import net.i2cat.mantychore.network.model.NetworkModelHelper;
+import net.i2cat.mantychore.network.model.topology.Interface;
+import net.i2cat.mantychore.network.model.topology.NetworkElement;
+import net.i2cat.mantychore.network.repository.NetworkMapperDescriptorToModel;
 import net.i2cat.mantychore.network.repository.NetworkMapperModelToDescriptor;
 
 import org.junit.Test;
+import org.opennaas.core.resources.ResourceException;
 import org.opennaas.core.resources.descriptor.network.NetworkTopology;
 
 public class NetworkDescriptorToMapperModelTest {
 
 	@Test
-	public void testMockMapperModel() {
+	public void testModelToDescriptorWithMockModel() {
 
 		NetworkTopology networkTopology = NetworkMapperModelToDescriptor.modelToDescriptor(MockNetworkModel.newNetworkModel());
 
@@ -20,26 +30,27 @@ public class NetworkDescriptorToMapperModelTest {
 
 		/* network description */
 		assertNotNull(networkTopology.getDevices());
-		assertEquals(networkTopology.getDevices().get(0).getName(), "#router:R-AS2-1");
-		assertEquals(networkTopology.getDevices().get(1).getName(), "#router:R-AS2-2");
-		assertEquals(networkTopology.getDevices().get(2).getName(), "#router:R-AS2-3");
+		assertEquals(networkTopology.getDevices().get(0).getName(), "router:R-AS2-1");
+		assertEquals(networkTopology.getDevices().get(1).getName(), "router:R-AS2-2");
+		assertEquals(networkTopology.getDevices().get(2).getName(), "router:R-AS2-3");
 
+		// notice that only references to topology elements start with #, names does not
 		assertNotNull(networkTopology.getDevices());
-		assertEquals(networkTopology.getDevices().get(0).getName(), "#router:R-AS2-1");
+		assertEquals(networkTopology.getDevices().get(0).getName(), "router:R-AS2-1");
 		assertNotNull(networkTopology.getDevices().get(0).getHasInterfaces());
 		assertEquals(networkTopology.getDevices().get(0).getHasInterfaces().size(), 3);
 		assertEquals(networkTopology.getDevices().get(0).getHasInterfaces().get(0).getResource(), "#router:R-AS2-1:lt-1/2/0.51");
 		assertEquals(networkTopology.getDevices().get(0).getHasInterfaces().get(1).getResource(), "#router:R-AS2-1:lt-1/2/0.100");
 		assertEquals(networkTopology.getDevices().get(0).getHasInterfaces().get(2).getResource(), "#router:R-AS2-1:lo0.1");
 
-		assertEquals(networkTopology.getDevices().get(1).getName(), "#router:R-AS2-2");
+		assertEquals(networkTopology.getDevices().get(1).getName(), "router:R-AS2-2");
 		assertNotNull(networkTopology.getDevices().get(1).getHasInterfaces());
 		assertEquals(networkTopology.getDevices().get(1).getHasInterfaces().size(), 3);
 		assertEquals(networkTopology.getDevices().get(1).getHasInterfaces().get(0).getResource(), "#router:R-AS2-2:lt-1/2/0.102");
 		assertEquals(networkTopology.getDevices().get(1).getHasInterfaces().get(1).getResource(), "#router:R-AS2-2:lt-1/2/0.101");
 		assertEquals(networkTopology.getDevices().get(1).getHasInterfaces().get(2).getResource(), "#router:R-AS2-2:lo0.3");
 
-		assertEquals(networkTopology.getDevices().get(2).getName(), "#router:R-AS2-3");
+		assertEquals(networkTopology.getDevices().get(2).getName(), "router:R-AS2-3");
 		assertNotNull(networkTopology.getDevices().get(2).getHasInterfaces());
 		assertEquals(networkTopology.getDevices().get(2).getHasInterfaces().size(), 2);
 		assertEquals(networkTopology.getDevices().get(2).getHasInterfaces().get(0).getResource(), "#router:R-AS2-3:lt-1/2/0.103");
@@ -48,27 +59,75 @@ public class NetworkDescriptorToMapperModelTest {
 		assertNotNull(networkTopology.getInterfaces());
 		assertEquals(networkTopology.getInterfaces().size(), 9);
 
-		assertEquals(networkTopology.getInterfaces().get(0).getName(), "#router:R-AS2-1:lt-1/2/0.51");
+		assertEquals(networkTopology.getInterfaces().get(0).getName(), "router:R-AS2-1:lt-1/2/0.51");
 		assertEquals(networkTopology.getInterfaces().get(0).getLinkTo().getName(), "#router:R1:lt-1/2/0.50");
 
-		assertEquals(networkTopology.getInterfaces().get(1).getName(), "#router:R-AS2-1:lt-1/2/0.100");
+		assertEquals(networkTopology.getInterfaces().get(1).getName(), "router:R-AS2-1:lt-1/2/0.100");
 		assertEquals(networkTopology.getInterfaces().get(1).getLinkTo().getName(), "#router:R-AS2-2:lt-1/2/0.101");
 
-		assertEquals(networkTopology.getInterfaces().get(2).getName(), "#router:R-AS2-1:lo0.1");
+		assertEquals(networkTopology.getInterfaces().get(2).getName(), "router:R-AS2-1:lo0.1");
 
-		assertEquals(networkTopology.getInterfaces().get(3).getName(), "#router:R-AS2-2:lt-1/2/0.102");
+		assertEquals(networkTopology.getInterfaces().get(3).getName(), "router:R-AS2-2:lt-1/2/0.102");
 		assertEquals(networkTopology.getInterfaces().get(3).getLinkTo().getName(), "#router:R-AS2-3:lt-1/2/0.103");
 
-		assertEquals(networkTopology.getInterfaces().get(4).getName(), "#router:R-AS2-2:lt-1/2/0.101");
+		assertEquals(networkTopology.getInterfaces().get(4).getName(), "router:R-AS2-2:lt-1/2/0.101");
 		assertEquals(networkTopology.getInterfaces().get(4).getLinkTo().getName(), "#router:R-AS2-1:lt-1/2/0.100");
 
-		assertEquals(networkTopology.getInterfaces().get(5).getName(), "#router:R-AS2-2:lo0.3");
+		assertEquals(networkTopology.getInterfaces().get(5).getName(), "router:R-AS2-2:lo0.3");
 
-		assertEquals(networkTopology.getInterfaces().get(6).getName(), "#router:R-AS2-3:lt-1/2/0.103");
+		assertEquals(networkTopology.getInterfaces().get(6).getName(), "router:R-AS2-3:lt-1/2/0.103");
 		assertEquals(networkTopology.getInterfaces().get(6).getLinkTo().getName(), "#router:R-AS2-2:lt-1/2/0.102");
 
-		assertEquals(networkTopology.getInterfaces().get(7).getName(), "#router:R-AS2-3:lo0.4");
+		assertEquals(networkTopology.getInterfaces().get(7).getName(), "router:R-AS2-3:lo0.4");
 
+	}
+
+	@Test
+	public void testModelToDescriptorAndViceversa() {
+
+		try {
+			NetworkModel model1 = MockNetworkModel.newNetworkModel();
+			NetworkTopology topology1 = NetworkMapperModelToDescriptor.modelToDescriptor(model1);
+			NetworkModel model2 = NetworkMapperDescriptorToModel.descriptorToModel(topology1);
+			NetworkTopology topology2 = NetworkMapperModelToDescriptor.modelToDescriptor(model2);
+
+			checkModels(model1, model2);
+			Assert.assertEquals(topology1, topology2);
+
+		} catch (ResourceException e) {
+			Assert.fail("Error mapping descriptor to model: " + e.getMessage());
+		}
+
+	}
+
+	private void checkModels(NetworkModel model1, NetworkModel model2) {
+
+		Assert.assertEquals(model1.getNetworkElements().size(), model2.getNetworkElements().size());
+		for (NetworkElement elem1 : model1.getNetworkElements()) {
+
+			List<NetworkElement> tmp_elems = NetworkModelHelper.getNetworkElementsByClassName(elem1.getClass(), model2.getNetworkElements());
+			Assert.assertFalse(tmp_elems.isEmpty());
+
+			if (elem1.getName() != null) { // should be elements without name?? Links has no name, by now.
+				int elemIndexInModel2 = NetworkModelHelper.getNetworkElementByName(elem1.getName(), tmp_elems);
+				Assert.assertFalse("Elem " + elem1.getName() + " of model1 is not in model2.", elemIndexInModel2 == -1);
+			}
+		}
+
+		for (Interface iface1 : NetworkModelHelper.getInterfaces(model1.getNetworkElements())) {
+			Interface iface2 = NetworkModelHelper.getInterfaceByName(model2.getNetworkElements(), iface1.getName());
+			Assert.assertNotNull("Interface " + iface1.getName() + " is not in model2", iface2);
+
+			if (iface1.getLinkTo() != null) {
+				Assert.assertNotNull(iface2.getLinkTo());
+				Assert.assertEquals(iface1.getLinkTo().getName(), iface2.getLinkTo().getName());
+			}
+
+			if (iface1.getSwitchedTo() != null) {
+				Assert.assertNotNull(iface2.getSwitchedTo());
+				Assert.assertEquals(iface1.getSwitchedTo().getName(), iface2.getSwitchedTo().getName());
+			}
+		}
 	}
 
 }

--- a/extensions/bundles/net.i2cat.mantychore.network.repository/src/test/java/net/i2cat/mantychore/network/repository/tests/NetworkMapperModelToDescriptorTest.java
+++ b/extensions/bundles/net.i2cat.mantychore.network.repository/src/test/java/net/i2cat/mantychore/network/repository/tests/NetworkMapperModelToDescriptorTest.java
@@ -11,6 +11,7 @@ import net.i2cat.mantychore.network.repository.NetworkMapperDescriptorToModel;
 import org.junit.Assert;
 import org.junit.Test;
 import org.opennaas.core.resources.ResourceException;
+import org.opennaas.core.resources.descriptor.network.NetworkTopology;
 import org.opennaas.core.resources.helpers.MockNetworkDescriptor;
 
 public class NetworkMapperModelToDescriptorTest {
@@ -18,10 +19,23 @@ public class NetworkMapperModelToDescriptorTest {
 	@Test
 	public void testMockMapperNetworkElems() {
 		try {
-			NetworkModel networkModel = NetworkMapperDescriptorToModel.descriptorToModel(MockNetworkDescriptor
-					.newNetworkDescriptorWithNetworkDomain());
+
+			NetworkTopology topology = MockNetworkDescriptor.newNetworkDescriptorWithNetworkDomain();
+
+			int topologyDeviceCount = topology.getDevices().size();
+			int topologyInterfacesCount = topology.getInterfaces().size();
+			int topologyDomainsCount = topology.getNetworkDomains().size();
+			int topologyLinksCount = 3; // has 3 links (2 of them bidi)
+			topologyInterfacesCount += 1; // has a link to an external interface
+
+			NetworkModel networkModel = NetworkMapperDescriptorToModel.descriptorToModel(topology);
 			Assert.assertNotNull(networkModel.getNetworkElements());
-			Assert.assertEquals(networkModel.getNetworkElements().size(), 16);
+
+			Assert.assertEquals(topologyDomainsCount, NetworkModelHelper.getDomains(networkModel).size());
+			Assert.assertEquals(topologyDeviceCount, NetworkModelHelper.getDevices(networkModel).size());
+			Assert.assertEquals(topologyInterfacesCount, NetworkModelHelper.getInterfaces(networkModel.getNetworkElements()).size());
+			Assert.assertEquals(topologyLinksCount, NetworkModelHelper.getLinks(networkModel).size());
+
 		} catch (ResourceException e) {
 			Assert.fail(e.getMessage());
 		}

--- a/manticore/utils/scripts/network/exporttopology.karaf
+++ b/manticore/utils/scripts/network/exporttopology.karaf
@@ -1,0 +1,18 @@
+
+#Creating and initializing a router
+resource:create /home/isart/workspace/opennaas/opennaas/manticore/utils/resource.descriptor
+protocols:context router:junos20 netconf mock://user:password@1.1.1.1:22/netconf
+resource:start router:junos20
+
+#Creating and initializing a network with empty model
+resource:create /home/isart/workspace/opennaas/opennaas/manticore/utils/basicNetwork.descriptor
+resource:start network:basicNet1
+
+#adding router to the network
+net:addResource network:basicNet1 router:junos20
+
+#adding a link
+net:l2attach network:basicNet1 router:junos20:fe-0/0/1.12 router:junos20:fe-0/0/3.1
+
+#exporting network topology
+resource:export -nt /home/isart/Escriptori/topology.xml network:basicNet1 /home/isart/Escriptori/basicNet1.descriptor


### PR DESCRIPTION
Fixes http://jira.i2cat.net:8080/browse/OPENNAAS-177

References in RDF begin with '#', but names must not.
Mappers have been updated to accomplish desired behaviour.
