### PR TITLE
Feature/autobahn

### DIFF
--- a/core/features/src/main/resources/features.xml
+++ b/core/features/src/main/resources/features.xml
@@ -124,6 +124,13 @@
 		<bundle>mvn:org.opennaas/org.opennaas.extensions.bod.actionsets.dummy/${project.version}</bundle>
 	</feature>
 
+        <feature name="opennaas-autobahn" version="${project.version}">
+            <feature>cxf</feature>
+            <feature version="${project.version}">opennaas-bod</feature>
+
+            <bundle>mvn:org.opennaas/org.opennaas.extensions.bod.autobahn/${project.version}</bundle>
+        </feature>
+
 	<feature name="opennaas-luminis" version="${project.version}">
 		<feature version="${project.version}">opennaas-cim</feature>
 

--- a/extensions/bundles/bod.autobahn/pom.xml
+++ b/extensions/bundles/bod.autobahn/pom.xml
@@ -1,0 +1,75 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>org.opennaas.extensions.bundles</artifactId>
+    <groupId>org.opennaas</groupId>
+    <version>1.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>org.opennaas.extensions.bod.autobahn</artifactId>
+  <modelVersion>4.0.0</modelVersion>
+  <packaging>bundle</packaging>
+  <name>BoD Autobahn</name>
+  <description>BoD Autobahn</description>
+
+  <dependencies>
+      <dependency>
+		  <groupId>org.opennaas</groupId>
+		  <artifactId>org.opennaas.extensions.bod.capability.l2bod</artifactId>
+      </dependency>
+      <dependency>
+          <groupId>com.googlecode.guava-osgi</groupId>
+          <artifactId>guava-osgi</artifactId>
+          <version>${guava.version}</version>
+      </dependency>
+  </dependencies>
+
+  <build>
+      <plugins>
+          <plugin>
+              <groupId>org.apache.cxf</groupId>
+              <artifactId>cxf-codegen-plugin</artifactId>
+              <version>${cxf.version}</version>
+              <executions>
+                  <execution>
+                      <id>generate-sources</id>
+                      <configuration>
+                          <wsdlOptions>
+                              <wsdlOption>
+                                  <wsdl>${basedir}/src/main/resources/META-INF/wsdl/useraccesspoint.wsdl</wsdl>
+                                  <extraargs>
+                                      <extraarg>-wsdlLocation</extraarg>
+                                      <wsdlUrl>classpath:META-INF/wsdl/useraccesspoint.wsdl</wsdlUrl>
+                                  </extraargs>
+                              </wsdlOption>
+                              <wsdlOption>
+                                  <wsdl>${basedir}/src/main/resources/META-INF/wsdl/administration.wsdl</wsdl>
+                                  <extraargs>
+                                      <extraarg>-wsdlLocation</extraarg>
+                                      <wsdlUrl>classpath:META-INF/wsdl/administration.wsdl</wsdlUrl>
+                                  </extraargs>
+                              </wsdlOption>
+                          </wsdlOptions>
+                      </configuration>
+                      <goals>
+                          <goal>wsdl2java</goal>
+                      </goals>
+                  </execution>
+              </executions>
+          </plugin>
+          <plugin>
+              <groupId>org.apache.felix</groupId>
+              <artifactId>maven-bundle-plugin</artifactId>
+              <extensions>true</extensions>
+              <configuration>
+                  <instructions>
+                      <!-- org.apache.cxf.jaxws.spi -->
+                      <DynamicImport-Package>*</DynamicImport-Package>
+                      <Export-Package>
+                          org.opennaas.extensions.bod.autobahn.*;version="${project.version}"
+                      </Export-Package>
+                  </instructions>
+              </configuration>
+          </plugin>
+      </plugins>
+  </build>
+</project>

--- a/extensions/bundles/bod.autobahn/src/main/java/org/opennaas/extensions/bod/autobahn/AutobahnAction.java
+++ b/extensions/bundles/bod.autobahn/src/main/java/org/opennaas/extensions/bod/autobahn/AutobahnAction.java
@@ -1,0 +1,44 @@
+package org.opennaas.extensions.bod.autobahn;
+
+import net.geant.autobahn.administration.Administration;
+import net.geant.autobahn.useraccesspoint.UserAccessPoint;
+
+import org.opennaas.core.resources.action.Action;
+import org.opennaas.core.resources.action.ActionException;
+import org.opennaas.core.resources.protocol.IProtocolSessionManager;
+import org.opennaas.core.resources.protocol.ProtocolException;
+
+import org.opennaas.extensions.bod.autobahn.protocol.AutobahnProtocolSession;
+
+public abstract class AutobahnAction extends Action
+{
+	private final static String AUTOBAHN = "autobahn";
+
+	@Override
+	public boolean checkParams(Object params) throws ActionException
+	{
+		return true;
+	}
+
+	protected AutobahnProtocolSession
+		getAutobahnProtocolSession(IProtocolSessionManager manager)
+		throws ProtocolException
+	{
+		return (AutobahnProtocolSession)
+			manager.obtainSessionByProtocol(AUTOBAHN, false);
+	}
+
+	protected UserAccessPoint
+		getUserAccessPointService(IProtocolSessionManager manager)
+		throws ProtocolException
+	{
+		return getAutobahnProtocolSession(manager).getUserAccessPointService();
+	}
+
+	protected Administration
+		getAdministrationService(IProtocolSessionManager manager)
+		throws ProtocolException
+	{
+		return getAutobahnProtocolSession(manager).getAdministrationService();
+	}
+}

--- a/extensions/bundles/bod.autobahn/src/main/java/org/opennaas/extensions/bod/autobahn/ReservationState.java
+++ b/extensions/bundles/bod.autobahn/src/main/java/org/opennaas/extensions/bod/autobahn/ReservationState.java
@@ -1,0 +1,26 @@
+package org.opennaas.extensions.bod.autobahn;
+
+public enum ReservationState
+{
+	UNKNOWN(0),
+	ACCEPTED(1),
+	PATHFINDING(2),
+	LOCAL_CHECK(3),
+	SCHEDULING(4),
+	SCHEDULED(5),
+	CANCELLING(6),
+	DEFERRED_CANCEL(7),
+	WITHDRAWING(8),
+	ACTIVATING(9),
+	ACTIVE(10),
+	FINISHING(11),
+	FINISHED(21),
+	CANCELLED(22),
+	FAILED(23);
+
+	public final int state;
+
+	ReservationState(int state) {
+		this.state = state;
+	}
+}

--- a/extensions/bundles/bod.autobahn/src/main/java/org/opennaas/extensions/bod/autobahn/bod/BoDActionSet.java
+++ b/extensions/bundles/bod.autobahn/src/main/java/org/opennaas/extensions/bod/autobahn/bod/BoDActionSet.java
@@ -1,0 +1,20 @@
+package org.opennaas.extensions.bod.autobahn.bod;
+
+import org.opennaas.core.resources.action.ActionSet;
+
+public class BoDActionSet extends ActionSet
+{
+	public BoDActionSet()
+	{
+		setActionSetId("bodActionSet");
+
+		putAction(RequestConnectionAction.ACTIONID,
+				  RequestConnectionAction.class);
+		putAction(ShutdownConnectionAction.ACTIONID,
+				  ShutdownConnectionAction.class);
+		putAction(GetTopologyAction.ACTIONID,
+				  GetTopologyAction.class);
+
+		refreshActions.add(GetTopologyAction.ACTIONID);
+	}
+}

--- a/extensions/bundles/bod.autobahn/src/main/java/org/opennaas/extensions/bod/autobahn/bod/GetTopologyAction.java
+++ b/extensions/bundles/bod.autobahn/src/main/java/org/opennaas/extensions/bod/autobahn/bod/GetTopologyAction.java
@@ -1,0 +1,162 @@
+package org.opennaas.extensions.bod.autobahn.bod;
+
+import com.google.common.base.Function;
+import com.google.common.base.Joiner;
+import com.google.common.collect.Maps;
+
+import java.util.List;
+import java.util.Map;
+
+import net.geant.autobahn.administration.Administration;
+import net.geant.autobahn.administration.ServiceType;
+import net.geant.autobahn.administration.ReservationType;
+import net.geant.autobahn.useraccesspoint.PortType;
+import net.geant.autobahn.useraccesspoint.UserAccessPoint;
+import net.geant.autobahn.useraccesspoint.UserAccessPointException_Exception;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.opennaas.core.resources.action.ActionException;
+import org.opennaas.core.resources.action.ActionResponse;
+import org.opennaas.core.resources.protocol.IProtocolSessionManager;
+import org.opennaas.core.resources.protocol.ProtocolException;
+import org.opennaas.extensions.bod.autobahn.AutobahnAction;
+import org.opennaas.extensions.bod.autobahn.model.AutobahnInterface;
+import org.opennaas.extensions.bod.autobahn.model.AutobahnLink;
+import org.opennaas.extensions.network.model.NetworkModel;
+
+import static com.google.common.collect.Iterables.concat;
+import static com.google.common.collect.Iterables.transform;
+
+public class GetTopologyAction extends AutobahnAction
+{
+	public final static String ACTIONID = "getTopology";
+
+	private final static Function<PortType,String> getAddress =
+		new Function<PortType,String>() {
+			@Override
+			public String apply(PortType port) {
+				return port.getAddress();
+			}
+		};
+
+	private final Log log = LogFactory.getLog(GetTopologyAction.class);
+
+	public GetTopologyAction()
+	{
+		setActionID(ACTIONID);
+	}
+
+	@Override
+	public ActionResponse
+		execute(IProtocolSessionManager protocolSessionManager)
+		throws ActionException
+	{
+		try {
+			log.info("Retrieving Autobahn topology");
+
+			Iterable<PortType> ports =
+				queryPorts(protocolSessionManager);
+			Iterable<ServiceType> services =
+				queryServices(protocolSessionManager);
+
+			log.info("Discovered interfaces " +
+					 Joiner.on(", ").join(transform(ports, getAddress)));
+
+			updateModel((NetworkModel) modelToUpdate, ports, services);
+
+			return ActionResponse.okResponse(getActionID());
+		} catch (UserAccessPointException_Exception e) {
+			throw new ActionException(e);
+		} catch (ProtocolException e) {
+			throw new ActionException(e);
+		}
+	}
+
+	protected Iterable<PortType>
+		queryPorts(IProtocolSessionManager protocolSessionManager)
+		throws ProtocolException, UserAccessPointException_Exception
+	{
+		UserAccessPoint userAccessPoint =
+			getUserAccessPointService(protocolSessionManager);
+		List<PortType> clientPorts = userAccessPoint.getAllClientPorts();
+		List<PortType> idcpPorts = userAccessPoint.getIdcpPorts();
+		return concat(clientPorts, idcpPorts);
+	}
+
+	protected Iterable<ServiceType>
+		queryServices(IProtocolSessionManager protocolSessionManager)
+		throws ProtocolException
+	{
+		Administration administration =
+			getAdministrationService(protocolSessionManager);
+		return administration.getServices();
+	}
+
+	private void updateModel(NetworkModel model,
+							 Iterable<PortType> ports,
+							 Iterable<ServiceType> services)
+	{
+		String userName = System.getProperty("user.name");
+
+		Map<String,AutobahnInterface> interfaces = Maps.newHashMap();
+		for (PortType port: ports) {
+			interfaces.put(port.getAddress(), createInterface(port));
+		}
+
+		for (ServiceType service: services) {
+			if (userName.equals(service.getUser().getName())) {
+				for (ReservationType reservation: service.getReservations()) {
+					if (!isFinalState(reservation.getState())) {
+						updateLinkTo(interfaces, service, reservation);
+					}
+				}
+			}
+		}
+
+		model.getNetworkElements().addAll(interfaces.values());
+	}
+
+	protected boolean isFinalState(int state)
+	{
+		return state >= 20;
+	}
+
+	protected AutobahnInterface createInterface(PortType port)
+	{
+		AutobahnInterface i = new AutobahnInterface();
+		i.setPortType(port);
+		i.setName(port.getAddress());
+		return i;
+	}
+
+	protected AutobahnLink createLink(AutobahnInterface source,
+									  AutobahnInterface sink,
+									  ServiceType service,
+									  ReservationType reservation)
+	{
+		AutobahnLink link = new AutobahnLink();
+		link.setSource(source);
+		link.setSink(sink);
+		link.setBidirectional(reservation.isBidirectional());
+		link.setReservation(reservation);
+		link.setService(service);
+		return link;
+	}
+
+	protected void updateLinkTo(Map<String,AutobahnInterface> interfaces,
+								ServiceType service,
+								ReservationType reservation)
+	{
+		AutobahnInterface source =
+			interfaces.get(reservation.getStartPort().getAddress());
+		AutobahnInterface sink =
+			interfaces.get(reservation.getEndPort().getAddress());
+
+		if (source != null && sink != null) {
+			source.setLinkTo(createLink(source, sink, service, reservation));
+			log.info("Discovered reservation " + service.getBodID() +
+					 " from " + source.getName() + " to " + sink.getName());
+		}
+	}
+}
+

