### PR TITLE
Feature/web increase timeout

### DIFF
--- a/web/opennaas-web/src/main/java/org/opennaas/web/ws/OpennaasClient.java
+++ b/web/opennaas-web/src/main/java/org/opennaas/web/ws/OpennaasClient.java
@@ -228,8 +228,8 @@ public class OpennaasClient {
 		HTTPConduit http = (HTTPConduit) serviceClient.getConduit();
 
 		HTTPClientPolicy httpClientPolicy = new HTTPClientPolicy();
-		httpClientPolicy.setConnectionTimeout(timeout);
-		httpClientPolicy.setReceiveTimeout(timeout);
+		// httpClientPolicy.setConnectionTimeout(timeout); // stablish connection
+		httpClientPolicy.setReceiveTimeout(timeout); // receive response
 
 		http.setClient(httpClientPolicy);
 	}


### PR DESCRIPTION
Default timeout is set to one minute, but resourceManager and queue calls may take longer,
specially when autobahn is involved.

This patch increases the timeout in these services calls.

It is related with issue: 
http://jira.i2cat.net:8080/browse/OPENNAAS-344
