### PR TITLE
Feature/publish macbridge ws

### DIFF
--- a/extensions/bundles/macbridge.capability.vlanawarebridge/pom.xml
+++ b/extensions/bundles/macbridge.capability.vlanawarebridge/pom.xml
@@ -77,24 +77,6 @@
 					</instructions>
 				</configuration>
 			</plugin>
-			<plugin>
-				<groupId>org.apache.cxf</groupId>
-				<artifactId>cxf-java2ws-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>generate-wsdl-vlanAwareBridge</id>
-						<phase>process-classes</phase>
-						<configuration>
-							<className>org.opennaas.extensions.capability.macbridge.vlanawarebridge.ws.IVLANAwareBridgeCapabilityService</className>
-							<genWsdl>true</genWsdl>
-							<verbose>true</verbose>
-						</configuration>
-						<goals>
-							<goal>java2ws</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
 		</plugins>
 		<pluginManagement>
 			<plugins>

--- a/extensions/bundles/macbridge.capability.vlanawarebridge/src/main/resources/OSGI-INF/blueprint/core.xml
+++ b/extensions/bundles/macbridge.capability.vlanawarebridge/src/main/resources/OSGI-INF/blueprint/core.xml
@@ -95,11 +95,4 @@
 			</completers>
 		</command>
 	</command-bundle>
-	<!-- Web service creation and export -->
-	<reference id="resourceManager" interface="org.opennaas.core.resources.IResourceManager" />
-    <cxf:bus id="vlanAwareBridgeCapabilityServiceBus"></cxf:bus>
-	<bean id="vlanAwareBridgeCapabilityServiceImpl" class="org.opennaas.extensions.capability.macbridge.vlanawarebridge.ws.VLANAwareBridgeCapabilityService">
-		<property name="resourceManager" ref="resourceManager" />
-	</bean>
-    <jaxws:endpoint  implementor="#vlanAwareBridgeCapabilityServiceImpl" address="${ws.url}/vlanAwareBridgeCapabilityService"  />
 </blueprint>

--- a/extensions/bundles/pom.xml
+++ b/extensions/bundles/pom.xml
@@ -51,11 +51,7 @@
 		<module>bod.repository</module>
 		<module>bod.capability.l2bod</module>
 		<module>bod.actionsets.dummy</module>
-        	<module>bod.autobahn</module>
-         
-		<module>itests.helpers</module>
-		
-		<module>webservice</module>
+		<module>bod.autobahn</module>
 
 		<module>transports.sockets</module>
 		<module>transports.telnet</module>
@@ -66,6 +62,10 @@
 		<module>macbridge.capability.vlanawarebridge</module>
 		<module>macbridge.ios.resource</module>
 		
-        	<module>sampleresource</module>
+		<module>itests.helpers</module>
+		
+		<module>webservice</module>
+
+		<module>sampleresource</module>
 	</modules>
 </project>

--- a/extensions/bundles/webservice/pom.xml
+++ b/extensions/bundles/webservice/pom.xml
@@ -65,17 +65,20 @@
 		<dependency>
 			<groupId>org.opennaas</groupId>
 			<artifactId>org.opennaas.extensions.network.capability.queue</artifactId>
-		</dependency>					
+		</dependency>
 		<dependency>
 			<groupId>org.opennaas</groupId>
 			<artifactId>org.opennaas.extensions.router.model</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.opennaas</groupId>
+			<artifactId>org.opennaas.extensions.macbridge.capability.vlanawarebridge</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.servicemix.bundles</groupId>
 			<artifactId>org.apache.servicemix.bundles.javax-inject</artifactId>
 		</dependency>
 	</dependencies>
-
 	<build>
 		<plugins>
 			<plugin>
@@ -259,6 +262,18 @@
 						<phase>process-classes</phase>
 						<configuration>
 							<className>org.opennaas.extensions.ws.services.IResourceManagerService</className>