--- a/extensions/bundles/bod.autobahn/src/main/java/org/opennaas/extensions/bod/autobahn/bod/RequestConnectionAction.java
+++ b/extensions/bundles/bod.autobahn/src/main/java/org/opennaas/extensions/bod/autobahn/bod/RequestConnectionAction.java
@@ -1,0 +1,96 @@
+package org.opennaas.extensions.bod.autobahn.bod;
+
+import java.util.GregorianCalendar;
+import java.util.List;
+
+import javax.xml.datatype.DatatypeFactory;
+import javax.xml.datatype.DatatypeConfigurationException;
+
+import net.geant.autobahn.useraccesspoint.Priority;
+import net.geant.autobahn.useraccesspoint.ReservationRequest;
+import net.geant.autobahn.useraccesspoint.Resiliency;
+import net.geant.autobahn.useraccesspoint.ServiceRequest;
+import net.geant.autobahn.useraccesspoint.UserAccessPoint;
+import net.geant.autobahn.useraccesspoint.UserAccessPointException_Exception;
+
+import org.opennaas.core.resources.action.ActionException;
+import org.opennaas.core.resources.action.ActionResponse;
+import org.opennaas.core.resources.protocol.IProtocolSessionManager;
+import org.opennaas.core.resources.protocol.ProtocolException;
+
+import org.opennaas.extensions.bod.actionsets.dummy.ActionConstants;
+import org.opennaas.extensions.bod.autobahn.AutobahnAction;
+import org.opennaas.extensions.bod.autobahn.model.AutobahnInterface;
+
+import org.opennaas.extensions.network.model.topology.Interface;
+
+public class RequestConnectionAction extends AutobahnAction
+{
+	public final static String ACTIONID = ActionConstants.REQUESTCONNECTION;
+
+	public RequestConnectionAction()
+	{
+		setActionID(ACTIONID);
+	}
+
+	@Override
+	public ActionResponse
+		execute(IProtocolSessionManager protocolSessionManager)
+		throws ActionException
+	{
+		try {
+			log.info("Requesting connection between " + params);
+
+			UserAccessPoint userAccessPoint =
+				getUserAccessPointService(protocolSessionManager);
+
+			String serviceId =
+				userAccessPoint.submitService(createServiceRequest());
+
+			log.info("Submitted service request " + serviceId);
+
+			return ActionResponse.okResponse(getActionID());
+		} catch (DatatypeConfigurationException e) {
+			throw new ActionException(e);
+		} catch (UserAccessPointException_Exception e) {
+			throw new ActionException(e);
+		} catch (ProtocolException e) {
+			throw new ActionException(e);
+		}
+	}
+
+	protected AutobahnInterface getInterface(int index)
+	{
+		List<Interface> interfaces = (List<Interface>) params;
+		return (AutobahnInterface) interfaces.get(index);
+	}
+
+	protected ServiceRequest createServiceRequest()
+		throws DatatypeConfigurationException
+	{
+		GregorianCalendar now = new GregorianCalendar();
+		GregorianCalendar tomorrow = new GregorianCalendar();
+		tomorrow.add(GregorianCalendar.DAY_OF_MONTH, 1);
+
+		DatatypeFactory factory = DatatypeFactory.newInstance();
+
+		ReservationRequest reservationRequest = new ReservationRequest();
+		reservationRequest.setStartPort(getInterface(0).getPortType());
+		reservationRequest.setEndPort(getInterface(1).getPortType());
+		reservationRequest.setStartTime(factory.newXMLGregorianCalendar(now));
+		reservationRequest.setEndTime(factory.newXMLGregorianCalendar(tomorrow));
+		reservationRequest.setDescription("Submitted by OpenNaaS");
+		reservationRequest.setCapacity(10000000);
+		reservationRequest.setBidirectional(true);
+		reservationRequest.setPriority(Priority.NORMAL);
+		reservationRequest.setProcessNow(true);
+		reservationRequest.setResiliency(Resiliency.NONE);
+
+		ServiceRequest serviceRequest = new ServiceRequest();
+		serviceRequest.setJustification("Submitted by OpenNaaS");
+		serviceRequest.setUserName(System.getProperty("user.name"));
+		serviceRequest.getReservations().add(reservationRequest);
+
+		return serviceRequest;
+	}
+}

--- a/extensions/bundles/bod.autobahn/src/main/java/org/opennaas/extensions/bod/autobahn/bod/ShutdownConnectionAction.java
+++ b/extensions/bundles/bod.autobahn/src/main/java/org/opennaas/extensions/bod/autobahn/bod/ShutdownConnectionAction.java
@@ -1,0 +1,79 @@
+package org.opennaas.extensions.bod.autobahn.bod;
+
+import java.util.List;
+
+import net.geant.autobahn.useraccesspoint.UserAccessPoint;
+import net.geant.autobahn.useraccesspoint.UserAccessPointException_Exception;
+
+import org.opennaas.core.resources.protocol.IProtocolSessionManager;
+import org.opennaas.core.resources.protocol.ProtocolException;
+import org.opennaas.core.resources.action.ActionException;
+import org.opennaas.core.resources.action.ActionResponse;
+
+import org.opennaas.extensions.bod.actionsets.dummy.ActionConstants;
+import org.opennaas.extensions.bod.autobahn.AutobahnAction;
+import org.opennaas.extensions.bod.autobahn.model.AutobahnInterface;
+import org.opennaas.extensions.bod.autobahn.model.AutobahnLink;
+
+import org.opennaas.extensions.network.model.topology.Interface;
+
+public class ShutdownConnectionAction extends AutobahnAction
+{
+	public final static String ACTIONID = ActionConstants.SHUTDOWNCONNECTION;
+
+	public ShutdownConnectionAction()
+	{
+		setActionID(ACTIONID);
+	}
+
+	@Override
+	public ActionResponse execute(IProtocolSessionManager protocolSessionManager)
+		throws ActionException
+	{
+		try {
+			log.info("Shuttting down connection between " + params);
+
+			String serviceId = getServiceIdOfLink();
+
+			UserAccessPoint userAccessPoint =
+				getUserAccessPointService(protocolSessionManager);
+			userAccessPoint.cancelService(serviceId);
+
+			getInterface(0).setLinkTo(null);
+
+			log.info("Cancelled service request " + serviceId);
+
+			return ActionResponse.okResponse(getActionID());
+		} catch (UserAccessPointException_Exception e) {
+			throw new ActionException(e);
+		} catch (ProtocolException e) {
+			throw new ActionException(e);
+		}
+	}
+
+	protected String getServiceIdOfLink()
+		throws ActionException
+	{
+		AutobahnInterface source = getInterface(0);
+		AutobahnInterface sink = getInterface(1);
+		AutobahnLink link = (AutobahnLink) source.getLinkTo();
+
+		log.info(String.valueOf(link));
+		if (link != null) {
+			log.info(link.getSink().hashCode());
+		}
+		log.info(sink.hashCode());
+
+		if (link == null || link.getSink() != sink) {
+			throw new ActionException(source.toString() + " is not linked to " + sink);
+		}
+
+		return link.getService().getBodID();
+	}
+
+	protected AutobahnInterface getInterface(int index)
+	{
+		List<Interface> interfaces = (List<Interface>) params;
+		return (AutobahnInterface) interfaces.get(index);
+	}
+}

--- a/extensions/bundles/bod.autobahn/src/main/java/org/opennaas/extensions/bod/autobahn/model/AutobahnInterface.java
+++ b/extensions/bundles/bod.autobahn/src/main/java/org/opennaas/extensions/bod/autobahn/model/AutobahnInterface.java
@@ -1,0 +1,26 @@
+package org.opennaas.extensions.bod.autobahn.model;
+
+import net.geant.autobahn.useraccesspoint.PortType;
+
+import org.opennaas.extensions.network.model.topology.Interface;
+
+public class AutobahnInterface extends Interface
+{
+	private PortType portType;
+
+	public void setPortType(PortType portType)
+	{
+		this.portType = portType;
+	}
+
+	public PortType getPortType()
+	{
+		return portType;
+	}
+
+	@Override
+	public String toString()
+	{
+		return (portType == null) ? super.toString() : portType.getAddress();
+	}
+}

--- a/extensions/bundles/bod.autobahn/src/main/java/org/opennaas/extensions/bod/autobahn/model/AutobahnLink.java
+++ b/extensions/bundles/bod.autobahn/src/main/java/org/opennaas/extensions/bod/autobahn/model/AutobahnLink.java
@@ -1,0 +1,32 @@
+package org.opennaas.extensions.bod.autobahn.model;
+
+import net.geant.autobahn.administration.ReservationType;
+import net.geant.autobahn.administration.ServiceType;
+
+import org.opennaas.extensions.network.model.topology.Link;
+
+public class AutobahnLink extends Link
+{
+	private ServiceType service;
+	private ReservationType reservation;
+
+	public void setReservation(ReservationType reservation)
+	{
+		this.reservation = reservation;
+	}
+
+	public ReservationType getReservation()
+	{
+		return reservation;
+	}
+
+	public void setService(ServiceType service)
+	{
+		this.service = service;
+	}
+
+	public ServiceType getService()
+	{
+		return service;
+	}
+}

