### PR TITLE
Feature/ws prototype

### DIFF
--- a/core/features/src/main/resources/features.xml
+++ b/core/features/src/main/resources/features.xml
@@ -77,6 +77,16 @@
 		<bundle start="false">mvn:org.opennaas/org.opennaas.extensions.fragment.velocity/${project.version}</bundle>
 	</feature>
 
+	<feature name="opennaas-ws" version="${project.version}">		
+		<feature>http</feature>
+		<feature>cxf</feature>
+		
+		<bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.javax-inject/${servicemix.javax-inject.version}</bundle>
+		
+		<bundle>mvn:org.opennaas/org.opennaas.extensions.ws/${project.version}</bundle>
+		<bundle>mvn:org.opennaas/org.opennaas.extensions.ws.proxy/${project.version}</bundle>	
+	</feature>
+
 	<feature name="opennaas-junos" version="${project.version}">
 		<feature version="${project.version}">opennaas-cim</feature>
 		<feature version="${project.version}">opennaas-netconf</feature>
@@ -141,6 +151,7 @@
 	</feature>
 
 	<feature name="opennaas" version="${project.version}">
+		<feature version="${project.version}">opennaas-ws</feature>
 		<feature version="${project.version}">opennaas-router</feature>
 		<feature version="${project.version}">opennaas-network</feature>
 		<feature version="${project.version}">opennaas-bod</feature>

