### PR TITLE
Feature/fix release deploy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1042,9 +1042,9 @@
 	<distributionManagement>
 		<repository>
 			<uniqueVersion>false</uniqueVersion>
-			<id>i2cat</id>
-			<name>i2cat maven repository</name>
-			<url>http://maven.i2cat.net:8081/artifactory/libs-release</url>
+			<id>maven.i2cat.net</id>
+			<name>>maven.i2cat.net-releases</name>
+			<url>http://maven.i2cat.net:8081/artifactory/libs-release-local</url>
 		</repository>
 		<snapshotRepository>
 			<uniqueVersion>true</uniqueVersion>


### PR DESCRIPTION
Before this patch, libs-releases was used, but "mvn deploy" failed with an http 405 error code.

You'll need to change maven settings.xml to include credentials for deploying in a server named maven.i2cat.net.