--- a/extensions/bundles/bod.autobahn/src/main/java/org/opennaas/extensions/bod/autobahn/protocol/AutobahnProtocolSession.java
+++ b/extensions/bundles/bod.autobahn/src/main/java/org/opennaas/extensions/bod/autobahn/protocol/AutobahnProtocolSession.java
@@ -1,0 +1,206 @@
+package org.opennaas.extensions.bod.autobahn.protocol;
+
+import com.google.common.base.Strings;
+
+import java.util.Map;
+
+import javax.xml.namespace.QName;
+import javax.xml.ws.Service;
+import javax.xml.ws.WebServiceException;
+import javax.xml.ws.soap.SOAPBinding;
+
+import net.geant.autobahn.useraccesspoint.UserAccessPoint;
+import net.geant.autobahn.administration.Administration;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.opennaas.core.resources.protocol.IProtocolMessageFilter;
+import org.opennaas.core.resources.protocol.IProtocolSession;
+import org.opennaas.core.resources.protocol.IProtocolSessionListener;
+import org.opennaas.core.resources.protocol.ProtocolException;
+import org.opennaas.core.resources.protocol.ProtocolSessionContext;
+
+import static com.google.common.base.Preconditions.*;
+import static org.opennaas.core.resources.protocol.ProtocolSessionContext.*;
+import static org.opennaas.core.resources.protocol.IProtocolSession.Status.*;
+
+public class AutobahnProtocolSession implements IProtocolSession
+{
+	private final static QName USER_ACCESS_POINT_SERVICE =
+		new QName("http://useraccesspoint.autobahn.geant.net/",
+				  "UserAccessPointService");
+	private final static QName USER_ACCESS_POINT_PORT =
+		new QName("http://useraccesspoint.autobahn.geant.net/",
+				  "UserAccessPointPort");
+	private final static QName ADMINISTRATION_SERVICE =
+		new QName("http://administration.autobahn.geant.net/",
+				  "AdministrationService");
+	private final static QName ADMINISTRATION_PORT =
+		new QName("http://administration.autobahn.geant.net/",
+				  "AdministrationPort");
+
+	private final Log log = LogFactory.getLog(AutobahnProtocolSession.class);
+
+	private ProtocolSessionContext protocolSessionContext;
+	private String sessionID;
+
+	private UserAccessPoint uapService;
+	private Administration administrationService;
+
+	private Status status;
+
+	public AutobahnProtocolSession(ProtocolSessionContext protocolSessionContext,
+								   String sessionID)
+		throws ProtocolException
+	{
+		this.protocolSessionContext = protocolSessionContext;
+		this.sessionID = sessionID;
+		this.status = DISCONNECTED_BY_USER;
+	}
+
+	@Override
+	public void asyncSend(Object requestMessage) throws ProtocolException
+	{
+		throw new UnsupportedOperationException("asyncSend not supported by AutobahnProtocolSession");
+	}
+
+	@Override
+	public Object sendReceive(Object requestMessage) throws ProtocolException
+	{
+		throw new UnsupportedOperationException("sendReceive not supported by AutobahnProtocolSession");
+	}
+
+	@Override
+	public void connect() throws ProtocolException
+	{
+		uapService =
+			createUserAccessPointService(getServiceUri() + "uap");
+		administrationService =
+			createAdministrationService(getServiceUri() + "administration");
+		status = CONNECTED;
+	}
+
+	@Override
+	public void disconnect() throws ProtocolException
+	{
+		status = DISCONNECTED_BY_USER;
+		uapService = null;
+		administrationService = null;
+	}
+
+	@Override
+	public ProtocolSessionContext getSessionContext()
+	{
+		return protocolSessionContext;
+	}
+
+	@Override
+	public String getSessionId()
+	{
+		return sessionID;
+	}
+
+	@Override
+	public Status getStatus()
+	{
+		return status;
+	}
+
+	@Override
+	public void
+		registerProtocolSessionListener(IProtocolSessionListener protocolSessionListener,
+										IProtocolMessageFilter protocolMessageFilter,
+										String idListener)
+	{
+	}
+
+	@Override
+	public void
+		unregisterProtocolSessionListener(IProtocolSessionListener protocolSessionListener,
+										  String idListener)
+	{
+	}
+
+	@Override
+	public void setSessionContext(ProtocolSessionContext context)
+	{
+		this.protocolSessionContext = context;
+	}
+
+	@Override
+	public void setSessionId(String sessionId)
+	{
+		this.sessionID = sessionId;
+	}
+
+	public UserAccessPoint getUserAccessPointService()
+	{
+		checkState(status == CONNECTED);
+		return uapService;
+	}
+
+	public Administration getAdministrationService()
+	{
+		checkState(status == CONNECTED);
+		return administrationService;
+	}
+
+	private String getServiceUri()
+		throws ProtocolException
+	{
+		Map<String,Object> parameters =
+			protocolSessionContext.getSessionParameters();
+		String uri = (String) parameters.get(PROTOCOL_URI);
+		if (Strings.isNullOrEmpty(uri)) {
+			throw new ProtocolException(PROTOCOL_URI + " is missing in protocol session context.");
+		}
+		if (!uri.endsWith("/")) {
+			uri = uri + "/";
+		}
+		return uri;
+	}
+
+	private <T> T createSoapService(String uri,
+									QName serviceName,
+									QName portName,
+									Class<T> clazz)
+		throws ProtocolException
+	{
+		/* The JAXWS SPI uses the context class loader to locate an
+		 * implementation. We therefore make sure the context class
+		 * loader is set to our class loader.
+		 */
+		Thread thread = Thread.currentThread();
+		ClassLoader oldLoader = thread.getContextClassLoader();
+		try {
+			thread.setContextClassLoader(getClass().getClassLoader());
+			Service service = Service.create(serviceName);
+			service.addPort(portName, SOAPBinding.SOAP11HTTP_BINDING, uri);
+			return service.getPort(portName, clazz);
+		} catch (WebServiceException e) {
+			throw new ProtocolException("Failed to create Autobahn session: " +
+										e.getMessage(), e);
+		} finally {
+			thread.setContextClassLoader(oldLoader);
+		}
+	}
+
+	private UserAccessPoint createUserAccessPointService(String uri)
+		throws ProtocolException
+	{
+		return createSoapService(uri,
+								 USER_ACCESS_POINT_SERVICE,
+								 USER_ACCESS_POINT_PORT,
+								 UserAccessPoint.class);
+	}
+
+	private Administration createAdministrationService(String uri)
+		throws ProtocolException
+	{
+		return createSoapService(uri,
+								 ADMINISTRATION_SERVICE,
+								 ADMINISTRATION_PORT,
+								 Administration.class);
+	}
+}

--- a/extensions/bundles/bod.autobahn/src/main/java/org/opennaas/extensions/bod/autobahn/protocol/AutobahnProtocolSessionFactory.java
+++ b/extensions/bundles/bod.autobahn/src/main/java/org/opennaas/extensions/bod/autobahn/protocol/AutobahnProtocolSessionFactory.java
@@ -1,0 +1,18 @@
+package org.opennaas.extensions.bod.autobahn.protocol;
+
+import org.opennaas.core.resources.protocol.IProtocolSession;
+import org.opennaas.core.resources.protocol.IProtocolSessionFactory;
+import org.opennaas.core.resources.protocol.ProtocolException;
+import org.opennaas.core.resources.protocol.ProtocolSessionContext;
+
+public class AutobahnProtocolSessionFactory implements IProtocolSessionFactory
+{
+    @Override
+    public IProtocolSession
+        createProtocolSession(String sessionID,
+                              ProtocolSessionContext protocolSessionContext)
+        throws ProtocolException
+    {
+        return new AutobahnProtocolSession(protocolSessionContext, sessionID);
+    }
+}

--- a/extensions/bundles/bod.autobahn/src/main/java/org/opennaas/extensions/bod/autobahn/queue/ConfirmAction.java
+++ b/extensions/bundles/bod.autobahn/src/main/java/org/opennaas/extensions/bod/autobahn/queue/ConfirmAction.java
@@ -1,0 +1,25 @@
+package org.opennaas.extensions.bod.autobahn.queue;
+
+import org.opennaas.core.resources.protocol.IProtocolSessionManager;
+import org.opennaas.core.resources.action.ActionException;
+import org.opennaas.core.resources.action.ActionResponse;
+import org.opennaas.core.resources.queue.QueueConstants;
+
+import org.opennaas.extensions.bod.autobahn.AutobahnAction;
+
+public class ConfirmAction extends AutobahnAction
+{
+	public final static String ACTIONID = QueueConstants.CONFIRM;
+
+	public ConfirmAction()
+	{
+		setActionID(ACTIONID);
+	}
+
+	@Override
+	public ActionResponse execute(IProtocolSessionManager protocolSessionManager)
+		throws ActionException
+	{
+		return ActionResponse.okResponse(getActionID());
+	}
+}

--- a/extensions/bundles/bod.autobahn/src/main/java/org/opennaas/extensions/bod/autobahn/queue/IsAliveAction.java
+++ b/extensions/bundles/bod.autobahn/src/main/java/org/opennaas/extensions/bod/autobahn/queue/IsAliveAction.java
@@ -1,0 +1,25 @@
+package org.opennaas.extensions.bod.autobahn.queue;
+
+import org.opennaas.core.resources.protocol.IProtocolSessionManager;
+import org.opennaas.core.resources.action.ActionException;
+import org.opennaas.core.resources.action.ActionResponse;
+import org.opennaas.core.resources.queue.QueueConstants;
+
+import org.opennaas.extensions.bod.autobahn.AutobahnAction;
+
+public class IsAliveAction extends AutobahnAction
+{
+	public final static String ACTIONID = QueueConstants.ISALIVE;
+
+	public IsAliveAction()
+	{
+		setActionID(ACTIONID);
+	}
+
+	@Override
+	public ActionResponse execute(IProtocolSessionManager protocolSessionManager)
+		throws ActionException
+	{
+		return ActionResponse.okResponse(getActionID());
+	}
+}

--- a/extensions/bundles/bod.autobahn/src/main/java/org/opennaas/extensions/bod/autobahn/queue/PrepareAction.java
+++ b/extensions/bundles/bod.autobahn/src/main/java/org/opennaas/extensions/bod/autobahn/queue/PrepareAction.java
@@ -1,0 +1,25 @@
+package org.opennaas.extensions.bod.autobahn.queue;
+
+import org.opennaas.core.resources.protocol.IProtocolSessionManager;
+import org.opennaas.core.resources.action.ActionException;
+import org.opennaas.core.resources.action.ActionResponse;
+import org.opennaas.core.resources.queue.QueueConstants;
+
+import org.opennaas.extensions.bod.autobahn.AutobahnAction;
+
+public class PrepareAction extends AutobahnAction
+{
+	public final static String ACTIONID = QueueConstants.PREPARE;
+
+	public PrepareAction()
+	{
+		setActionID(ACTIONID);
+	}
+
+	@Override
+	public ActionResponse execute(IProtocolSessionManager protocolSessionManager)
+		throws ActionException
+	{
+		return ActionResponse.okResponse(getActionID());
+	}
+}

--- a/extensions/bundles/bod.autobahn/src/main/java/org/opennaas/extensions/bod/autobahn/queue/QueueActionSet.java
+++ b/extensions/bundles/bod.autobahn/src/main/java/org/opennaas/extensions/bod/autobahn/queue/QueueActionSet.java
@@ -1,0 +1,15 @@
+package org.opennaas.extensions.bod.autobahn.queue;
+
+import org.opennaas.core.resources.action.ActionSet;
+
+public class QueueActionSet extends ActionSet
+{
+    public QueueActionSet()
+    {
+        setActionSetId("queueActionSet");
+        putAction(ConfirmAction.ACTIONID, ConfirmAction.class);
+        putAction(IsAliveAction.ACTIONID, IsAliveAction.class);
+        putAction(PrepareAction.ACTIONID, PrepareAction.class);
+        putAction(RestoreAction.ACTIONID, RestoreAction.class);
+    }
+}

--- a/extensions/bundles/bod.autobahn/src/main/java/org/opennaas/extensions/bod/autobahn/queue/RestoreAction.java
+++ b/extensions/bundles/bod.autobahn/src/main/java/org/opennaas/extensions/bod/autobahn/queue/RestoreAction.java
@@ -1,0 +1,25 @@
+package org.opennaas.extensions.bod.autobahn.queue;
+
+import org.opennaas.core.resources.protocol.IProtocolSessionManager;
+import org.opennaas.core.resources.action.ActionException;
+import org.opennaas.core.resources.action.ActionResponse;
+import org.opennaas.core.resources.queue.QueueConstants;
+
+import org.opennaas.extensions.bod.autobahn.AutobahnAction;
+
+public class RestoreAction extends AutobahnAction
+{
+	public final static String ACTIONID = QueueConstants.RESTORE;
+
+	public RestoreAction()
+	{
+		setActionID(ACTIONID);
+	}
+
+	@Override
+	public ActionResponse execute(IProtocolSessionManager protocolSessionManager)
+		throws ActionException
+	{
+		return ActionResponse.okResponse(getActionID());
+	}
+}