--- a/core/resources/src/main/java/org/opennaas/core/resources/shell/InfoResourcesCommand.java
+++ b/core/resources/src/main/java/org/opennaas/core/resources/shell/InfoResourcesCommand.java
@@ -59,7 +59,8 @@ public class InfoResourcesCommand extends GenericKarafCommand {
 
 						resource = manager.getResource(identifier);
 						Information information = resource.getResourceDescriptor().getInformation();
-						printInfo("Resource ID: " + information.getName());
+						printInfo("Resource Id: " + resource.getResourceIdentifier().getId());
+						printInfo("Resource Name: " + information.getName());
 						printInfo("State: " + resource.getState());
 						printSymbol(horizontalSeparator);
 						printInfo("Resource descriptor ");

--- a/extensions/bundles/pom.xml
+++ b/extensions/bundles/pom.xml
@@ -42,8 +42,6 @@
 		<module>roadm.capability.connections</module>
 		<module>roadm.capability.monitoring</module>
 
-		<module>nexus.tests.helper</module>
-
 		<module>network.model</module>
 		<module>network.repository</module>
 		<module>network.capability.basic</module>
@@ -53,6 +51,8 @@
 		<module>bod.repository</module>
 		<module>bod.capability.l2bod</module>
 		<module>bod.actionsets.dummy</module>
-                <module>bod.autobahn</module>
+        <module>bod.autobahn</module>
+		<module>webservice</module>
+		<module>webservice-proxy</module>
 	</modules>
 </project>

--- a/extensions/bundles/router.model/src/main/java/org/opennaas/extensions/router/model/AdminDomain.java
+++ b/extensions/bundles/router.model/src/main/java/org/opennaas/extensions/router/model/AdminDomain.java
@@ -5,8 +5,10 @@
 
 package org.opennaas.extensions.router.model;
 
-import java.io.*;
-import java.lang.Exception;
+import java.io.Serializable;
+
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlType;
 
 /**
  * This Class contains accessor and mutator methods for all properties defined in the CIM class AdminDomain as well as methods comparable to the
@@ -36,7 +38,7 @@ public class AdminDomain extends System implements Serializable {
 	/**
 	 * The following constants are defined for use with the ValueMap/Values qualified property NameFormat.
 	 */
-
+	@XmlType(name = "AdminDomainNameFormatEnum")
 	public enum NameFormat {
 		OTHER,
 		AUTONOMOUS_SYSTEM,

--- a/extensions/bundles/router.model/src/main/java/org/opennaas/extensions/router/model/ComputerSystem.java
+++ b/extensions/bundles/router.model/src/main/java/org/opennaas/extensions/router/model/ComputerSystem.java
@@ -9,6 +9,8 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.xml.bind.annotation.XmlType;
+
 /**
  * This Class contains accessor and mutator methods for all properties defined in the CIM class ComputerSystem as well as methods comparable to the
  * invokeMethods defined for this class. This Class implements the ComputerSystemBean Interface. The CIM class ComputerSystem is described as follows:
@@ -33,7 +35,7 @@ public class ComputerSystem extends System implements Serializable {
 	/**
 	 * The following constants are defined for use with the ValueMap/Values qualified property NameFormat.
 	 */
-
+	@XmlType(name = "ComputerSystemNameFormatEnum")
 	public enum NameFormat {
 		OTHER,
 		IP,
@@ -291,6 +293,7 @@ public class ComputerSystem extends System implements Serializable {
 	/**
 	 * The following constants are defined for use with the ValueMap/Values qualified property PowerManagementCapabilities.
 	 */
+	@XmlType(name = "ComputerSystemPowerManagementEnum")
 	@Deprecated
 	public enum PowerManagementCapabilities {
 		UNKNOWN,

--- a/extensions/bundles/router.model/src/main/java/org/opennaas/extensions/router/model/IPProtocolEndpoint.java
+++ b/extensions/bundles/router.model/src/main/java/org/opennaas/extensions/router/model/IPProtocolEndpoint.java
@@ -5,8 +5,9 @@
 
 package org.opennaas.extensions.router.model;
 
-import java.io.*;
-import java.lang.Exception;
+import java.io.Serializable;
+
+import javax.xml.bind.annotation.XmlType;
 
 /**
  * This Class contains accessor and mutator methods for all properties defined in the CIM class IPProtocolEndpoint as well as methods comparable to
@@ -194,6 +195,7 @@ public class IPProtocolEndpoint extends ProtocolEndpoint implements
 	/**
 	 * The following constants are defined for use with the ValueMap/Values qualified property AddressType.
 	 */
+	@XmlType(name = "IPProtocolEndpointAddressTypeEnum")
 	@Deprecated
 	public enum AddressType {
 		UNKNOWN,

--- a/extensions/bundles/router.model/src/main/java/org/opennaas/extensions/router/model/LogicalDevice.java
+++ b/extensions/bundles/router.model/src/main/java/org/opennaas/extensions/router/model/LogicalDevice.java
@@ -8,6 +8,8 @@ package org.opennaas.extensions.router.model;
 import java.io.Serializable;
 import java.util.List;
 
+import javax.xml.bind.annotation.XmlType;
+
 /**
  * This Class contains accessor and mutator methods for all properties defined in the CIM class LogicalDevice as well as methods comparable to the
  * invokeMethods defined for this class. This Class implements the LogicalDeviceBean Interface. The CIM class LogicalDevice is described as follows:
@@ -341,6 +343,7 @@ public class LogicalDevice extends EnabledLogicalElement implements
 	/**
 	 * The following constants are defined for use with the ValueMap/Values qualified property PowerManagementCapabilities.
 	 */
+	@XmlType(name = "LogicalDevicePowerManagementEnum")
 	@Deprecated
 	public enum PowerManagementCapabilities {
 		UNKNOWN,

--- a/extensions/bundles/router.model/src/main/java/org/opennaas/extensions/router/model/NextHopIPRoute.java
+++ b/extensions/bundles/router.model/src/main/java/org/opennaas/extensions/router/model/NextHopIPRoute.java
@@ -5,8 +5,9 @@
 
 package org.opennaas.extensions.router.model;
 
-import java.io.*;
-import java.lang.Exception;
+import java.io.Serializable;
+
+import javax.xml.bind.annotation.XmlType;
 
 /**
  * This Class contains accessor and mutator methods for all properties defined in the CIM class NextHopIPRoute as well as methods comparable to the
@@ -170,7 +171,7 @@ public class NextHopIPRoute extends NextHopRoute implements Serializable {
 	/**
 	 * The following constants are defined for use with the ValueMap/Values qualified property AddressType.
 	 */
-
+	@XmlType(name = "NextHopIPRouteAddressTypeEnum")
 	public enum AddressType {
 		UNKNOWN,
 		IPV4,

--- a/extensions/bundles/webservice-proxy/pom.xml
+++ b/extensions/bundles/webservice-proxy/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<!-- Maven parent  -->
+	<parent>
+		<artifactId>org.opennaas.extensions.bundles</artifactId>
+		<groupId>org.opennaas</groupId>
+		<version>1.0.0-SNAPSHOT</version>
+	</parent>
+	<!--  POM id -->
+	<artifactId>org.opennaas.extensions.ws.proxy</artifactId>
+	<!--  Maven configuration -->
+	<modelVersion>4.0.0</modelVersion>
+	<packaging>bundle</packaging>
+	<name>Web Service Proxy</name>
+	<description>Web Service Proxy</description>
+	<dependencies>
+
+	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.ops4j</groupId>
+				<artifactId>maven-pax-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<extensions>true</extensions>
+				<!--
+					| the following instructions build a simple set of public/private
+					classes into an OSGi bundle
+				-->
+				<configuration>
+					<instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                    </instructions>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/extensions/bundles/webservice-proxy/src/main/resources/OSGI-INF/blueprint/core.xml
+++ b/extensions/bundles/webservice-proxy/src/main/resources/OSGI-INF/blueprint/core.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE file
+distributed with this work for additional information regarding copyright ownership. The ASF licenses this file to You under
+the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may
+obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to
+in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under
+the License. -->
+
+<!-- xmlns:ext="http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.0.0" -->
+
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0" xmlns:cxf="http://cxf.apache.org/blueprint/core"
+    xmlns:jaxrs="http://cxf.apache.org/blueprint/jaxrs" xmlns:jaxws="http://cxf.apache.org/blueprint/jaxws"
+    xsi:schemaLocation="
+	http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
+	http://www.osgi.org/xmlns/blueprint-ext/v1.1.0 https://svn.apache.org/repos/asf/aries/tags/blueprint-0.3.1/blueprint-core/src/main/resources/org/apache/aries/blueprint/ext/blueprint-ext.xsd
+	http://cxf.apache.org/blueprint/jaxws http://cxf.apache.org/schemas/blueprint/jaxws.xsd
+	http://cxf.apache.org/blueprint/jaxrs http://cxf.apache.org/schemas/blueprint/jaxrs.xsd
+	http://cxf.apache.org/blueprint/core http://cxf.apache.org/schemas/blueprint/core.xsd
+	http://camel.apache.org/schema/blueprint http://camel.apache.org/schema/blueprint/camel-blueprint.xsd
+	http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0 http://aries.apache.org/schemas/blueprint-cm/blueprint-cm-1.1.0.xsd
+	">
+    
+    <jaxws:client id="chassisCapabilityServiceProxy" serviceClass="org.opennaas.extensions.ws.services.IChassisCapabilityService" address="http://localhost:8182/cxf/chassisCapabilityService" />
+    <service ref="chassisCapabilityServiceProxy" interface="org.opennaas.extensions.ws.services.IChassisCapabilityService" />
+
+</blueprint>

--- a/extensions/bundles/webservice/pom.xml
+++ b/extensions/bundles/webservice/pom.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<!-- Maven parent -->
+	<parent>
+		<artifactId>org.opennaas.extensions.bundles</artifactId>
+		<groupId>org.opennaas</groupId>
+		<version>1.0.0-SNAPSHOT</version>
+	</parent>
+	<!-- POM id -->
+	<artifactId>org.opennaas.extensions.ws</artifactId>
+	<!-- Maven configuration -->
+	<modelVersion>4.0.0</modelVersion>
+	<packaging>bundle</packaging>
+	<name>Web Service</name>
+	<description>Web Service</description>
+	<dependencies>
+		<dependency>
+			<groupId>org.opennaas</groupId>
+			<artifactId>org.opennaas.core.resources</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.opennaas</groupId>
+			<artifactId>org.opennaas.extensions.router.capability.chassis</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.opennaas</groupId>
+			<artifactId>org.opennaas.extensions.router.model</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.servicemix.bundles</groupId>
+			<artifactId>org.apache.servicemix.bundles.javax-inject</artifactId>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.ops4j</groupId>
+				<artifactId>maven-pax-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<extensions>true</extensions>
+				<!-- | the following instructions build a simple set of public/private 
+					classes into an OSGi bundle -->
+				<configuration>
+					<instructions>
+						<Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+					</instructions>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.cxf</groupId>
+				<artifactId>cxf-java2ws-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>generate-wsdl</id>
+						<phase>process-classes</phase>
+						<configuration>
+							<className>org.opennaas.extensions.ws.services.IChassisCapabilityService</className>
+							<genWsdl>true</genWsdl>
+							<verbose>true</verbose>
+						</configuration>
+						<goals>
+							<goal>java2ws</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+		<pluginManagement>
+			<plugins>
+				<!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+				<plugin>
+					<groupId>org.eclipse.m2e</groupId>
+					<artifactId>lifecycle-mapping</artifactId>
+					<version>1.0.0</version>
+					<configuration>
+						<lifecycleMappingMetadata>
+							<pluginExecutions>
+								<pluginExecution>
+									<pluginExecutionFilter>
+										<groupId>
+											org.apache.cxf
+										</groupId>
+										<artifactId>
+											cxf-codegen-plugin
+										</artifactId>
+										<versionRange>
+											[2.0.9,)
+										</versionRange>
+										<goals>
+											<goal>java2wsdl</goal>
+										</goals>
+									</pluginExecutionFilter>
+									<action>
+										<ignore></ignore>
+									</action>
+								</pluginExecution>
+							</pluginExecutions>
+						</lifecycleMappingMetadata>
+					</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+	</build>
+</project>

--- a/extensions/bundles/webservice/src/main/java/org/opennaas/extensions/ws/impl/ChassisCapabilityServiceImpl.java
+++ b/extensions/bundles/webservice/src/main/java/org/opennaas/extensions/ws/impl/ChassisCapabilityServiceImpl.java
@@ -1,0 +1,181 @@
+package org.opennaas.extensions.ws.impl;
+
+import java.util.List;
+
+import javax.jws.WebService;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.opennaas.core.resources.capability.CapabilityException;
+import org.opennaas.extensions.router.capability.chassis.ChassisCapability;
+import org.opennaas.extensions.router.capability.chassis.IChassisCapability;
+import org.opennaas.extensions.router.model.ComputerSystem;
+
+import org.opennaas.extensions.router.model.LogicalPort;
+import org.opennaas.extensions.router.model.NetworkPort;
+import org.opennaas.extensions.router.model.ProtocolEndpoint.ProtocolIFType;
+
+import org.opennaas.extensions.ws.services.IChassisCapabilityService;
+
+/**
+ * @author Jordi Puig
+ */
+@WebService(portName = "ChassisCapabilityPort", serviceName = "ChassisCapabilityService", targetNamespace = "http:/www.opennaas.org/ws")
+public class ChassisCapabilityServiceImpl extends GenericCapabilityServiceImpl implements IChassisCapabilityService {
+
+	Log	log	= LogFactory.getLog(ChassisCapabilityServiceImpl.class);
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.opennaas.extensions.ws.services.IChassisCapabilityService#createLogicalRouter(java.lang.String,
+	 * org.opennaas.extensions.router.model.ComputerSystem)
+	 */
+	@Override
+	public void createLogicalRouter(String resourceId, ComputerSystem logicalRouter) throws CapabilityException {
+		try {
+			IChassisCapability iChassisCapability = (IChassisCapability) getCapability(resourceId, ChassisCapability.CAPABILITY_TYPE);
+			iChassisCapability.createLogicalRouter(logicalRouter);
+		} catch (CapabilityException e) {
+			log.error(e);
+			throw e;
+		}
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.opennaas.extensions.ws.services.IChassisCapabilityService#deleteLogicalRouter(java.lang.String,
+	 * org.opennaas.extensions.router.model.ComputerSystem)
+	 */
+	@Override
+	public void deleteLogicalRouter(String resourceId, ComputerSystem logicalRouter) throws CapabilityException {
+		try {
+			IChassisCapability iChassisCapability = (IChassisCapability) getCapability(resourceId, ChassisCapability.CAPABILITY_TYPE);
+			iChassisCapability.deleteLogicalRouter(logicalRouter);
+		} catch (CapabilityException e) {
+			log.error(e);
+			throw e;
+		}
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.opennaas.extensions.ws.services.IChassisCapabilityService#upPhysicalInterface(org.opennaas.extensions.router.model.LogicalPort)
+	 */
+	@Override
+	public void upPhysicalInterface(String resourceId, LogicalPort iface) throws CapabilityException {
+		try {
+			IChassisCapability iChassisCapability = (IChassisCapability) getCapability(resourceId, ChassisCapability.CAPABILITY_TYPE);
+			iChassisCapability.upPhysicalInterface(iface);
+		} catch (CapabilityException e) {
+			log.error(e);
+			throw e;
+		}
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.opennaas.extensions.ws.services.IChassisCapabilityService#downPhysicalInterface(org.opennaas.extensions.router.model.LogicalPort)
+	 */
+	@Override
+	public void downPhysicalInterface(String resourceId, LogicalPort iface) throws CapabilityException {
+		try {
+			IChassisCapability iChassisCapability = (IChassisCapability) getCapability(resourceId, ChassisCapability.CAPABILITY_TYPE);
+			iChassisCapability.downPhysicalInterface(iface);
+		} catch (CapabilityException e) {
+			log.error(e);
+			throw e;
+		}
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.opennaas.extensions.ws.services.IChassisCapabilityService#setEncapsulationLabel(java.lang.String,
+	 * org.opennaas.extensions.router.model.LogicalPort, java.lang.String)
+	 */
+	@Override
+	public void setEncapsulationLabel(String resourceId, LogicalPort iface, String encapsulationLabel) throws CapabilityException {
+		try {
+			IChassisCapability iChassisCapability = (IChassisCapability) getCapability(resourceId, ChassisCapability.CAPABILITY_TYPE);
+			iChassisCapability.setEncapsulationLabel(iface, encapsulationLabel);
+		} catch (CapabilityException e) {
+			log.error(e);
+			throw e;
+		}
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.opennaas.extensions.ws.services.IChassisCapabilityService#addInterfacesToLogicalRouter(java.lang.String,
+	 * org.opennaas.extensions.router.model.ComputerSystem, java.util.List)
+	 */
+	@Override
+	public void addInterfacesToLogicalRouter(String resourceId, ComputerSystem logicalRouter, List<LogicalPort> interfaces)
+			throws CapabilityException {
+		try {
+			IChassisCapability iChassisCapability = (IChassisCapability) getCapability(resourceId, ChassisCapability.CAPABILITY_TYPE);
+			iChassisCapability.addInterfacesToLogicalRouter(logicalRouter, interfaces);
+		} catch (CapabilityException e) {
+			log.error(e);
+			throw e;
+		}
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.opennaas.extensions.ws.services.IChassisCapabilityService#removeInterfacesFromLogicalRouter(java.lang.String,
+	 * org.opennaas.extensions.router.model.ComputerSystem, java.util.List)
+	 */
+	@Override
+	public void removeInterfacesFromLogicalRouter(String resourceId, ComputerSystem logicalRouter, List<LogicalPort> interfaces)
+			throws CapabilityException {
+		try {
+			IChassisCapability iChassisCapability = (IChassisCapability) getCapability(resourceId, ChassisCapability.CAPABILITY_TYPE);
+			iChassisCapability.removeInterfacesFromLogicalRouter(logicalRouter, interfaces);
+		} catch (CapabilityException e) {
+			log.error(e);
+			throw e;
+		}
+
+	}
+
+	@Override
+	public void createSubInterface(String resourceId, NetworkPort iface) throws CapabilityException {
+		try {
+			IChassisCapability iChassisCapability = (IChassisCapability) getCapability(resourceId, ChassisCapability.CAPABILITY_TYPE);
+			iChassisCapability.createSubInterface(iface);
+		} catch (CapabilityException e) {
+			log.error(e);
+			throw e;
+		}
+	}
+
+	@Override
+	public void deleteSubInterface(String resourceId, NetworkPort iface) throws CapabilityException {
+		try {
+			IChassisCapability iChassisCapability = (IChassisCapability) getCapability(resourceId, ChassisCapability.CAPABILITY_TYPE);
+			iChassisCapability.deleteSubInterface(iface);
+		} catch (CapabilityException e) {
+			log.error(e);
+			throw e;
+		}
+	}
+
+	@Override
+	public void setEncapsulation(String resourceId, LogicalPort iface, ProtocolIFType encapsulationType) throws CapabilityException {
+		try {
+			IChassisCapability iChassisCapability = (IChassisCapability) getCapability(resourceId, ChassisCapability.CAPABILITY_TYPE);
+			iChassisCapability.setEncapsulation(iface, encapsulationType);
+		} catch (CapabilityException e) {
+			log.error(e);
+			throw e;
+		}
+	}
+
+}

--- a/extensions/bundles/webservice/src/main/java/org/opennaas/extensions/ws/impl/GenericCapabilityServiceImpl.java
+++ b/extensions/bundles/webservice/src/main/java/org/opennaas/extensions/ws/impl/GenericCapabilityServiceImpl.java
@@ -1,0 +1,62 @@
+/**
+ * 
+ */
+package org.opennaas.extensions.ws.impl;
+
+import org.opennaas.core.resources.IResource;
+import org.opennaas.core.resources.IResourceManager;
+import org.opennaas.core.resources.ResourceException;
+import org.opennaas.core.resources.capability.CapabilityException;
+import org.opennaas.core.resources.capability.ICapability;
+
+/**
+ * @author Jordi
+ */
+public class GenericCapabilityServiceImpl {
+
+	private IResourceManager	resourceManager;
+
+	/**
+	 * Get the capability from the resource
+	 * 
+	 * @param resourceId
+	 * @return the resource with resourceId = resourceId
+	 * @throws ResourceException
+	 */
+	protected IResource getResource(String resourceId) throws ResourceException {
+		return resourceManager.getResourceById(resourceId);
+	}
+
+	/**
+	 * Get the capability from the resource
+	 * 
+	 * @param capabilities
+	 * @param type
+	 * @return the capability
+	 * @throws ResourceException
+	 */
+	protected ICapability getCapability(String resourceId, String type) throws CapabilityException {
+		try {
+			IResource resource = getResource(resourceId);
+			return resource.getCapabilityByType(type);
+		} catch (ResourceException e) {
+			throw new CapabilityException("Capability not found", e);
+		}
+	}
+
+	/**
+	 * @return the resourceManager
+	 */
+	public IResourceManager getResourceManager() {
+		return resourceManager;
+	}
+
+	/**
+	 * @param resourceManager
+	 *            the resourceManager to set
+	 */
+	public void setResourceManager(IResourceManager resourceManager) {
+		this.resourceManager = resourceManager;
+	}
+
+}

--- a/extensions/bundles/webservice/src/main/java/org/opennaas/extensions/ws/impl/ResourceManagerServiceImpl.java
+++ b/extensions/bundles/webservice/src/main/java/org/opennaas/extensions/ws/impl/ResourceManagerServiceImpl.java
@@ -1,0 +1,38 @@
+package org.opennaas.extensions.ws.impl;
+
+import javax.inject.Inject;
+import javax.jws.WebService;
+
+import org.opennaas.core.resources.IResource;
+import org.opennaas.core.resources.IResourceManager;
+import org.opennaas.core.resources.ResourceException;
+import org.opennaas.core.resources.descriptor.ResourceDescriptor;
+import org.opennaas.extensions.ws.services.IResourceManagerService;
+
+/**
+ * @author Jordi Puig
+ */
+@WebService
+public class ResourceManagerServiceImpl implements IResourceManagerService {
+
+	@Inject
+	private IResourceManager	resourceManager;
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.opennaas.ws.core.resources.IResourceManagerService#createResource(org.opennaas.core.resources.descriptor.ResourceDescriptor)
+	 */
+	@Override
+	public String createResource(ResourceDescriptor resourceDescriptor) {
+		String resourceId = "";
+		IResource resource = null;
+		try {
+			resource = resourceManager.createResource(resourceDescriptor);
+			resourceId = resource != null ? resource.getResourceIdentifier().getId() : "-1";
+		} catch (ResourceException e) {
+			resourceId = "-1";
+		}
+		return resourceId;
+	}
+}

--- a/extensions/bundles/webservice/src/main/java/org/opennaas/extensions/ws/services/IChassisCapabilityService.java
+++ b/extensions/bundles/webservice/src/main/java/org/opennaas/extensions/ws/services/IChassisCapabilityService.java
@@ -1,0 +1,229 @@
+package org.opennaas.extensions.ws.services;
+
+import java.util.List;
+
+import javax.jws.WebService;
+import javax.xml.bind.annotation.XmlSeeAlso;
+
+import org.opennaas.core.resources.capability.CapabilityException;
+import org.opennaas.extensions.router.model.ComputerSystem;
+import org.opennaas.extensions.router.model.LogicalPort;
+import org.opennaas.extensions.router.model.NetworkPort;
+import org.opennaas.extensions.router.model.ProtocolEndpoint.ProtocolIFType;
+
+/**
+ * @author Jordi Puig
+ */
+
+@WebService(portName = "ChassisCapabilityPort", serviceName = "ChassisCapabilityService", targetNamespace = "http:/www.opennaas.org/ws")
+/*
+ * All router model beans listed here. This forces all router model to be included in generated wsdl
+ */
+@XmlSeeAlso({
+		org.opennaas.extensions.router.model.AdminDomain.class,
+		org.opennaas.extensions.router.model.AreaOfConfiguration.class,
+		org.opennaas.extensions.router.model.Association.class,
+		org.opennaas.extensions.router.model.BindsTo.class,
+		org.opennaas.extensions.router.model.Component.class,
+		org.opennaas.extensions.router.model.ComputerSystem.class,
+		org.opennaas.extensions.router.model.Dependency.class,
+		org.opennaas.extensions.router.model.DeviceConnection.class,
+		org.opennaas.extensions.router.model.DeviceSAPImplementation.class,
+		org.opennaas.extensions.router.model.EnabledLogicalElement.class,
+		org.opennaas.extensions.router.model.EndpointInArea.class,
+		org.opennaas.extensions.router.model.EthernetPort.class,
+		org.opennaas.extensions.router.model.FCPort.class,
+		org.opennaas.extensions.router.model.FilterEntryBase.class,
+		org.opennaas.extensions.router.model.GREService.class,
+		org.opennaas.extensions.router.model.GRETunnelConfiguration.class,
+		org.opennaas.extensions.router.model.GRETunnelEndpoint.class,
+		org.opennaas.extensions.router.model.GRETunnelServiceConfiguration.class,
+		org.opennaas.extensions.router.model.GRETunnelService.class,
+		org.opennaas.extensions.router.model.HostedDependency.class,
+		org.opennaas.extensions.router.model.HostedRoute.class,
+		org.opennaas.extensions.router.model.HostedRoutingServices.class,
+		org.opennaas.extensions.router.model.HostedService.class,
+		org.opennaas.extensions.router.model.IPHeadersFilter.class,
+		org.opennaas.extensions.router.model.IPProtocolEndpoint.class,
+		org.opennaas.extensions.router.model.LogicalDevice.class,
+		org.opennaas.extensions.router.model.LogicalElement.class,
+		org.opennaas.extensions.router.model.LogicalModule.class,
+		org.opennaas.extensions.router.model.LogicalPort.class,
+		org.opennaas.extensions.router.model.LogicalTunnelPort.class,
+		org.opennaas.extensions.router.model.ManagedElement.class,
+		org.opennaas.extensions.router.model.ManagedSystemElement.class,
+		org.opennaas.extensions.router.model.ModulePort.class,
+		org.opennaas.extensions.router.model.NetworkPort.class,
+		org.opennaas.extensions.router.model.NetworkService.class,
+		org.opennaas.extensions.router.model.NextHopIPRoute.class,
+		org.opennaas.extensions.router.model.NextHopRoute.class,
+		org.opennaas.extensions.router.model.OSPFAreaConfiguration.class,
+		org.opennaas.extensions.router.model.OSPFArea.class,
+		org.opennaas.extensions.router.model.OSPFProtocolEndpointBase.class,
+		org.opennaas.extensions.router.model.OSPFProtocolEndpoint.class,
+		org.opennaas.extensions.router.model.OSPFServiceConfiguration.class,
+		org.opennaas.extensions.router.model.OSPFService.class,
+		org.opennaas.extensions.router.model.PortImplementsEndpoint.class,
+		org.opennaas.extensions.router.model.PortOnDevice.class,
+		org.opennaas.extensions.router.model.ProtocolEndpoint.class,
+		org.opennaas.extensions.router.model.ProvidesEndpoint.class,
+		org.opennaas.extensions.router.model.RouteCalculationService.class,
+		org.opennaas.extensions.router.model.RouteUsesEndpoint.class,
+		org.opennaas.extensions.router.model.RoutingProtocolDomain.class,
+		org.opennaas.extensions.router.model.SAPSAPDependency.class,
+		org.opennaas.extensions.router.model.ServiceAccessBySAP.class,
+		org.opennaas.extensions.router.model.ServiceAccessPoint.class,
+		org.opennaas.extensions.router.model.Service.class,
+		org.opennaas.extensions.router.model.SystemComponent.class,
+		org.opennaas.extensions.router.model.SystemDevice.class,
+		org.opennaas.extensions.router.model.System.class,
+		org.opennaas.extensions.router.model.VLANEndpoint.class })
+public interface IChassisCapabilityService {
+
+	/*
+	 * Interfaces
+	 */
+
+	/**
+	 * Activates given physical interface (iface) so it can receive/send traffic.
+	 * 
+	 * Note: This call uses the driver to communicate with the physical device this capability belongs to, and uses actions to modify the device
+	 * state. This call end by adding required actions to the device queue, hence device state is not modified yet. An execution of this device queue
+	 * is required for queued actions to take effect.
+	 * 
+	 * @param iface
+	 *            to activate (must be a physical one)
+	 * @throws CapabilityException
+	 *             if any error occurred. In that case, queue remains untouched.
+	 */
+	public void upPhysicalInterface(String resourceId, LogicalPort iface) throws CapabilityException;
+
+	/**
+	 * Deactivates given physical interface (iface) so it can not receive/send traffic.
+	 * 
+	 * Note: This call uses the driver to communicate with the physical device this capability belongs to, and uses actions to modify the device
+	 * state. This call end by adding required actions to the device queue, hence device state is not modified yet. An execution of this device queue
+	 * is required for queued actions to take effect.
+	 * 
+	 * @param iface
+	 *            to deactivate (must be a physical one)
+	 * @throws CapabilityException
+	 *             if any error occurred. In that case, queue remains untouched.
+	 */
+	public void downPhysicalInterface(String resourceId, LogicalPort iface) throws CapabilityException;
+
+	/**
+	 * Creates given logical interface (iface).
+	 * 
+	 * Note: This call uses the driver to communicate with the physical device this capability belongs to, and uses actions to modify the device
+	 * state. This call end by adding required actions to the device queue, hence device state is not modified yet. An execution of this device queue
+	 * is required for queued actions to take effect.
+	 * 
+	 * @param iface
+	 *            to be created
+	 * @throws CapabilityException
+	 *             if any error occurred. In that case, queue remains untouched.
+	 */
+	public void createSubInterface(String resourceId, NetworkPort iface) throws CapabilityException;
+
+	/**
+	 * Deletes given logical interface (iface).
+	 * 
+	 * Note: This call uses the driver to communicate with the physical device this capability belongs to, and uses actions to modify the device
+	 * state. This call end by adding required actions to the device queue, hence device state is not modified yet. An execution of this device queue
+	 * is required for queued actions to take effect.
+	 * 
+	 * @param iface
+	 *            to be deleted
+	 * @throws CapabilityException
+	 *             if any error occurred. In that case, queue remains untouched.
+	 */
+	public void deleteSubInterface(String resourceId, NetworkPort iface) throws CapabilityException;
+
+	/**
+	 * Configures the type of encapsulation to use in given iface.
+	 * 
+	 * Note: This call uses the driver to communicate with the physical device this capability belongs to, and uses actions to modify the device
+	 * state. This call end by adding required actions to the device queue, hence device state is not modified yet. An execution of this device queue
+	 * is required for queued actions to take effect.
+	 * 
+	 * @param iface
+	 *            to be configured
+	 * @param encapsulationType
+	 *            to use in given iface
+	 * @throws CapabilityException
+	 *             if any error occurred. In that case, queue remains untouched.
+	 */
+	public void setEncapsulation(String resourceId, LogicalPort iface, ProtocolIFType encapsulationType) throws CapabilityException;
+
+	/**
+	 * Configures the encapsulation label to use in given iface.
+	 * 
+	 * Note: This call uses the driver to communicate with the physical device this capability belongs to, and uses actions to modify the device
+	 * state. This call end by adding required actions to the device queue, hence device state is not modified yet. An execution of this device queue
+	 * is required for queued actions to take effect.
+	 * 
+	 * @param iface
+	 *            to use given label
+	 * @param encapsulationLabel
+	 *            to use in given iface
+	 * @throws CapabilityException
+	 *             if any error occurred. In that case, queue remains untouched.
+	 */
+	public void setEncapsulationLabel(String resourceId, LogicalPort iface, String encapsulationLabel) throws CapabilityException;
+
+	/*
+	 * Logical Routers
+	 */
+	/**
+	 * Creates a logical router.
+	 * 
+	 * Note: This call uses the driver to communicate with the physical device this capability belongs to, and uses actions to modify the device
+	 * state. This call end by adding required actions to the device queue, hence device state is not modified yet. An execution of this device queue
+	 * is required for queued actions to take effect.
+	 * 
+	 * @param logicalRouter
+	 *            to be created
+	 * @throws CapabilityException
+	 *             if any error occurred. In that case, queue remains untouched.
+	 */
+	public void createLogicalRouter(String resourceId, ComputerSystem logicalRouter) throws CapabilityException;
+
+	/**
+	 * Deletes given logical router.
+	 * 
+	 * @param logicalRouter
+	 *            existing logical router to delete.
+	 * @throws CapabilityException
+	 *             if any error occurred. In that case, queue remains untouched.
+	 */
+	public void deleteLogicalRouter(String resourceId, ComputerSystem logicalRouter) throws CapabilityException;
+
+	/**
+	 * Adds given interfaces to given logical router, thus giving control over them to the logical router.
+	 * 
+	 * @param logicalRouter
+	 *            that will receive the interfaces
+	 * @param interfaces
+	 *            to be added to the logical router
+	 * @throws CapabilityException
+	 *             if any error occurred. In that case, queue remains untouched.
+	 */
+	public void addInterfacesToLogicalRouter(String resourceId, ComputerSystem logicalRouter, List<LogicalPort> interfaces)
+			throws CapabilityException;
+
+	/**
+	 * Removes given interfaces from given logical router, returning control over them to the physical router.
+	 * 
+	 * 
+	 * @param logicalRouter
+	 *            to remove the interfaces from
+	 * @param interfaces
+	 *            to be removed from the logical router
+	 * @throws CapabilityException
+	 *             if any error occurred. In that case, queue remains untouched.
+	 */
+	public void removeInterfacesFromLogicalRouter(String resourceId, ComputerSystem logicalRouter, List<LogicalPort> interfaces)
+			throws CapabilityException;
+
+}

--- a/extensions/bundles/webservice/src/main/java/org/opennaas/extensions/ws/services/IResourceManagerService.java
+++ b/extensions/bundles/webservice/src/main/java/org/opennaas/extensions/ws/services/IResourceManagerService.java
@@ -1,0 +1,18 @@
+package org.opennaas.extensions.ws.services;
+
+import javax.jws.WebService;
+
+import org.opennaas.core.resources.descriptor.ResourceDescriptor;
+
+/**
+ * @author Jordi Puig
+ */
+@WebService
+public interface IResourceManagerService {
+
+	/**
+	 * @param resourceDescriptor
+	 * @return
+	 */
+	public String createResource(ResourceDescriptor resourceDescriptor);
+}

--- a/extensions/bundles/webservice/src/main/resources/OSGI-INF/blueprint/core.xml
+++ b/extensions/bundles/webservice/src/main/resources/OSGI-INF/blueprint/core.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE file
+distributed with this work for additional information regarding copyright ownership. The ASF licenses this file to You under
+the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may
+obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to
+in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under
+the License. -->
+
+<!-- xmlns:ext="http://aries.apache.org/blueprint/xmlns/blueprint-ext/v1.0.0" -->
+
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0" xmlns:cxf="http://cxf.apache.org/blueprint/core"
+    xmlns:jaxrs="http://cxf.apache.org/blueprint/jaxrs" xmlns:jaxws="http://cxf.apache.org/blueprint/jaxws"
+    xsi:schemaLocation="
+	http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
+	http://www.osgi.org/xmlns/blueprint-ext/v1.1.0 https://svn.apache.org/repos/asf/aries/tags/blueprint-0.3.1/blueprint-core/src/main/resources/org/apache/aries/blueprint/ext/blueprint-ext.xsd
+	http://cxf.apache.org/blueprint/jaxws http://cxf.apache.org/schemas/blueprint/jaxws.xsd
+	http://cxf.apache.org/blueprint/jaxrs http://cxf.apache.org/schemas/blueprint/jaxrs.xsd
+	http://cxf.apache.org/blueprint/core http://cxf.apache.org/schemas/blueprint/core.xsd
+	http://camel.apache.org/schema/blueprint http://camel.apache.org/schema/blueprint/camel-blueprint.xsd
+	http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0 http://aries.apache.org/schemas/blueprint-cm/blueprint-cm-1.1.0.xsd
+">
+
+    <cxf:bus id="chassisCapabilityServiceBus"></cxf:bus>
+    
+	<!-- Definition for resourceManager bean -->
+	<reference id="resourceManager" interface="org.opennaas.core.resources.IResourceManager" />
+    
+	<bean id="chassisCapabilityServiceImpl" class="org.opennaas.extensions.ws.impl.ChassisCapabilityServiceImpl">
+		<property name="resourceManager" ref="resourceManager" />
+	</bean>
+    <jaxws:endpoint  implementor="#chassisCapabilityServiceImpl" address="http://localhost:8182/cxf/chassisCapabilityService"  />
+
+
+</blueprint>

--- a/platform/src/main/filtered-resources/etc/org.ops4j.pax.logging.cfg
+++ b/platform/src/main/filtered-resources/etc/org.ops4j.pax.logging.cfg
@@ -58,6 +58,9 @@ log4j.logger.net.i2cat.luminis = DEBUG, opticalswitchout
 log4j.logger.com.wonesys.emsModule = DEBUG, opticalswitchout
 log4j.logger.org.opennaas.extensions.router.model.opticalSwitch = DEBUG, opticalswitchout
 
+# WS
+log4j.logger.org.opennaas.extensions.ws = DEBUG, wsout
+
 # ITESTS
 log4j.logger.net.i2cat.nexus.tests = DEBUG, itestsout
 log4j.logger.net.i2cat.nexus.resources.tests = DEBUG, itestsout
@@ -142,6 +145,14 @@ log4j.appender.opticalswitchout.layout=org.apache.log4j.PatternLayout
 log4j.appender.opticalswitchout.layout.ConversionPattern=${opennaas.log.usedPattern}
 log4j.appender.opticalswitchout.file=${karaf.base}/data/log/opticalswitch.log
 log4j.appender.opticalswitchout.append=true
+
+# WS file appender 
+log4j.appender.wsout=org.apache.log4j.RollingFileAppender
+log4j.appender.wsout.MaxFileSize=1000KB
+log4j.appender.wsout.layout=org.apache.log4j.PatternLayout
+log4j.appender.wsout.layout.ConversionPattern=${opennaas.log.usedPattern}
+log4j.appender.wsout.file=${karaf.base}/data/log/ws.log
+log4j.appender.wsout.append=true
 
 # ITESTS file appender
 log4j.appender.itestsout=org.apache.log4j.RollingFileAppender

--- a/tests/integration/commandsKaraf/src/test/java/org/opennaas/extensions/commandsKaraf/test/ResourceCommandsKarafTest.java
+++ b/tests/integration/commandsKaraf/src/test/java/org/opennaas/extensions/commandsKaraf/test/ResourceCommandsKarafTest.java
@@ -1,16 +1,16 @@
 package org.opennaas.extensions.commandsKaraf.test;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.StringWriter;
+import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.keepRuntimeFolder;
+import static org.opennaas.extensions.nexus.tests.helper.OpennaasExamOptions.includeFeatures;
+import static org.opennaas.extensions.nexus.tests.helper.OpennaasExamOptions.includeTestHelper;
+import static org.opennaas.extensions.nexus.tests.helper.OpennaasExamOptions.noConsole;
+import static org.opennaas.extensions.nexus.tests.helper.OpennaasExamOptions.opennaasDistributionConfiguration;
+import static org.ops4j.pax.exam.CoreOptions.options;
+
 import java.util.ArrayList;
 import java.util.List;
-import javax.inject.Inject;
 
-import org.opennaas.extensions.nexus.tests.helper.AbstractKarafCommandTest;
+import javax.inject.Inject;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -18,7 +18,6 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
 import org.opennaas.core.resources.ILifecycle.State;
 import org.opennaas.core.resources.IResource;
 import org.opennaas.core.resources.IResourceManager;
@@ -28,24 +27,20 @@ import org.opennaas.core.resources.helpers.ResourceDescriptorFactory;
 import org.opennaas.core.resources.protocol.IProtocolManager;
 import org.opennaas.core.resources.protocol.ProtocolException;
 import org.opennaas.core.resources.protocol.ProtocolSessionContext;
-
+import org.opennaas.extensions.nexus.tests.helper.AbstractKarafCommandTest;
 import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.junit.Configuration;
-import org.ops4j.pax.exam.junit.JUnit4TestRunner;
 import org.ops4j.pax.exam.junit.ExamReactorStrategy;
+import org.ops4j.pax.exam.junit.JUnit4TestRunner;
 import org.ops4j.pax.exam.spi.reactors.EagerSingleStagedReactorFactory;
 import org.ops4j.pax.exam.util.Filter;
 import org.osgi.service.blueprint.container.BlueprintContainer;
-
-import static org.opennaas.extensions.nexus.tests.helper.OpennaasExamOptions.*;
-import static org.openengsb.labs.paxexam.karaf.options.KarafDistributionOption.*;
-import static org.ops4j.pax.exam.CoreOptions.*;
 
 @RunWith(JUnit4TestRunner.class)
 @ExamReactorStrategy(EagerSingleStagedReactorFactory.class)
 public class ResourceCommandsKarafTest extends AbstractKarafCommandTest
 {
-	static Log log = LogFactory.getLog(ResourceCommandsKarafTest.class);
+	static Log					log	= LogFactory.getLog(ResourceCommandsKarafTest.class);
 
 	@Inject
 	private IResourceManager	resourceManager;
@@ -53,25 +48,25 @@ public class ResourceCommandsKarafTest extends AbstractKarafCommandTest
 	@Inject
 	private IProtocolManager	protocolManager;
 
-    @Inject
-    @Filter("(osgi.blueprint.container.symbolicname=org.opennaas.extensions.router.repository)")
-    private BlueprintContainer routerRepositoryService;
+	@Inject
+	@Filter("(osgi.blueprint.container.symbolicname=org.opennaas.extensions.router.repository)")
+	private BlueprintContainer	routerRepositoryService;
 
-    @Inject
-    @Filter("(osgi.blueprint.container.symbolicname=org.opennaas.extensions.router.capability.ip)")
-    private BlueprintContainer ipService;
+	@Inject
+	@Filter("(osgi.blueprint.container.symbolicname=org.opennaas.extensions.router.capability.ip)")
+	private BlueprintContainer	ipService;
 
-    @Inject
-    @Filter("(osgi.blueprint.container.symbolicname=org.opennaas.extensions.queuemanager)")
-    private BlueprintContainer queueService;
+	@Inject
+	@Filter("(osgi.blueprint.container.symbolicname=org.opennaas.extensions.queuemanager)")
+	private BlueprintContainer	queueService;
 
 	@Configuration
 	public static Option[] configuration() {
 		return options(opennaasDistributionConfiguration(),
-					   includeFeatures("opennaas-router"),
-					   includeTestHelper(),
-					   noConsole(),
-					   keepRuntimeFolder());
+				includeFeatures("opennaas-router"),
+				includeTestHelper(),
+				noConsole(),
+				keepRuntimeFolder());
 	}
 
 	/**
@@ -110,25 +105,25 @@ public class ResourceCommandsKarafTest extends AbstractKarafCommandTest
 		ResourceDescriptor resourceDescriptor = ResourceDescriptorFactory
 				.newResourceDescriptor("junosm20", "router", capabilities);
 		String resourceFriendlyID =
-			resourceDescriptor.getInformation()
-				.getType()
-				+ ":"
-				+ resourceDescriptor.getInformation().getName();
+				resourceDescriptor.getInformation()
+						.getType()
+						+ ":"
+						+ resourceDescriptor.getInformation().getName();
 
 		IResource resource =
-			resourceManager.createResource(resourceDescriptor);
+				resourceManager.createResource(resourceDescriptor);
 		createProtocolForResource(resource.getResourceIdentifier().getId());
 		resourceManager.startResource(resource.getResourceIdentifier());
 
 		List<String> response =
-			executeCommand("resource:info " + resourceFriendlyID);
+				executeCommand("resource:info " + resourceFriendlyID);
 
 		if (!response.get(1).isEmpty()) {
 			Assert.fail(response.get(1));
 		}
 		Assert.assertTrue(response.get(1).isEmpty());
 
-		Assert.assertTrue(response.get(0).contains("Resource ID: junosm20"));
+		Assert.assertTrue(response.get(0).contains("Resource Id: " + resource.getResourceIdentifier().getId()));
 		Assert.assertTrue(response.get(0).contains("Type: ipv4"));
 		Assert.assertTrue(response.get(0).contains("Type: queue"));
 


### PR DESCRIPTION
This patch implements a webservice facade for chassisCapability.
Use it as a model to implement web services  for other capabilities.

IChassisCapability is exported as a WS through a SOAP endpoint, using CXF.

The interface is not exported as such. Instead, an extra parameter containing the resourceId is added to all calls, as shown in IChassisCapabilityService.
IChassisCapabiiltyService implementation is a facade which resolves correct IChassisCapability instance (the one related to given resourceId) and calls the appropriated method.

Router model has been annotated to allow marshalling and unmarshalling, to call IChassisCapability methods. However, this patch does not check model is well marshalled/unmarshalled. It is possible that calls launched from the web service fails due to incomplete parameters.
Another pull request will fix these issues.
