### PR TITLE
Feature/fix dosgi deps

### DIFF
--- a/core/features/src/main/resources/features.xml
+++ b/core/features/src/main/resources/features.xml
@@ -29,6 +29,7 @@
 
 		<bundle dependency="true">mvn:org.osgi/org.osgi.compendium/${osgi.version}</bundle>
 		<bundle dependency="true">mvn:org.apache.felix/org.apache.felix.eventadmin/1.2.14</bundle>
+		<bundle dependency="true">mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.jsr311-api-1.1/${servicemix.specs.version}</bundle>
 
 		<bundle>mvn:org.opennaas/org.opennaas.core.resources/${project.version}</bundle>
 	</feature>
@@ -86,7 +87,7 @@
 		<bundle dependency="true">mvn:org.springframework.osgi/spring-osgi-core/${spring.osgi.version}</bundle>
 		<bundle dependency="true">mvn:org.springframework.osgi/spring-osgi-io/${spring.osgi.version}</bundle>							
 		<bundle dependency="true">mvn:org.springframework.osgi/spring-osgi-extender/${spring.osgi.version}</bundle>		
-		<bundle dependency="true">mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.jsr311-api-1.1/1.8.0</bundle>		
+		<bundle dependency="true">mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.jsr311-api-1.1/${servicemix.specs.version}</bundle>		
 		<bundle dependency="true">mvn:org.apache.ws.commons.schema/XmlSchema/${xmlschema.version}</bundle>
 	</feature>
 

--- a/core/resources/pom.xml
+++ b/core/resources/pom.xml
@@ -70,18 +70,10 @@
 			<artifactId>paxexam-karaf-container</artifactId>
 			<scope>compile</scope>
 		</dependency>
-		<!-- DOSGi -->
+		<!-- REST annotations -->
 		<dependency>
-			<groupId>org.apache.cxf</groupId>
-		  	<artifactId>cxf-bundle-minimal</artifactId>
-		</dependency>
-		<dependency>
-		  	<groupId>org.apache.cxf.dosgi</groupId>
-		  	<artifactId>cxf-dosgi-ri-discovery-local</artifactId>
-		</dependency>
-		<dependency>
-		  	<groupId>org.apache.cxf.dosgi</groupId>
-		  	<artifactId>cxf-dosgi-ri-dsw-cxf</artifactId>
+			<groupId>org.apache.servicemix.specs</groupId>
+			<artifactId>org.apache.servicemix.specs.jsr311-api-1.1</artifactId>
 		</dependency>
 	</dependencies>
 	
@@ -110,9 +102,6 @@
 							com.google.common.*;resolution:=optional,
 							org.slf4j,
 							org.osgi.framework,
-							org.apache.ws.commons.schema.*,
-							org.apache.cxf.*,
-							org.apache.cxf.jaxrs.provider.*,
 							*
 						</Import-Package>
 						<Meta-Persistence>META-INF/persistence.xml</Meta-Persistence>

--- a/extensions/bundles/router.capability.ospf/pom.xml
+++ b/extensions/bundles/router.capability.ospf/pom.xml
@@ -53,12 +53,8 @@
 							classes are under ".internal"
 						-->
 						<Import-Package>
-  							org.slf4j,
-  							javax.ws.rs.*,
+							org.slf4j,
 							org.apache.felix.service.command,
-							javax.xml.bind,
-							javax.xml.bind.annotation,
-							com.sun.xml.bind.v2.runtime.reflect,
 							*
 							</Import-Package>
 						<Export-Package>

--- a/extensions/bundles/test.xml
+++ b/extensions/bundles/test.xml
@@ -1,2 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<test/>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
 		<commons.net.version>1.4.1_3</commons.net.version>
 		<commons.pool.version>1.5.4</commons.pool.version>
 		<cxf.version>2.4.3-fuse-01-02</cxf.version>
-		<cxf.dosgi.version>1.3.1</cxf.dosgi.version>
+		<cxf.dosgi.version>1.3</cxf.dosgi.version>
 		<easymock.version>3.1</easymock.version>
 		<felix.gogo.version>0.10.0</felix.gogo.version>
 		<geronimo.jaxws.version>1.0</geronimo.jaxws.version>
@@ -560,13 +560,18 @@
 			<!-- Web services support -->
 			<dependency>
 				<groupId>org.apache.servicemix.specs</groupId>
+				<artifactId>org.apache.servicemix.specs.jsr311-api-1.1</artifactId>
+				<version>${servicemix.specs.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.servicemix.specs</groupId>
 				<artifactId>org.apache.servicemix.specs.jaxb-api-2.1</artifactId>
 				<version>${servicemix.specs.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.servicemix.specs</groupId>
 				<artifactId>org.apache.servicemix.specs.jaxb-api-2.2</artifactId>
-				<version>1.8.0</version>
+				<version>${servicemix.specs.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.servicemix.bundles</groupId>
@@ -639,6 +644,7 @@
 				<artifactId>cxf-rt-frontend-jaxws</artifactId>
 				<version>${cxf.version}</version>
 			</dependency>
+			
 			<dependency>
 				<groupId>org.apache.cxf</groupId>
 				<artifactId>cxf-rt-transports-http</artifactId>


### PR DESCRIPTION
OpenNaaS bundles do not depend on dosgi bundles anymore, only opennaas-ws-rest does.

The only required dependency in opennas bundles is caused to import javax.ws.rs and its sub packages so REST annotations are resolved.
These packages are provided by
mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.jsr311-api-1.1/${servicemix.specs.version}
so a dependency to this bundle should be added to bundles using REST annotations.

A bug has been found in dosgi 1.3.1: NullPointerException in TopologyManager when unregistering a service.
This bug does not apperr in dosgi 1.3, and as 1.3 seems to provide all functionallity we reuire, we are using 1.3 from now.