--- a/extensions/bundles/bod.autobahn/src/main/resources/META-INF/wsdl/administration.wsdl
+++ b/extensions/bundles/bod.autobahn/src/main/resources/META-INF/wsdl/administration.wsdl
@@ -1,0 +1,654 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions name="Administration" targetNamespace="http://administration.autobahn.geant.net/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:tns="http://administration.autobahn.geant.net/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/">
+  <wsdl:types>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ns1="http://administration.autobahn.geant.net/" targetNamespace="useraccesspoint.autobahn.geant.net" version="1.0">
+<xs:import namespace="http://administration.autobahn.geant.net/"/>
+<xs:complexType name="PortType">
+<xs:sequence>
+<xs:element minOccurs="0" name="address" type="xs:string"/>
+<xs:element minOccurs="0" name="mode" type="ns1:mode"/>
+<xs:element name="vlan" type="xs:int"/>
+<xs:element minOccurs="0" name="description" type="xs:string"/>
+<xs:element name="isIdcp" type="xs:boolean"/>
+<xs:element name="isClient" type="xs:boolean"/>
+</xs:sequence>
+</xs:complexType>
+</xs:schema>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ns1="network.autobahn.geant.net" targetNamespace="reservation.autobahn.geant.net" version="1.0">
+<xs:import namespace="network.autobahn.geant.net"/>
+<xs:complexType name="User">
+<xs:sequence>
+<xs:element minOccurs="0" name="name" type="xs:string"/>
+<xs:element minOccurs="0" name="homeDomain" type="ns1:AdminDomain"/>
+<xs:element minOccurs="0" name="email" type="xs:string"/>
+</xs:sequence>
+</xs:complexType>
+</xs:schema>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="network.autobahn.geant.net" targetNamespace="network.autobahn.geant.net" version="1.0">
+<xs:complexType name="AdminDomain">
+<xs:sequence>
+<xs:element minOccurs="0" name="bodID" type="xs:string"/>
+<xs:element minOccurs="0" name="ASID" type="xs:string"/>
+<xs:element minOccurs="0" name="name" type="xs:string"/>
+<xs:element name="clientDomain" type="xs:boolean"/>
+<xs:element minOccurs="0" name="idcpServer" type="xs:string"/>
+</xs:sequence>
+</xs:complexType>
+<xs:complexType name="Path">
+<xs:sequence>
+<xs:element maxOccurs="unbounded" name="links" nillable="true" type="tns:Link"/>
+<xs:element name="monetary_cost" type="xs:double"/>
+<xs:element name="manual_cost" type="xs:double"/>
+<xs:element name="capacity" type="xs:long"/>
+</xs:sequence>
+</xs:complexType>
+<xs:complexType name="Link">
+<xs:sequence>
+<xs:element minOccurs="0" name="bodID" type="xs:string"/>
+<xs:element name="kind" type="xs:int"/>
+<xs:element minOccurs="0" name="startPort" type="tns:Port"/>
+<xs:element minOccurs="0" name="endPort" type="tns:Port"/>
+<xs:element name="bidirectional" type="xs:boolean"/>
+<xs:element name="delay" type="xs:int"/>
+<xs:element name="manualCost" type="xs:double"/>
+<xs:element name="monetaryCost" type="xs:double"/>
+<xs:element name="granularity" type="xs:long"/>
+<xs:element name="minResCapacity" type="xs:long"/>
+<xs:element name="maxResCapacity" type="xs:long"/>
+<xs:element name="capacity" type="xs:long"/>
+<xs:element minOccurs="0" name="resilience" type="xs:string"/>
+<xs:element minOccurs="0" name="timestamp" type="xs:dateTime"/>
+<xs:element minOccurs="0" name="localName" type="xs:string"/>
+<xs:element minOccurs="0" name="type" type="tns:LinkType"/>
+<xs:element minOccurs="0" name="operationalState" type="tns:StateOper"/>
+<xs:element minOccurs="0" name="administrativeState" type="tns:StateAdmin"/>
+</xs:sequence>
+</xs:complexType>
+<xs:complexType name="Port">
+<xs:sequence>
+<xs:element minOccurs="0" name="bodID" type="xs:string"/>
+<xs:element minOccurs="0" name="description" type="xs:string"/>
+<xs:element minOccurs="0" name="technology" type="xs:string"/>
+<xs:element name="bundled" type="xs:boolean"/>
+<xs:element minOccurs="0" name="node" type="tns:Node"/>
+</xs:sequence>
+</xs:complexType>
+<xs:complexType name="Node">
+<xs:sequence>
+<xs:element minOccurs="0" name="bodID" type="xs:string"/>
+<xs:element minOccurs="0" name="type" type="xs:string"/>
+<xs:element minOccurs="0" name="address" type="xs:string"/>
+<xs:element minOccurs="0" name="provisioningDomain" type="tns:ProvisioningDomain"/>
+<xs:element minOccurs="0" name="name" type="xs:string"/>
+<xs:element minOccurs="0" name="country" type="xs:string"/>
+<xs:element minOccurs="0" name="city" type="xs:string"/>
+<xs:element minOccurs="0" name="institution" type="xs:string"/>
+<xs:element minOccurs="0" name="longitude" type="xs:string"/>
+<xs:element minOccurs="0" name="latitude" type="xs:string"/>
+</xs:sequence>
+</xs:complexType>
+<xs:complexType name="ProvisioningDomain">
+<xs:sequence>
+<xs:element minOccurs="0" name="bodID" type="xs:string"/>
+<xs:element minOccurs="0" name="provType" type="xs:string"/>
+<xs:element minOccurs="0" name="adminDomain" type="tns:AdminDomain"/>
+</xs:sequence>
+</xs:complexType>
+<xs:complexType name="LinkType">
+<xs:sequence>
+<xs:element name="type" type="xs:int"/>
+<xs:element minOccurs="0" name="desc" type="xs:string"/>
+</xs:sequence>
+</xs:complexType>
+<xs:complexType name="StateOper">
+<xs:sequence>
+<xs:element name="id" type="xs:int"/>
+<xs:element minOccurs="0" name="desc" type="xs:string"/>
+</xs:sequence>
+</xs:complexType>
+<xs:complexType name="StateAdmin">
+<xs:sequence>
+<xs:element name="id" type="xs:int"/>
+<xs:element minOccurs="0" name="desc" type="xs:string"/>
+</xs:sequence>
+</xs:complexType>
+</xs:schema>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ns1="administration.autobahn.geant.net" xmlns:ns2="network.autobahn.geant.net" xmlns:tns="http://administration.autobahn.geant.net/" attributeFormDefault="unqualified" elementFormDefault="unqualified" targetNamespace="http://administration.autobahn.geant.net/">
+<xs:import namespace="administration.autobahn.geant.net"/>
+<xs:import namespace="network.autobahn.geant.net"/>
+<xs:element name="cancelAllServices" type="tns:cancelAllServices"/>
+<xs:element name="cancelAllServicesResponse" type="tns:cancelAllServicesResponse"/>
+<xs:element name="getLog" type="tns:getLog"/>
+<xs:element name="getLogResponse" type="tns:getLogResponse"/>
+<xs:element name="getProperties" type="tns:getProperties"/>
+<xs:element name="getPropertiesResponse" type="tns:getPropertiesResponse"/>
+<xs:element name="getReservation" type="tns:getReservation"/>
+<xs:element name="getReservationResponse" type="tns:getReservationResponse"/>
+<xs:element name="getService" type="tns:getService"/>
+<xs:element name="getServiceResponse" type="tns:getServiceResponse"/>
+<xs:element name="getServices" type="tns:getServices"/>
+<xs:element name="getServicesResponse" type="tns:getServicesResponse"/>
+<xs:element name="getStatistics" type="tns:getStatistics"/>
+<xs:element name="getStatisticsResponse" type="tns:getStatisticsResponse"/>
+<xs:element name="getStatus" type="tns:getStatus"/>
+<xs:element name="getStatusResponse" type="tns:getStatusResponse"/>
+<xs:element name="getTopology" type="tns:getTopology"/>
+<xs:element name="getTopologyResponse" type="tns:getTopologyResponse"/>
+<xs:element name="handleTopologyChange" type="tns:handleTopologyChange"/>
+<xs:element name="handleTopologyChangeResponse" type="tns:handleTopologyChangeResponse"/>
+<xs:element name="restart" type="tns:restart"/>
+<xs:element name="restartResponse" type="tns:restartResponse"/>
+<xs:element name="setProperties" type="tns:setProperties"/>
+<xs:element name="setPropertiesResponse" type="tns:setPropertiesResponse"/>
+<xs:element name="setTopology" type="tns:setTopology"/>
+<xs:element name="setTopologyResponse" type="tns:setTopologyResponse"/>
+<xs:complexType name="getService">
+<xs:sequence>
+<xs:element minOccurs="0" name="arg0" type="xs:string"/>
+</xs:sequence>
+</xs:complexType>
+<xs:complexType name="getServiceResponse">
+<xs:sequence>
+<xs:element minOccurs="0" name="service" type="ns1:ServiceType"/>
+</xs:sequence>
+</xs:complexType>
+<xs:complexType name="setTopology">
+<xs:sequence>
+<xs:element maxOccurs="unbounded" minOccurs="0" name="links" type="ns2:Link"/>
+</xs:sequence>
+</xs:complexType>
+<xs:complexType name="setTopologyResponse">
+<xs:sequence/>
+</xs:complexType>
+<xs:complexType name="getStatus">
+<xs:sequence/>
+</xs:complexType>
+<xs:complexType name="getStatusResponse">
+<xs:sequence>
+<xs:element minOccurs="0" name="status" type="ns1:Status"/>
+</xs:sequence>
+</xs:complexType>
+<xs:complexType name="getProperties">
+<xs:sequence/>
+</xs:complexType>
+<xs:complexType name="getPropertiesResponse">
+<xs:sequence>
+<xs:element maxOccurs="unbounded" minOccurs="0" name="Properties" type="ns1:KeyValue"/>
+</xs:sequence>
+</xs:complexType>
+<xs:complexType name="getStatistics">
+<xs:sequence>
+<xs:element name="all" type="xs:boolean"/>
+</xs:sequence>
+</xs:complexType>
+<xs:complexType name="getStatisticsResponse">
+<xs:sequence>
+<xs:element minOccurs="0" name="statistics" type="ns1:StatisticsType"/>
+</xs:sequence>
+</xs:complexType>
+<xs:complexType name="statisticsEntry">
+<xs:sequence>
+<xs:element name="id" type="xs:int"/>
+<xs:element name="intradomain" type="xs:boolean"/>
+<xs:element minOccurs="0" name="reservation_id" type="xs:string"/>
+<xs:element name="setup_time" type="xs:long"/>
+</xs:sequence>
+</xs:complexType>
+<xs:complexType name="getTopology">
+<xs:sequence/>
+</xs:complexType>
+<xs:complexType name="getTopologyResponse">
+<xs:sequence>
+<xs:element maxOccurs="unbounded" minOccurs="0" name="links" type="ns2:Link"/>
+</xs:sequence>
+</xs:complexType>
+<xs:complexType name="getLog">
+<xs:sequence>
+<xs:element name="all" type="xs:boolean"/>
+</xs:sequence>
+</xs:complexType>
+<xs:complexType name="getLogResponse">
+<xs:sequence>
+<xs:element minOccurs="0" name="log" type="xs:string"/>
+</xs:sequence>
+</xs:complexType>
+<xs:complexType name="setProperties">
+<xs:sequence>
+<xs:element maxOccurs="unbounded" minOccurs="0" name="properties" type="ns1:KeyValue"/>
+</xs:sequence>
+</xs:complexType>
+<xs:complexType name="setPropertiesResponse">
+<xs:sequence/>
+</xs:complexType>
+<xs:complexType name="cancelAllServices">
+<xs:sequence/>
+</xs:complexType>
+<xs:complexType name="cancelAllServicesResponse">
+<xs:sequence/>
+</xs:complexType>
+<xs:complexType name="handleTopologyChange">
+<xs:sequence>
+<xs:element name="arg0" type="xs:boolean"/>
+</xs:sequence>
+</xs:complexType>
+<xs:complexType name="handleTopologyChangeResponse">
+<xs:sequence/>
+</xs:complexType>
+<xs:complexType name="getServices">
+<xs:sequence/>
+</xs:complexType>
+<xs:complexType name="getServicesResponse">
+<xs:sequence>
+<xs:element maxOccurs="unbounded" minOccurs="0" name="serivces" type="ns1:ServiceType"/>
+</xs:sequence>
+</xs:complexType>
+<xs:complexType name="getReservation">
+<xs:sequence>
+<xs:element minOccurs="0" name="resID" type="xs:string"/>
+</xs:sequence>
+</xs:complexType>
+<xs:complexType name="getReservationResponse">
+<xs:sequence>
+<xs:element minOccurs="0" name="Reservation" type="ns1:ReservationType"/>
+</xs:sequence>
+</xs:complexType>
+<xs:complexType name="restart">
+<xs:sequence/>
+</xs:complexType>
+<xs:complexType name="restartResponse">
+<xs:sequence/>
+</xs:complexType>
+<xs:simpleType name="mode">
+<xs:restriction base="xs:string">
+<xs:enumeration value="VLAN"/>
+<xs:enumeration value="UNTAGGED"/>
+<xs:enumeration value="TRANSPARENT"/>
+</xs:restriction>
+</xs:simpleType>
+<xs:element name="AdministrationException" type="tns:AdministrationException"/>
+<xs:complexType name="AdministrationException">
+<xs:sequence/>
+</xs:complexType>
+</xs:schema>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ns1="reservation.autobahn.geant.net" xmlns:ns2="useraccesspoint.autobahn.geant.net" xmlns:ns3="network.autobahn.geant.net" xmlns:ns4="http://administration.autobahn.geant.net/" xmlns:tns="administration.autobahn.geant.net" targetNamespace="administration.autobahn.geant.net" version="1.0">
+<xs:import namespace="reservation.autobahn.geant.net"/>
+<xs:import namespace="useraccesspoint.autobahn.geant.net"/>
+<xs:import namespace="network.autobahn.geant.net"/>
+<xs:import namespace="http://administration.autobahn.geant.net/"/>
+<xs:complexType name="ServiceType">
+<xs:sequence>
+<xs:element minOccurs="0" name="bodID" type="xs:string"/>
+<xs:element minOccurs="0" name="justification" type="xs:string"/>
+<xs:element name="priority" type="xs:int"/>
+<xs:element minOccurs="0" name="user" type="ns1:User"/>
+<xs:element maxOccurs="unbounded" minOccurs="0" name="reservations" nillable="true" type="tns:ReservationType"/>
+</xs:sequence>
+</xs:complexType>
+<xs:complexType name="ReservationType">
+<xs:sequence>
+<xs:element minOccurs="0" name="bodID" type="xs:string"/>
+<xs:element minOccurs="0" name="startPort" type="ns2:PortType"/>
+<xs:element minOccurs="0" name="endPort" type="ns2:PortType"/>
+<xs:element minOccurs="0" name="startTime" type="xs:dateTime"/>
+<xs:element minOccurs="0" name="endTime" type="xs:dateTime"/>
+<xs:element name="priority" type="xs:int"/>
+<xs:element minOccurs="0" name="description" type="xs:string"/>
+<xs:element name="capacity" type="xs:long"/>
+<xs:element name="mtu" type="xs:int"/>
+<xs:element name="maxDelay" type="xs:int"/>
+<xs:element minOccurs="0" name="resiliency" type="xs:string"/>
+<xs:element name="bidirectional" type="xs:boolean"/>
+<xs:element minOccurs="0" name="path" type="ns3:Path"/>
+<xs:element name="state" type="xs:int"/>
+<xs:element minOccurs="0" name="failureCause" type="xs:string"/>
+</xs:sequence>
+</xs:complexType>
+<xs:complexType name="Status">
+<xs:sequence>
+<xs:element minOccurs="0" name="domain" type="xs:string"/>
+<xs:element name="longitude" type="xs:float"/>
+<xs:element name="latitude" type="xs:float"/>
+<xs:element maxOccurs="unbounded" name="neighbors" nillable="true" type="tns:Neighbor"/>
+</xs:sequence>
+</xs:complexType>
+<xs:complexType name="Neighbor">
+<xs:sequence>
+<xs:element minOccurs="0" name="domain" type="xs:string"/>
+<xs:element minOccurs="0" name="link" type="ns3:Link"/>
+</xs:sequence>
+</xs:complexType>
+<xs:complexType name="KeyValue">
+<xs:sequence>
+<xs:element minOccurs="0" name="key" type="xs:string"/>
+<xs:element minOccurs="0" name="value" type="xs:string"/>
+</xs:sequence>
+</xs:complexType>
+<xs:complexType name="StatisticsType">
+<xs:sequence>
+<xs:element name="averageIntra" type="xs:long"/>
+<xs:element name="averageInter" type="xs:long"/>
+<xs:element maxOccurs="unbounded" minOccurs="0" name="intra" nillable="true" type="ns4:statisticsEntry"/>
+<xs:element maxOccurs="unbounded" minOccurs="0" name="inter" nillable="true" type="ns4:statisticsEntry"/>
+</xs:sequence>
+</xs:complexType>
+</xs:schema>
+  </wsdl:types>
+  <wsdl:message name="setTopologyResponse">
+    <wsdl:part name="parameters" element="tns:setTopologyResponse">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getServicesResponse">
+    <wsdl:part name="parameters" element="tns:getServicesResponse">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="setProperties">
+    <wsdl:part name="parameters" element="tns:setProperties">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="cancelAllServices">
+    <wsdl:part name="parameters" element="tns:cancelAllServices">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="restartResponse">
+    <wsdl:part name="parameters" element="tns:restartResponse">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="setTopology">
+    <wsdl:part name="parameters" element="tns:setTopology">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getService">
+    <wsdl:part name="parameters" element="tns:getService">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getStatistics">
+    <wsdl:part name="parameters" element="tns:getStatistics">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="handleTopologyChange">
+    <wsdl:part name="parameters" element="tns:handleTopologyChange">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="handleTopologyChangeResponse">
+    <wsdl:part name="parameters" element="tns:handleTopologyChangeResponse">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getStatus">
+    <wsdl:part name="parameters" element="tns:getStatus">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getLog">
+    <wsdl:part name="parameters" element="tns:getLog">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getServiceResponse">
+    <wsdl:part name="parameters" element="tns:getServiceResponse">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="restart">
+    <wsdl:part name="parameters" element="tns:restart">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getStatusResponse">
+    <wsdl:part name="parameters" element="tns:getStatusResponse">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getTopologyResponse">
+    <wsdl:part name="parameters" element="tns:getTopologyResponse">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getTopology">
+    <wsdl:part name="parameters" element="tns:getTopology">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getReservationResponse">
+    <wsdl:part name="parameters" element="tns:getReservationResponse">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getProperties">
+    <wsdl:part name="parameters" element="tns:getProperties">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="cancelAllServicesResponse">
+    <wsdl:part name="parameters" element="tns:cancelAllServicesResponse">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="setPropertiesResponse">
+    <wsdl:part name="parameters" element="tns:setPropertiesResponse">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getReservation">
+    <wsdl:part name="parameters" element="tns:getReservation">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getPropertiesResponse">
+    <wsdl:part name="parameters" element="tns:getPropertiesResponse">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getLogResponse">
+    <wsdl:part name="parameters" element="tns:getLogResponse">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getServices">
+    <wsdl:part name="parameters" element="tns:getServices">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getStatisticsResponse">
+    <wsdl:part name="parameters" element="tns:getStatisticsResponse">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="AdministrationException">
+    <wsdl:part name="AdministrationException" element="tns:AdministrationException">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:portType name="Administration">
+    <wsdl:operation name="getService">
+      <wsdl:input name="getService" message="tns:getService">
+    </wsdl:input>
+      <wsdl:output name="getServiceResponse" message="tns:getServiceResponse">
+    </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="setTopology">
+      <wsdl:input name="setTopology" message="tns:setTopology">
+    </wsdl:input>
+      <wsdl:output name="setTopologyResponse" message="tns:setTopologyResponse">
+    </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="getStatus">
+      <wsdl:input name="getStatus" message="tns:getStatus">
+    </wsdl:input>
+      <wsdl:output name="getStatusResponse" message="tns:getStatusResponse">
+    </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="getProperties">
+      <wsdl:input name="getProperties" message="tns:getProperties">
+    </wsdl:input>
+      <wsdl:output name="getPropertiesResponse" message="tns:getPropertiesResponse">
+    </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="getStatistics">
+      <wsdl:input name="getStatistics" message="tns:getStatistics">
+    </wsdl:input>
+      <wsdl:output name="getStatisticsResponse" message="tns:getStatisticsResponse">
+    </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="getTopology">
+      <wsdl:input name="getTopology" message="tns:getTopology">
+    </wsdl:input>
+      <wsdl:output name="getTopologyResponse" message="tns:getTopologyResponse">
+    </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="getLog">
+      <wsdl:input name="getLog" message="tns:getLog">
+    </wsdl:input>
+      <wsdl:output name="getLogResponse" message="tns:getLogResponse">
+    </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="setProperties">
+      <wsdl:input name="setProperties" message="tns:setProperties">
+    </wsdl:input>
+      <wsdl:output name="setPropertiesResponse" message="tns:setPropertiesResponse">
+    </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="cancelAllServices">
+      <wsdl:input name="cancelAllServices" message="tns:cancelAllServices">
+    </wsdl:input>
+      <wsdl:output name="cancelAllServicesResponse" message="tns:cancelAllServicesResponse">
+    </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="handleTopologyChange">
+      <wsdl:input name="handleTopologyChange" message="tns:handleTopologyChange">
+    </wsdl:input>
+      <wsdl:output name="handleTopologyChangeResponse" message="tns:handleTopologyChangeResponse">
+    </wsdl:output>
+      <wsdl:fault name="AdministrationException" message="tns:AdministrationException">
+    </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="getServices">
+      <wsdl:input name="getServices" message="tns:getServices">
+    </wsdl:input>
+      <wsdl:output name="getServicesResponse" message="tns:getServicesResponse">
+    </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="getReservation">
+      <wsdl:input name="getReservation" message="tns:getReservation">
+    </wsdl:input>
+      <wsdl:output name="getReservationResponse" message="tns:getReservationResponse">
+    </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="restart">
+      <wsdl:input name="restart" message="tns:restart">
+    </wsdl:input>
+      <wsdl:output name="restartResponse" message="tns:restartResponse">
+    </wsdl:output>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="AdministrationServiceSoapBinding" type="tns:Administration">
+    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="getService">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="getService">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="getServiceResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="setTopology">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="setTopology">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="setTopologyResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="getStatus">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="getStatus">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="getStatusResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="getProperties">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="getProperties">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="getPropertiesResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="getStatistics">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="getStatistics">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="getStatisticsResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="getTopology">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="getTopology">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="getTopologyResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="getLog">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="getLog">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="getLogResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="setProperties">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="setProperties">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="setPropertiesResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="cancelAllServices">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="cancelAllServices">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="cancelAllServicesResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="handleTopologyChange">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="handleTopologyChange">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="handleTopologyChangeResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="AdministrationException">
+        <soap:fault name="AdministrationException" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="getServices">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="getServices">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="getServicesResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="getReservation">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="getReservation">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="getReservationResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="restart">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="restart">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="restartResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="Administration">
+    <wsdl:port name="AdministrationPort" binding="tns:AdministrationServiceSoapBinding">
+      <soap:address location="http://localhost:9090/AdministrationPort"/>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>

