### PR TITLE
Feature/autobahn

### DIFF
--- a/extensions/bundles/bod.autobahn/src/main/java/org/opennaas/extensions/bod/autobahn/bod/RequestConnectionAction.java
+++ b/extensions/bundles/bod.autobahn/src/main/java/org/opennaas/extensions/bod/autobahn/bod/RequestConnectionAction.java
@@ -63,8 +63,12 @@ public class RequestConnectionAction extends AutobahnAction
 
 	protected ServiceRequest
 		createServiceRequest(RequestConnectionParameters request)
-		throws DatatypeConfigurationException
+		throws ActionException, DatatypeConfigurationException
 	{
+		if (!((AutobahnInterface) request.interface1).isLocal()) {
+			throw new ActionException("First interface must be local to this Autobahn domain");
+		}
+
 		boolean processNow =
 			request.startTime.isBefore(DateTime.now().plusSeconds(10));
 

--- a/extensions/bundles/bod.autobahn/src/main/java/org/opennaas/extensions/bod/autobahn/model/AutobahnInterface.java
+++ b/extensions/bundles/bod.autobahn/src/main/java/org/opennaas/extensions/bod/autobahn/model/AutobahnInterface.java
@@ -7,6 +7,7 @@ import org.opennaas.extensions.network.model.topology.Interface;
 public class AutobahnInterface extends Interface
 {
 	private PortType portType;
+	private boolean isLocal;
 
 	public void setPortType(PortType portType)
 	{
@@ -18,13 +19,23 @@ public class AutobahnInterface extends Interface
 		return portType;
 	}
 
+	public void setLocal(boolean isLocal)
+	{
+		this.isLocal = isLocal;
+	}
+
+	public boolean isLocal()
+	{
+		return isLocal;
+	}
+
 	@Override
 	public String toString()
 	{
 		return (portType == null)
 			? super.toString()
-			: (portType.getDescription() == null)
-			? portType.getAddress()
-			: portType.getDescription();
+			: ((portType.getDescription() == null)
+			   ? portType.getAddress()
+			   : portType.getDescription()) + (isLocal ? ",local" : "");
 	}
 }


### PR DESCRIPTION
Autobahn can only establish connections from a domain local interface to
some other interface (which may be local to the Autobahn domain, or in
the domain of some other BoD system).

This patch collects information about which interfaces are local to a
particular Autobahn BoD resource and reject requests for which the first
interface is not local.