+							<genWsdl>true</genWsdl>
+							<verbose>true</verbose>
+						</configuration>
+						<goals>
+							<goal>java2ws</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>generate-wsdl-vlanAwareBridge</id>
+						<phase>process-classes</phase>
+						<configuration>
+							<className>org.opennaas.extensions.ws.services.IVLANAwareBridgeCapabilityService</className>
 							<genWsdl>true</genWsdl>
 							<verbose>true</verbose>
 						</configuration>

--- a/extensions/bundles/webservice/src/main/java/org/opennaas/extensions/ws/impl/VLANAwareBridgeCapabilityService.java
+++ b/extensions/bundles/webservice/src/main/java/org/opennaas/extensions/ws/impl/VLANAwareBridgeCapabilityService.java
@@ -1,25 +1,20 @@
-package org.opennaas.extensions.capability.macbridge.vlanawarebridge.ws;
+package org.opennaas.extensions.ws.impl;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import javax.jws.WebService;
 
-import org.opennaas.core.resources.IResource;
-import org.opennaas.core.resources.IResourceManager;
-import org.opennaas.core.resources.ResourceException;
 import org.opennaas.core.resources.capability.CapabilityException;
-import org.opennaas.core.resources.capability.ICapability;
 import org.opennaas.extensions.capability.macbridge.model.MACBridge;
 import org.opennaas.extensions.capability.macbridge.model.StaticVLANRegistrationEntry;
 import org.opennaas.extensions.capability.macbridge.model.VLANConfiguration;
 import org.opennaas.extensions.capability.macbridge.vlanawarebridge.IVLANAwareBridgeCapability;
+import org.opennaas.extensions.ws.services.IVLANAwareBridgeCapabilityService;
 
 @WebService(portName = "VLANAwareBridgeCapabilityPort", serviceName = "VLANAwareBridgeCapabilityService", targetNamespace = "http:/www.opennaas.org/ws")