--- a/extensions/bundles/bod.autobahn/src/main/resources/META-INF/wsdl/useraccesspoint.wsdl
+++ b/extensions/bundles/bod.autobahn/src/main/resources/META-INF/wsdl/useraccesspoint.wsdl
@@ -1,0 +1,662 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions name="UserAccessPoint" targetNamespace="http://useraccesspoint.autobahn.geant.net/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:tns="http://useraccesspoint.autobahn.geant.net/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/">
+  <wsdl:types>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ns1="http://useraccesspoint.autobahn.geant.net/" xmlns:ns2="aai.autobahn.geant.net" xmlns:tns="useraccesspoint.autobahn.geant.net" targetNamespace="useraccesspoint.autobahn.geant.net" version="1.0">
+<xs:import namespace="http://useraccesspoint.autobahn.geant.net/"/>
+<xs:import namespace="aai.autobahn.geant.net"/>
+<xs:complexType name="ServiceRequest">
+<xs:sequence>
+<xs:element minOccurs="0" name="userName" type="xs:string"/>
+<xs:element minOccurs="0" name="userHomeDomain" type="xs:string"/>
+<xs:element minOccurs="0" name="userEmail" type="xs:string"/>
+<xs:element minOccurs="0" name="justification" type="xs:string"/>
+<xs:element maxOccurs="unbounded" name="reservations" nillable="true" type="tns:ReservationRequest"/>
+</xs:sequence>
+</xs:complexType>
+<xs:complexType name="ReservationRequest">
+<xs:sequence>
+<xs:element minOccurs="0" name="startPort" type="tns:PortType"/>
+<xs:element minOccurs="0" name="endPort" type="tns:PortType"/>
+<xs:element minOccurs="0" name="startTime" type="xs:dateTime"/>
+<xs:element minOccurs="0" name="endTime" type="xs:dateTime"/>
+<xs:element minOccurs="0" name="priority" type="ns1:priority"/>
+<xs:element minOccurs="0" name="description" type="xs:string"/>
+<xs:element name="capacity" type="xs:long"/>
+<xs:element minOccurs="0" name="userInclude" type="tns:PathInfo"/>
+<xs:element minOccurs="0" name="userExclude" type="tns:PathInfo"/>
+<xs:element name="mtu" type="xs:int"/>
+<xs:element name="maxDelay" type="xs:int"/>
+<xs:element minOccurs="0" name="resiliency" type="ns1:resiliency"/>
+<xs:element name="bidirectional" type="xs:boolean"/>
+<xs:element name="processNow" type="xs:boolean"/>
+<xs:element minOccurs="0" name="authParameters" type="ns2:UserAuthParameters"/>
+</xs:sequence>
+</xs:complexType>
+<xs:complexType name="PortType">
+<xs:sequence>
+<xs:element minOccurs="0" name="address" type="xs:string"/>
+<xs:element minOccurs="0" name="mode" type="ns1:mode"/>
+<xs:element name="vlan" type="xs:int"/>
+<xs:element minOccurs="0" name="description" type="xs:string"/>
+<xs:element name="isIdcp" type="xs:boolean"/>
+<xs:element name="isClient" type="xs:boolean"/>
+</xs:sequence>
+</xs:complexType>
+<xs:complexType name="PathInfo">
+<xs:sequence>
+<xs:element maxOccurs="unbounded" minOccurs="0" name="domains" nillable="true" type="xs:string"/>
+<xs:element maxOccurs="unbounded" minOccurs="0" name="links" nillable="true" type="xs:string"/>
+</xs:sequence>
+</xs:complexType>
+<xs:complexType name="ModifyRequest">
+<xs:sequence>
+<xs:element minOccurs="0" name="resId" type="xs:string"/>
+<xs:element minOccurs="0" name="startTime" type="xs:dateTime"/>
+<xs:element minOccurs="0" name="endTime" type="xs:dateTime"/>
+</xs:sequence>
+</xs:complexType>
+<xs:complexType name="ServiceResponse">
+<xs:sequence>
+<xs:element minOccurs="0" name="userName" type="xs:string"/>
+<xs:element minOccurs="0" name="userHomeDomain" type="xs:string"/>
+<xs:element minOccurs="0" name="userEmail" type="xs:string"/>
+<xs:element maxOccurs="unbounded" name="reservations" nillable="true" type="tns:ReservationResponse"/>
+</xs:sequence>
+</xs:complexType>
+<xs:complexType name="ReservationResponse">
+<xs:sequence>
+<xs:element minOccurs="0" name="bodID" type="xs:string"/>
+<xs:element minOccurs="0" name="state" type="ns1:state"/>
+<xs:element minOccurs="0" name="message" type="xs:string"/>
+<xs:element minOccurs="0" name="startPort" type="xs:string"/>
+<xs:element minOccurs="0" name="endPort" type="xs:string"/>
+<xs:element minOccurs="0" name="startTime" type="xs:dateTime"/>
+<xs:element minOccurs="0" name="endTime" type="xs:dateTime"/>
+<xs:element minOccurs="0" name="priority" type="ns1:priority"/>
+<xs:element minOccurs="0" name="description" type="xs:string"/>
+<xs:element name="capacity" type="xs:long"/>
+<xs:element minOccurs="0" name="userInclude" type="tns:PathInfo"/>
+<xs:element minOccurs="0" name="userExclude" type="tns:PathInfo"/>
+<xs:element name="userVlanId" type="xs:int"/>
+<xs:element name="mtu" type="xs:int"/>
+<xs:element name="maxDelay" type="xs:int"/>
+<xs:element minOccurs="0" name="resiliency" type="ns1:resiliency"/>
+<xs:element name="bidirectional" type="xs:boolean"/>
+</xs:sequence>
+</xs:complexType>
+</xs:schema>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ns1="useraccesspoint.autobahn.geant.net" xmlns:tns="http://useraccesspoint.autobahn.geant.net/" attributeFormDefault="unqualified" elementFormDefault="unqualified" targetNamespace="http://useraccesspoint.autobahn.geant.net/">
+<xs:import namespace="useraccesspoint.autobahn.geant.net"/>
+<xs:element name="cancelService" type="tns:cancelService"/>
+<xs:element name="cancelServiceResponse" type="tns:cancelServiceResponse"/>
+<xs:element name="checkReservationPossibility" type="tns:checkReservationPossibility"/>
+<xs:element name="checkReservationPossibilityResponse" type="tns:checkReservationPossibilityResponse"/>
+<xs:element name="getAllClientPorts" type="tns:getAllClientPorts"/>
+<xs:element name="getAllClientPortsResponse" type="tns:getAllClientPortsResponse"/>
+<xs:element name="getAllDomains" type="tns:getAllDomains"/>
+<xs:element name="getAllDomainsResponse" type="tns:getAllDomainsResponse"/>
+<xs:element name="getAllDomains_NonClient" type="tns:getAllDomains_NonClient"/>
+<xs:element name="getAllDomains_NonClientResponse" type="tns:getAllDomains_NonClientResponse"/>
+<xs:element name="getAllLinks" type="tns:getAllLinks"/>
+<xs:element name="getAllLinksResponse" type="tns:getAllLinksResponse"/>
+<xs:element name="getAllLinks_NonClient" type="tns:getAllLinks_NonClient"/>
+<xs:element name="getAllLinks_NonClientResponse" type="tns:getAllLinks_NonClientResponse"/>
+<xs:element name="getDomainClientPorts" type="tns:getDomainClientPorts"/>
+<xs:element name="getDomainClientPortsResponse" type="tns:getDomainClientPortsResponse"/>
+<xs:element name="getIdcpPorts" type="tns:getIdcpPorts"/>
+<xs:element name="getIdcpPortsResponse" type="tns:getIdcpPortsResponse"/>
+<xs:element name="modifyReservation" type="tns:modifyReservation"/>
+<xs:element name="modifyReservationResponse" type="tns:modifyReservationResponse"/>
+<xs:element name="queryService" type="tns:queryService"/>
+<xs:element name="queryServiceResponse" type="tns:queryServiceResponse"/>
+<xs:element name="registerCallback" type="tns:registerCallback"/>
+<xs:element name="registerCallbackResponse" type="tns:registerCallbackResponse"/>
+<xs:element name="submitService" type="tns:submitService"/>
+<xs:element name="submitServiceAndRegister" type="tns:submitServiceAndRegister"/>
+<xs:element name="submitServiceAndRegisterResponse" type="tns:submitServiceAndRegisterResponse"/>
+<xs:element name="submitServiceResponse" type="tns:submitServiceResponse"/>
+<xs:complexType name="registerCallback">
+<xs:sequence>
+<xs:element minOccurs="0" name="serviceID" type="xs:string"/>
+<xs:element minOccurs="0" name="url" type="xs:string"/>
+</xs:sequence>
+</xs:complexType>
+<xs:complexType name="registerCallbackResponse">
+<xs:sequence/>
+</xs:complexType>
+<xs:complexType name="submitServiceAndRegister">
+<xs:sequence>
+<xs:element minOccurs="0" name="request" type="ns1:ServiceRequest"/>
+<xs:element minOccurs="0" name="url" type="xs:string"/>
+</xs:sequence>
+</xs:complexType>
+<xs:complexType name="submitServiceAndRegisterResponse">
+<xs:sequence>
+<xs:element minOccurs="0" name="serviceID" type="xs:string"/>
+</xs:sequence>
+</xs:complexType>
+<xs:complexType name="getAllClientPorts">
+<xs:sequence/>
+</xs:complexType>
+<xs:complexType name="getAllClientPortsResponse">
+<xs:sequence>
+<xs:element maxOccurs="unbounded" minOccurs="0" name="PortTypes" type="ns1:PortType"/>
+</xs:sequence>
+</xs:complexType>
+<xs:complexType name="getAllLinks">
+<xs:sequence/>
+</xs:complexType>
+<xs:complexType name="getAllLinksResponse">
+<xs:sequence>
+<xs:element maxOccurs="unbounded" minOccurs="0" name="Links" type="xs:string"/>
+</xs:sequence>
+</xs:complexType>
+<xs:complexType name="checkReservationPossibility">
+<xs:sequence>
+<xs:element minOccurs="0" name="request" type="ns1:ReservationRequest"/>
+</xs:sequence>
+</xs:complexType>
+<xs:complexType name="checkReservationPossibilityResponse">
+<xs:sequence>
+<xs:element name="Possibility" type="xs:boolean"/>
+</xs:sequence>
+</xs:complexType>
+<xs:complexType name="cancelService">
+<xs:sequence>
+<xs:element minOccurs="0" name="serviceID" type="xs:string"/>
+</xs:sequence>
+</xs:complexType>
+<xs:complexType name="cancelServiceResponse">
+<xs:sequence/>
+</xs:complexType>
+<xs:complexType name="getAllLinks_NonClient">
+<xs:sequence/>
+</xs:complexType>
+<xs:complexType name="getAllLinks_NonClientResponse">
+<xs:sequence>
+<xs:element maxOccurs="unbounded" minOccurs="0" name="Links" type="xs:string"/>
+</xs:sequence>
+</xs:complexType>
+<xs:complexType name="submitService">
+<xs:sequence>
+<xs:element minOccurs="0" name="request" type="ns1:ServiceRequest"/>
+</xs:sequence>
+</xs:complexType>
+<xs:complexType name="submitServiceResponse">
+<xs:sequence>
+<xs:element minOccurs="0" name="serviceID" type="xs:string"/>
+</xs:sequence>
+</xs:complexType>
+<xs:complexType name="modifyReservation">
+<xs:sequence>
+<xs:element minOccurs="0" name="request" type="ns1:ModifyRequest"/>
+</xs:sequence>
+</xs:complexType>
+<xs:complexType name="modifyReservationResponse">
+<xs:sequence/>
+</xs:complexType>
+<xs:complexType name="queryService">
+<xs:sequence>
+<xs:element minOccurs="0" name="serviceID" type="xs:string"/>
+</xs:sequence>
+</xs:complexType>
+<xs:complexType name="queryServiceResponse">
+<xs:sequence>
+<xs:element minOccurs="0" name="ServiceResponse" type="ns1:ServiceResponse"/>
+</xs:sequence>
+</xs:complexType>
+<xs:complexType name="getIdcpPorts">
+<xs:sequence/>
+</xs:complexType>
+<xs:complexType name="getIdcpPortsResponse">
+<xs:sequence>
+<xs:element maxOccurs="unbounded" minOccurs="0" name="PortTypes" type="ns1:PortType"/>
+</xs:sequence>
+</xs:complexType>
+<xs:complexType name="getAllDomains">
+<xs:sequence/>
+</xs:complexType>
+<xs:complexType name="getAllDomainsResponse">
+<xs:sequence>
+<xs:element maxOccurs="unbounded" minOccurs="0" name="Domains" type="xs:string"/>
+</xs:sequence>
+</xs:complexType>
+<xs:complexType name="getDomainClientPorts">
+<xs:sequence/>
+</xs:complexType>
+<xs:complexType name="getDomainClientPortsResponse">
+<xs:sequence>
+<xs:element maxOccurs="unbounded" minOccurs="0" name="PortTypes" type="ns1:PortType"/>
+</xs:sequence>
+</xs:complexType>
+<xs:complexType name="getAllDomains_NonClient">
+<xs:sequence/>
+</xs:complexType>
+<xs:complexType name="getAllDomains_NonClientResponse">
+<xs:sequence>
+<xs:element maxOccurs="unbounded" minOccurs="0" name="Domains" type="xs:string"/>
+</xs:sequence>
+</xs:complexType>
+<xs:simpleType name="mode">
+<xs:restriction base="xs:string">
+<xs:enumeration value="VLAN"/>
+<xs:enumeration value="UNTAGGED"/>
+<xs:enumeration value="TRANSPARENT"/>
+</xs:restriction>
+</xs:simpleType>
+<xs:simpleType name="priority">
+<xs:restriction base="xs:string">
+<xs:enumeration value="NORMAL"/>
+<xs:enumeration value="HIGH"/>
+<xs:enumeration value="HIGHEST"/>
+</xs:restriction>
+</xs:simpleType>
+<xs:simpleType name="resiliency">
+<xs:restriction base="xs:string">
+<xs:enumeration value="NONE"/>
+<xs:enumeration value="ONE_TO_ONE"/>
+<xs:enumeration value="ONE_PLUS_ONE"/>
+</xs:restriction>
+</xs:simpleType>
+<xs:simpleType name="state">
+<xs:restriction base="xs:string">
+<xs:enumeration value="ACCEPTED"/>
+<xs:enumeration value="PATHFINDING"/>
+<xs:enumeration value="LOCAL_CHECK"/>
+<xs:enumeration value="SCHEDULING"/>
+<xs:enumeration value="SCHEDULED"/>
+<xs:enumeration value="CANCELLING"/>
+<xs:enumeration value="WITHDRAWING"/>
+<xs:enumeration value="DEFERRED_CANCEL"/>
+<xs:enumeration value="ACTIVATING"/>
+<xs:enumeration value="ACTIVE"/>
+<xs:enumeration value="FINISHING"/>
+<xs:enumeration value="FINISHED"/>
+<xs:enumeration value="CANCELLED"/>
+<xs:enumeration value="FAILED"/>
+</xs:restriction>
+</xs:simpleType>
+<xs:element name="UserAccessPointException" type="tns:UserAccessPointException"/>
+<xs:complexType name="UserAccessPointException">
+<xs:sequence/>
+</xs:complexType>
+</xs:schema>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="aai.autobahn.geant.net" version="1.0">
+<xs:complexType name="UserAuthParameters">
+<xs:sequence>
+<xs:element minOccurs="0" name="identifier" type="xs:string"/>
+<xs:element minOccurs="0" name="organization" type="xs:string"/>
+<xs:element minOccurs="0" name="projectMembership" type="xs:string"/>
+<xs:element minOccurs="0" name="projectRole" type="xs:string"/>
+<xs:element minOccurs="0" name="email" type="xs:string"/>
+</xs:sequence>
+</xs:complexType>
+</xs:schema>
+  </wsdl:types>
+  <wsdl:message name="cancelService">
+    <wsdl:part name="parameters" element="tns:cancelService">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="queryServiceResponse">
+    <wsdl:part name="parameters" element="tns:queryServiceResponse">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getAllClientPortsResponse">
+    <wsdl:part name="parameters" element="tns:getAllClientPortsResponse">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="modifyReservation">
+    <wsdl:part name="parameters" element="tns:modifyReservation">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getAllLinks_NonClientResponse">
+    <wsdl:part name="parameters" element="tns:getAllLinks_NonClientResponse">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="UserAccessPointException">
+    <wsdl:part name="UserAccessPointException" element="tns:UserAccessPointException">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="submitServiceResponse">
+    <wsdl:part name="parameters" element="tns:submitServiceResponse">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getAllDomains_NonClientResponse">
+    <wsdl:part name="parameters" element="tns:getAllDomains_NonClientResponse">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getAllLinks_NonClient">
+    <wsdl:part name="parameters" element="tns:getAllLinks_NonClient">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getIdcpPortsResponse">
+    <wsdl:part name="parameters" element="tns:getIdcpPortsResponse">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="checkReservationPossibility">
+    <wsdl:part name="parameters" element="tns:checkReservationPossibility">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getAllDomains_NonClient">
+    <wsdl:part name="parameters" element="tns:getAllDomains_NonClient">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getAllLinksResponse">
+    <wsdl:part name="parameters" element="tns:getAllLinksResponse">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="cancelServiceResponse">
+    <wsdl:part name="parameters" element="tns:cancelServiceResponse">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="queryService">
+    <wsdl:part name="parameters" element="tns:queryService">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="submitServiceAndRegister">
+    <wsdl:part name="parameters" element="tns:submitServiceAndRegister">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getIdcpPorts">
+    <wsdl:part name="parameters" element="tns:getIdcpPorts">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getAllClientPorts">
+    <wsdl:part name="parameters" element="tns:getAllClientPorts">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="submitService">
+    <wsdl:part name="parameters" element="tns:submitService">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="registerCallbackResponse">
+    <wsdl:part name="parameters" element="tns:registerCallbackResponse">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="registerCallback">
+    <wsdl:part name="parameters" element="tns:registerCallback">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getDomainClientPortsResponse">
+    <wsdl:part name="parameters" element="tns:getDomainClientPortsResponse">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="checkReservationPossibilityResponse">
+    <wsdl:part name="parameters" element="tns:checkReservationPossibilityResponse">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="submitServiceAndRegisterResponse">
+    <wsdl:part name="parameters" element="tns:submitServiceAndRegisterResponse">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="modifyReservationResponse">
+    <wsdl:part name="parameters" element="tns:modifyReservationResponse">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getAllDomains">
+    <wsdl:part name="parameters" element="tns:getAllDomains">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getAllDomainsResponse">
+    <wsdl:part name="parameters" element="tns:getAllDomainsResponse">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getDomainClientPorts">
+    <wsdl:part name="parameters" element="tns:getDomainClientPorts">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="getAllLinks">
+    <wsdl:part name="parameters" element="tns:getAllLinks">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:portType name="UserAccessPoint">
+    <wsdl:operation name="registerCallback">
+      <wsdl:input name="registerCallback" message="tns:registerCallback">
+    </wsdl:input>
+      <wsdl:output name="registerCallbackResponse" message="tns:registerCallbackResponse">
+    </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="submitServiceAndRegister">
+      <wsdl:input name="submitServiceAndRegister" message="tns:submitServiceAndRegister">
+    </wsdl:input>
+      <wsdl:output name="submitServiceAndRegisterResponse" message="tns:submitServiceAndRegisterResponse">
+    </wsdl:output>
+      <wsdl:fault name="UserAccessPointException" message="tns:UserAccessPointException">
+    </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="getAllClientPorts">
+      <wsdl:input name="getAllClientPorts" message="tns:getAllClientPorts">
+    </wsdl:input>
+      <wsdl:output name="getAllClientPortsResponse" message="tns:getAllClientPortsResponse">
+    </wsdl:output>
+      <wsdl:fault name="UserAccessPointException" message="tns:UserAccessPointException">
+    </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="getAllLinks">
+      <wsdl:input name="getAllLinks" message="tns:getAllLinks">
+    </wsdl:input>
+      <wsdl:output name="getAllLinksResponse" message="tns:getAllLinksResponse">
+    </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="checkReservationPossibility">
+      <wsdl:input name="checkReservationPossibility" message="tns:checkReservationPossibility">
+    </wsdl:input>
+      <wsdl:output name="checkReservationPossibilityResponse" message="tns:checkReservationPossibilityResponse">
+    </wsdl:output>
+      <wsdl:fault name="UserAccessPointException" message="tns:UserAccessPointException">
+    </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="cancelService">
+      <wsdl:input name="cancelService" message="tns:cancelService">
+    </wsdl:input>
+      <wsdl:output name="cancelServiceResponse" message="tns:cancelServiceResponse">
+    </wsdl:output>
+      <wsdl:fault name="UserAccessPointException" message="tns:UserAccessPointException">
+    </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="getAllLinks_NonClient">
+      <wsdl:input name="getAllLinks_NonClient" message="tns:getAllLinks_NonClient">
+    </wsdl:input>
+      <wsdl:output name="getAllLinks_NonClientResponse" message="tns:getAllLinks_NonClientResponse">
+    </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="submitService">
+      <wsdl:input name="submitService" message="tns:submitService">
+    </wsdl:input>
+      <wsdl:output name="submitServiceResponse" message="tns:submitServiceResponse">
+    </wsdl:output>
+      <wsdl:fault name="UserAccessPointException" message="tns:UserAccessPointException">
+    </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="modifyReservation">
+      <wsdl:input name="modifyReservation" message="tns:modifyReservation">
+    </wsdl:input>
+      <wsdl:output name="modifyReservationResponse" message="tns:modifyReservationResponse">
+    </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="queryService">
+      <wsdl:input name="queryService" message="tns:queryService">
+    </wsdl:input>
+      <wsdl:output name="queryServiceResponse" message="tns:queryServiceResponse">
+    </wsdl:output>
+      <wsdl:fault name="UserAccessPointException" message="tns:UserAccessPointException">
+    </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="getIdcpPorts">
+      <wsdl:input name="getIdcpPorts" message="tns:getIdcpPorts">
+    </wsdl:input>
+      <wsdl:output name="getIdcpPortsResponse" message="tns:getIdcpPortsResponse">
+    </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="getAllDomains">
+      <wsdl:input name="getAllDomains" message="tns:getAllDomains">
+    </wsdl:input>
+      <wsdl:output name="getAllDomainsResponse" message="tns:getAllDomainsResponse">
+    </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="getDomainClientPorts">
+      <wsdl:input name="getDomainClientPorts" message="tns:getDomainClientPorts">
+    </wsdl:input>
+      <wsdl:output name="getDomainClientPortsResponse" message="tns:getDomainClientPortsResponse">
+    </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="getAllDomains_NonClient">
+      <wsdl:input name="getAllDomains_NonClient" message="tns:getAllDomains_NonClient">
+    </wsdl:input>
+      <wsdl:output name="getAllDomains_NonClientResponse" message="tns:getAllDomains_NonClientResponse">
+    </wsdl:output>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="UserAccessPointServiceSoapBinding" type="tns:UserAccessPoint">
+    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="registerCallback">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="registerCallback">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="registerCallbackResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="getAllClientPorts">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="getAllClientPorts">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="getAllClientPortsResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="UserAccessPointException">
+        <soap:fault name="UserAccessPointException" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="submitServiceAndRegister">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="submitServiceAndRegister">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="submitServiceAndRegisterResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="UserAccessPointException">
+        <soap:fault name="UserAccessPointException" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="getAllLinks">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="getAllLinks">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="getAllLinksResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="cancelService">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="cancelService">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="cancelServiceResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="UserAccessPointException">
+        <soap:fault name="UserAccessPointException" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="checkReservationPossibility">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="checkReservationPossibility">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="checkReservationPossibilityResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="UserAccessPointException">
+        <soap:fault name="UserAccessPointException" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="getAllLinks_NonClient">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="getAllLinks_NonClient">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="getAllLinks_NonClientResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="submitService">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="submitService">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="submitServiceResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="UserAccessPointException">
+        <soap:fault name="UserAccessPointException" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="modifyReservation">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="modifyReservation">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="modifyReservationResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="getIdcpPorts">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="getIdcpPorts">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="getIdcpPortsResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="queryService">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="queryService">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="queryServiceResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="UserAccessPointException">
+        <soap:fault name="UserAccessPointException" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+    <wsdl:operation name="getAllDomains">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="getAllDomains">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="getAllDomainsResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="getDomainClientPorts">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="getDomainClientPorts">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="getDomainClientPortsResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="getAllDomains_NonClient">
+      <soap:operation soapAction="" style="document"/>
+      <wsdl:input name="getAllDomains_NonClient">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="getAllDomains_NonClientResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="UserAccessPoint">
+    <wsdl:port name="UserAccessPointPort" binding="tns:UserAccessPointServiceSoapBinding">
+      <soap:address location="http://localhost:9090/UserAccessPointPort"/>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>

