### PR TITLE
Fix/platform dup dependencies warning

### DIFF
--- a/platform/pom.xml
+++ b/platform/pom.xml
@@ -147,10 +147,6 @@
 		</dependency>
 		<dependency>
 			<groupId>org.opennaas</groupId>
-			<artifactId>org.opennaas.extensions.network.capability.queue</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.opennaas</groupId>
 			<artifactId>org.opennaas.extensions.router.capability.staticroute</artifactId>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
network.queue dependency was duplicated and causing a warning when running mvn.
This patch removes duplication.