-public class VLANAwareBridgeCapabilityService implements IVLANAwareBridgeCapabilityService {
+public class VLANAwareBridgeCapabilityService extends GenericCapabilityService implements IVLANAwareBridgeCapabilityService {
 
-	private IResourceManager resourceManager = null;
-	
 	@Override
 	public void createVLANConfiguration(String resourceId, VLANConfiguration vlanConriguration) throws CapabilityException {
 		IVLANAwareBridgeCapability capability = (IVLANAwareBridgeCapability) getCapability(resourceId, IVLANAwareBridgeCapability.class);
@@ -31,13 +26,13 @@ public class VLANAwareBridgeCapabilityService implements IVLANAwareBridgeCapabil
 		IVLANAwareBridgeCapability capability = (IVLANAwareBridgeCapability) getCapability(resourceId, IVLANAwareBridgeCapability.class);
 		capability.deleteVLANConfiguration(vlanId);
 	}
-	
+
 	@Override
 	public List<VLANConfiguration> readVLANConfigurationsInVLANDatabase(String resourceId) throws CapabilityException {
-		try{
+		try {
 			MACBridge macBridge = (MACBridge) getResource(resourceId).getModel();
 			return new ArrayList<VLANConfiguration>(macBridge.getVLANDatabase().values());
-		}catch(Exception ex){
+		} catch (Exception ex) {
 			throw new CapabilityException(ex);
 		}
 	}
@@ -53,63 +48,20 @@ public class VLANAwareBridgeCapabilityService implements IVLANAwareBridgeCapabil
 		IVLANAwareBridgeCapability capability = (IVLANAwareBridgeCapability) getCapability(resourceId, IVLANAwareBridgeCapability.class);
 		capability.deleteStaticVLANRegistrationEntryFromFilteringDatabase(vlanID);
 	}
-	
+
 	/**
 	 * Show the static VLAN configuration entries in the filtering database
+	 * 
 	 * @param resourceId
 	 * @return
 	 * @throws CapabilityException
 	 */
-	public List<StaticVLANRegistrationEntry> readStaticVLANRegistrationEntriesInFilteringDatabase(String resourceId) throws CapabilityException{
-		try{
+	public List<StaticVLANRegistrationEntry> readStaticVLANRegistrationEntriesInFilteringDatabase(String resourceId) throws CapabilityException {
+		try {
 			MACBridge macBridge = (MACBridge) getResource(resourceId).getModel();
 			return new ArrayList<StaticVLANRegistrationEntry>(macBridge.getFilteringDatabase().getStaticVLANRegistrations().values());
-		}catch(Exception ex){
+		} catch (Exception ex) {
 			throw new CapabilityException(ex);
 		}
 	}
-	
-	/**
-	 * Get the capability from the resource
-	 * 
-	 * @param resourceId
-	 * @return the resource with resourceId = resourceId
-	 * @throws ResourceException
-	 */
-	protected IResource getResource(String resourceId) throws ResourceException {
-		return resourceManager.getResourceById(resourceId);
-	}
-
-	/**
-	 * Get the capability from the resource
-	 * 
-	 * @param capabilities
-	 * @param type
-	 * @return the capability
-	 * @throws ResourceException
-	 */
-	protected ICapability getCapability(String resourceId, Class<? extends ICapability> _class) throws CapabilityException {
-		try {
-			IResource resource = getResource(resourceId);
-			return resource.getCapabilityByInterface(_class);
-		} catch (ResourceException e) {
-			throw new CapabilityException("Capability not found", e);
-		}
-	}
-
-	/**
-	 * @return the resourceManager
-	 */
-	public IResourceManager getResourceManager() {
-		return resourceManager;
-	}
-
-	/**
-	 * @param resourceManager
-	 *            the resourceManager to set
-	 */
-	public void setResourceManager(IResourceManager resourceManager) {
-		this.resourceManager = resourceManager;
-	}
-
 }

--- a/extensions/bundles/webservice/src/main/java/org/opennaas/extensions/ws/services/IVLANAwareBridgeCapabilityService.java
+++ b/extensions/bundles/webservice/src/main/java/org/opennaas/extensions/ws/services/IVLANAwareBridgeCapabilityService.java
@@ -1,4 +1,4 @@
-package org.opennaas.extensions.capability.macbridge.vlanawarebridge.ws;
+package org.opennaas.extensions.ws.services;
 
 import java.util.List;
 

--- a/extensions/bundles/webservice/src/main/resources/OSGI-INF/blueprint/core.xml
+++ b/extensions/bundles/webservice/src/main/resources/OSGI-INF/blueprint/core.xml
@@ -134,4 +134,11 @@ the License. -->
 	</bean>
     <jaxws:endpoint  implementor="#netQueueCapabilityServiceImpl" address="${ws.url}/netQueueCapabilityService"  />
 	
+	<!-- vlanAwareBridge -->
+    <cxf:bus id="vlanAwareBridgeCapabilityServiceBus"></cxf:bus>
+	<bean id="vlanAwareBridgeCapabilityServiceImpl" class="org.opennaas.extensions.ws.impl.VLANAwareBridgeCapabilityService">
+		<property name="resourceManager" ref="resourceManager" />
+	</bean>
+    <jaxws:endpoint  implementor="#vlanAwareBridgeCapabilityServiceImpl" address="${ws.url}/vlanAwareBridgeCapabilityService"  />
+	
 </blueprint>

--- a/pom.xml
+++ b/pom.xml
@@ -278,6 +278,21 @@
 				<artifactId>org.opennaas.extensions.sampleresource</artifactId>
 				<version>${project.version}</version>
 			</dependency>
+			<dependency>
+				<groupId>org.opennaas</groupId>
+				<artifactId>org.opennaas.extensions.macbridge.capability.vlanawarebridge</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.opennaas</groupId>
+				<artifactId>org.opennaas.extensions.macbridge.model</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.opennaas</groupId>
+				<artifactId>org.opennaas.extensions.macbridge.ios.resource</artifactId>
+				<version>${project.version}</version>
+			</dependency>
 			<!-- Netconf4j -->
 			<dependency>
 				<groupId>net.i2cat.netconf</groupId>


### PR DESCRIPTION
Macbridge web service facade has been moved to org.opennaas.extensions.ws bundle,
and it is published from there, exactly as other capabilities web services are.

Changes in some pom.xml files have been required.
Worth to notice is that bundles build order has changed to asure macbridge is build before ws is.

Also, outermost pom has been updated with macbridge bundles versions.