--- a/extensions/bundles/bod.autobahn/src/main/resources/OSGI-INF/blueprint/core.xml
+++ b/extensions/bundles/bod.autobahn/src/main/resources/OSGI-INF/blueprint/core.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
+    <bean id="protocol-session-factory"
+          class="org.opennaas.extensions.bod.autobahn.protocol.AutobahnProtocolSessionFactory"/>
+    <bean id="bod-action-set"
+          class="org.opennaas.extensions.bod.autobahn.bod.BoDActionSet"/>
+    <bean id="queue-action-set"
+          class="org.opennaas.extensions.bod.autobahn.queue.QueueActionSet"/>
+
+    <service ref="protocol-session-factory"
+             interface="org.opennaas.core.resources.protocol.IProtocolSessionFactory">
+        <service-properties>
+            <entry key="protocol" value="autobahn"/>
+            <entry key="protocol.version" value="1.0.0"/>
+        </service-properties>
+    </service>
+
+    <service ref="bod-action-set"
+             interface="org.opennaas.core.resources.action.IActionSet">
+        <service-properties>
+            <entry key="actionset.name" value="autobahn"/>
+            <entry key="actionset.capability" value="l2bod"/>
+            <entry key="actionset.version" value="1.0"/>
+        </service-properties>
+    </service>
+
+    <service ref="queue-action-set"
+             interface="org.opennaas.core.resources.action.IActionSet">
+        <service-properties>
+            <entry key="actionset.name" value="autobahn"/>
+            <entry key="actionset.capability" value="queue"/>
+            <entry key="actionset.version" value="1.0"/>
+        </service-properties>
+    </service>
+</blueprint>

