### PR TITLE
Fix/remove activator in macbridge model

### DIFF
--- a/extensions/bundles/macbridge.model/pom.xml
+++ b/extensions/bundles/macbridge.model/pom.xml
@@ -42,7 +42,6 @@
 				-->
 				<configuration>
 					<instructions>
-						<Bundle-Activator>org.opennaas.extensions.router.capability.ospf.Activator</Bundle-Activator>
 						<!--
 							| assume public classes are in the top package, and private
 							classes are under ".internal"


### PR DESCRIPTION
Remove unused activator from macbridge model bundle pom. 
