### PR TITLE
Fix OPENNAAS-254

### DIFF
--- a/extensions/bundles/queuemanager/src/main/java/org/opennaas/extensions/queuemanager/QueueManager.java
+++ b/extensions/bundles/queuemanager/src/main/java/org/opennaas/extensions/queuemanager/QueueManager.java
@@ -601,9 +601,16 @@ public class QueueManager extends AbstractCapability implements
 	 * @return the response of remove the action
 	 */
 	private Object remove(int posAction) {
-		queue.remove(posAction);
-		return Response.okResponse(QueueConstants.MODIFY,
-				"Remove operation in pos: " + posAction);
+
+		try {
+			queue.remove(posAction);
+			return Response.okResponse(QueueConstants.MODIFY,
+					"Remove operation in pos: " + posAction);
+		} catch (ArrayIndexOutOfBoundsException e) {
+			Vector<String> errors = new Vector<String>(1);
+			errors.add("Invalid index. Index " + posAction + " does not point to any action in the queue.");
+			return Response.errorResponse(QueueConstants.MODIFY, errors);
+		}
 
 	}
 

--- a/extensions/bundles/queuemanager/src/main/java/org/opennaas/extensions/queuemanager/shell/RemoveCommand.java
+++ b/extensions/bundles/queuemanager/src/main/java/org/opennaas/extensions/queuemanager/shell/RemoveCommand.java
@@ -1,16 +1,16 @@
 package org.opennaas.extensions.queuemanager.shell;
 
-import org.opennaas.extensions.queuemanager.QueueManager;
-
 import org.apache.felix.gogo.commands.Argument;
 import org.apache.felix.gogo.commands.Command;
 import org.opennaas.core.resources.IResource;
 import org.opennaas.core.resources.IResourceIdentifier;
 import org.opennaas.core.resources.IResourceManager;
 import org.opennaas.core.resources.capability.ICapability;
+import org.opennaas.core.resources.command.Response;
 import org.opennaas.core.resources.queue.ModifyParams;
 import org.opennaas.core.resources.queue.QueueConstants;
 import org.opennaas.core.resources.shell.GenericKarafCommand;
+import org.opennaas.extensions.queuemanager.QueueManager;
 
 @Command(scope = "queue", name = "remove", description = "Remove an action from the queue")
 public class RemoveCommand extends GenericKarafCommand {
@@ -53,8 +53,8 @@ public class RemoveCommand extends GenericKarafCommand {
 			ICapability queue = getCapability(resource.getCapabilities(), QueueManager.QUEUE);
 			// printSymbol("Removing action " + posQueue + "...");
 			ModifyParams params = ModifyParams.newRemoveOperation(posQueue);
-			queue.sendMessage(QueueConstants.MODIFY, params);
-			printSymbol("Action " + posQueue + " removed from queue");
+			Response resp = (Response) queue.sendMessage(QueueConstants.MODIFY, params);
+			printResponseStatus(resp);
 
 		} catch (Exception e) {
 			printError("Error removing action from queue.");


### PR DESCRIPTION
Fix in queue to launch proper error when an invalid index is passed to modify method.

RemoveCommand has been updated to print received response, instead of a self-crafted one.