--- a/extensions/bundles/bod.capability.l2bod/pom.xml
+++ b/extensions/bundles/bod.capability.l2bod/pom.xml
@@ -1,20 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<!-- Maven parent  -->
   	<parent>
     	<artifactId>org.opennaas.extensions.bundles</artifactId>
     	<groupId>org.opennaas</groupId>
     	<version>1.0.0-SNAPSHOT</version>
   	</parent>
-	<!--  POM id -->
+
   	<artifactId>org.opennaas.extensions.bod.capability.l2bod</artifactId>
-	<!--  Maven configuration -->
 	<modelVersion>4.0.0</modelVersion>
 	<packaging>bundle</packaging>
 	<name>BoD :: L2BoD capability</name>
 	<description>L2BoD Capability Implementation</description>
+
 	<dependencies>
-		<!-- mantychore dependencies -->
 		<dependency>
 			<groupId>org.opennaas</groupId>
 			<artifactId>org.opennaas.core.resources</artifactId>
@@ -31,38 +29,31 @@
 			<groupId>org.opennaas</groupId>
 			<artifactId>org.opennaas.extensions.bod.actionsets.dummy</artifactId>
 		</dependency>
-		<!--  auxiliar methods to use with commands -->
+		<dependency>
+			<groupId>com.googlecode.guava-osgi</groupId>
+			<artifactId>guava-osgi</artifactId>
+			<version>${guava.version}</version>
+		</dependency>
 		<dependency>
 			<groupId>org.apache.karaf.shell</groupId>
 			<artifactId>org.apache.karaf.shell.console</artifactId>
 		</dependency>
 	</dependencies>
+
 	<build>
 		<plugins>
-			<plugin>
-				<groupId>org.ops4j</groupId>
-				<artifactId>maven-pax-plugin</artifactId>
-			</plugin>
 			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>
 				<extensions>true</extensions>
-				<!--
-					| the following instructions build a simple set of public/private
-					classes into an OSGi bundle
-				-->
 				<configuration>
 					<instructions>
 						<Bundle-Activator>org.opennaas.extensions.bod.capability.l2bod.Activator</Bundle-Activator>
-						<!--
-							| assume public classes are in the top package, and private
-							classes are under ".internal"
-						-->
 						<Import-Package>
   							org.slf4j,
 							org.apache.felix.service.command, <!--  necessary to do karaf commands -->
 							*
-							</Import-Package>
+						</Import-Package>
 						<Export-Package>
 							org.opennaas.extensions.bod.capability.l2bod;version="${project.version}"
 						</Export-Package>

--- a/extensions/bundles/bod.capability.l2bod/src/main/java/org/opennaas/extensions/bod/capability/l2bod/shell/RequestConnectionCommand.java
+++ b/extensions/bundles/bod.capability.l2bod/src/main/java/org/opennaas/extensions/bod/capability/l2bod/shell/RequestConnectionCommand.java
@@ -1,11 +1,14 @@
 package org.opennaas.extensions.bod.capability.l2bod.shell;
 
-import java.util.ArrayList;
+import com.google.common.collect.Lists;
+
 import java.util.List;
+import java.util.NoSuchElementException;
 
 import org.opennaas.extensions.network.model.NetworkModel;
 import org.opennaas.extensions.network.model.NetworkModelHelper;
 import org.opennaas.extensions.network.model.topology.Interface;
+import org.opennaas.extensions.network.model.topology.NetworkElement;
 
 import org.apache.felix.gogo.commands.Argument;
 import org.apache.felix.gogo.commands.Command;
@@ -59,18 +62,20 @@ public class RequestConnectionCommand extends GenericKarafCommand {
 	 *
 	 * @return list of interfaces
 	 */
-	private List<Interface> getInterfaces(NetworkModel networkModel) {
+	private List<Interface> getInterfaces(NetworkModel model)
+	{
+		return Lists.newArrayList(getInterface(model, interfaceName1),
+								  getInterface(model, interfaceName2));
+	}
 
-		List<Interface> listInterfaces = new ArrayList<Interface>();
-
-		// Add Interface 1
-		Interface interface1 = NetworkModelHelper.getInterfaceByName(networkModel.getNetworkElements(), interfaceName1);
-		listInterfaces.add(interface1);
-
-		// Add Interface 2
-		Interface interface2 = NetworkModelHelper.getInterfaceByName(networkModel.getNetworkElements(), interfaceName2);
-		listInterfaces.add(interface2);
-
-		return listInterfaces;
+	private Interface getInterface(NetworkModel model, String name)
+	{
+		List<NetworkElement> elements = model.getNetworkElements();
+		Interface i =
+			NetworkModelHelper.getInterfaceByName(elements, name);
+		if (i == null) {
+			throw new NoSuchElementException("No such interface: " + name);
+		}
+		return i;
 	}
 }

--- a/extensions/bundles/bod.capability.l2bod/src/main/java/org/opennaas/extensions/bod/capability/l2bod/shell/ShutdownConnectionCommand.java
+++ b/extensions/bundles/bod.capability.l2bod/src/main/java/org/opennaas/extensions/bod/capability/l2bod/shell/ShutdownConnectionCommand.java
@@ -1,11 +1,14 @@
 package org.opennaas.extensions.bod.capability.l2bod.shell;
 
-import java.util.ArrayList;
+import com.google.common.collect.Lists;
+
 import java.util.List;
+import java.util.NoSuchElementException;
 
 import org.opennaas.extensions.network.model.NetworkModel;
 import org.opennaas.extensions.network.model.NetworkModelHelper;
 import org.opennaas.extensions.network.model.topology.Interface;
+import org.opennaas.extensions.network.model.topology.NetworkElement;
 
 import org.apache.felix.gogo.commands.Argument;
 import org.apache.felix.gogo.commands.Command;
@@ -58,19 +61,20 @@ public class ShutdownConnectionCommand extends GenericKarafCommand {
 	 *
 	 * @return list of interfaces
 	 */
-	private List<Interface> getInterfaces(NetworkModel networkModel) {
-
-		List<Interface> listInterfaces = new ArrayList<Interface>();
-
-		// Add Interface 1
-		Interface interface1 = NetworkModelHelper.getInterfaceByName(networkModel.getNetworkElements(), interfaceName1);
-		listInterfaces.add(interface1);
-
-		// Add Interface 2
-		Interface interface2 = NetworkModelHelper.getInterfaceByName(networkModel.getNetworkElements(), interfaceName2);
-		listInterfaces.add(interface2);
-
-		return listInterfaces;
+	private List<Interface> getInterfaces(NetworkModel model)
+	{
+		return Lists.newArrayList(getInterface(model, interfaceName1),
+								  getInterface(model, interfaceName2));
 	}
 
+	private Interface getInterface(NetworkModel model, String name)
+	{
+		List<NetworkElement> elements = model.getNetworkElements();
+		Interface i =
+			NetworkModelHelper.getInterfaceByName(elements, name);
+		if (i == null) {
+			throw new NoSuchElementException("No such interface: " + name);
+		}
+		return i;
+	}
 }

--- a/extensions/bundles/pom.xml
+++ b/extensions/bundles/pom.xml
@@ -54,5 +54,6 @@
 		<module>bod.repository</module>
 		<module>bod.capability.l2bod</module>
 		<module>bod.actionsets.dummy</module>
+                <module>bod.autobahn</module>
 	</modules>
 </project>

--- a/extensions/bundles/queuemanager/src/main/java/org/opennaas/extensions/queuemanager/QueueManager.java
+++ b/extensions/bundles/queuemanager/src/main/java/org/opennaas/extensions/queuemanager/QueueManager.java
@@ -47,7 +47,7 @@ public class QueueManager extends AbstractCapability implements
 
 	/**
 	 * Constructor to test the component
-	 * 
+	 *
 	 * @param queueDescriptor
 	 */
 	public QueueManager(CapabilityDescriptor queueDescriptor) {
@@ -151,6 +151,8 @@ public class QueueManager extends AbstractCapability implements
 
 				}
 			} catch (Exception e) {
+				log.warn("Failed to execute queue", e);
+
 				// restore action
 				assert protocolSessionManager != null;
 				try {
@@ -310,7 +312,7 @@ public class QueueManager extends AbstractCapability implements
 	}
 
 	/*
-	 * 
+	 *
 	 * @see org.opennaas.core.resources.capability.AbstractCapability#initializeCapability()
 	 */
 	@Override
@@ -340,7 +342,7 @@ public class QueueManager extends AbstractCapability implements
 
 	/**
 	 * Refresh the actions of the queue
-	 * 
+	 *
 	 * @throws CapabilityException
 	 */
 	private void sendRefresh() throws CapabilityException {
@@ -401,8 +403,8 @@ public class QueueManager extends AbstractCapability implements
 
 	/**
 	 * Create a new resource descriptor with the name = nameResource <br>
-	 * 
-	 * 
+	 *
+	 *
 	 * @param resourceDescriptor
 	 * @param nameResource
 	 * @return the resourceDescriptor
@@ -477,7 +479,7 @@ public class QueueManager extends AbstractCapability implements
 
 	/**
 	 * Execute the actions of the queue
-	 * 
+	 *
 	 * @param protocolSessionManager
 	 * @return the action response
 	 * @throws ActionException
@@ -503,7 +505,7 @@ public class QueueManager extends AbstractCapability implements
 
 	/**
 	 * Execute the confirm action of the queue
-	 * 
+	 *
 	 * @param protocolSessionManager
 	 * @return the action response
 	 * @throws ActionException
@@ -524,7 +526,7 @@ public class QueueManager extends AbstractCapability implements
 
 	/**
 	 * Execute the prepare action of the queue
-	 * 
+	 *
 	 * @param protocolSessionManager
 	 * @return the action response
 	 * @throws ActionException
@@ -540,7 +542,7 @@ public class QueueManager extends AbstractCapability implements
 
 	/**
 	 * Execute the restore action of the queue
-	 * 
+	 *
 	 * @param protocolSessionManager
 	 * @return the action response
 	 * @throws ActionException
@@ -556,7 +558,7 @@ public class QueueManager extends AbstractCapability implements
 
 	/**
 	 * Get the action list of the queue
-	 * 
+	 *
 	 * @return a list of IAction
 	 */
 	private List<IAction> getQueue() {
@@ -572,7 +574,7 @@ public class QueueManager extends AbstractCapability implements
 	/**
 	 * Implementation for the execution of a single action. <br>
 	 * Clean the queue, add an action and send the message
-	 * 
+	 *
 	 * @param action
 	 * @return the queue response
 	 * @throws CapabilityException
@@ -631,7 +633,7 @@ public class QueueManager extends AbstractCapability implements
 
 	/**
 	 * Unregister the capability
-	 * 
+	 *
 	 * @throws InvalidSyntaxException
 	 * @throws BundleException
 	 */

--- a/platform/pom.xml
+++ b/platform/pom.xml
@@ -54,6 +54,10 @@
 		</dependency>
 		<dependency>
 			<groupId>org.opennaas</groupId>
+			<artifactId>org.opennaas.extensions.bod.autobahn</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.opennaas</groupId>
 			<artifactId>org.opennaas.core.tests-mockprofile</artifactId>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,11 @@
 			</dependency>
 			<dependency>
 				<groupId>org.opennaas</groupId>
+				<artifactId>org.opennaas.extensions.bod.autobahn</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.opennaas</groupId>
 				<artifactId>org.opennaas.core.tests-mockprofile</artifactId>
 				<version>${project.version}</version>
 			</dependency>


### PR DESCRIPTION
This patch adds support for requesting and shutting down
connections via the Autobahn BoD.

This initial version hardcodes most connection parameters due
to lack of support for such parameters in OpenNaaS (bandwidth,
vlan ID, lifetime, etc). Once OpenNaaS BoD support has been
extended, the driver can be extended too. Consider this driver
a use case to drive the OpenNaaS BoD support forward.

The initial version lacks support for queue transactions. This
is because the Autobahn webservice is stateless and does not
support explicit transaction demarcation. Poor man's
transaction support without isolation could be achieved
by rolling back the creation/release manually (by releasing
or recreating), although there is no guarantee that a released
resource can be rereserved (it may have been taken by other
reservations). Implementing this is not straightforward as
OpenNaaS lacks support for a queue context or some other
way of maintaining state accross actions that are part of the
same queue execution. Once such support is added the poor man's
transaction support can be implemented.

The Autobahn driver requires access to both the user access
point and adminstration webservice interfaces of Autobahn.
These are by default published on the same port, so the
protocol context URI is simply the base URI for both services.
Eg:

protocols:context bod:autobahn autobahn http://autobahn.example.org:8080/autobahn/

The driver will internally append "uap" or "adminstration" to
this URI.

Access to the administrative interface is required as it is
otherwise not possible to query the list of existing reservations.

Note that OpenNaaS provides no user interface for inspecting the
model of the BoD resource. You either have to know the network
interfaces of Autobahn (by using the Autobahn GUI) or you have
to inspect the OpenNaaS log files.

Note that the Autobahn reservation process is asynchronous. When
OpenNaaS executes the request action, the driver only submits a
reservation request. Setting up the reservation can possible take
minutes (in multidomain setups). Therefore the driver will create
a link in the resource's model for any reservation not in a
finished state. Autobahn does allow a callback to be registered,
but this requires that OpenNaaS implements a particular webservice
and that there is connectivity from Autobahn to OpenNaaS (no
firewall). In either case, OpenNaaS doesn't know about such
asynchronous changes, so even if we implemented the callback
interface, we wouldn't be able to react to reservation changes
outside the execution of a queue.

As mentioned above, a reservation is represented as a link in
the model. It is set on the source's linkedTo field. Note that
Autobahn supports creating multiple reservations between the
same two ports (interfaces): Each reservation can use a
different VLAN ID. Since an interface in OpenNaaS only has one
linkedTo field, such reservations cannot be represented in
OpenNaaS.

Note that the NSI protocol treats interfaces differently: NSI
uses the concept of a network service endpoint, and such an
endpoint incorporates the VLAN. Ie VLAN isn't a property in NSI.
Instead, if you have two interfaces A and B, and a VLAN range
of 1000-1002, then you have service endpoints A-1000, A-1001,
A-1002, B-1000, B-1001, B-1002 (or whatever naming scheme the
NSA chooses to implement). In that case you can indeed only
have one connection between two endpoints (which would be
interfaces in OpenNaaS). The problem here is that often one
cannot connect all endpoints, eg A-1000 and B-1001 are not
connectable (depends on the hardware, of course). My point is
that BoD systems are sufficiently different from each other
that it may become difficult to make a common abstraction
in OpenNaaS (or that it will require extensive configuration
info to map between OpenNaaS' representation and the
representation in the BoD system - something that would be
a pain to maintain).

Authentication in Autobahn is disabled by default and it not
supported by the initial revision of this driver.

Integration tests are missing. These will be added soon.
