### PR TITLE
Feature/dont load static ws in platform

### DIFF
--- a/core/features/src/main/resources/features.xml
+++ b/core/features/src/main/resources/features.xml
@@ -187,7 +187,7 @@
 		<feature version="${project.version}">opennaas-roadm-proteus</feature>
 		<feature version="${project.version}">opennaas-sampleresource</feature>
 		<feature version="${project.version}">opennaas-cisco</feature>
-		<feature version="${project.version}">opennaas-ws-soap</feature>
+		<!-- <feature version="${project.version}">opennaas-ws-soap</feature> -->
 	</feature>
 
 	<feature name="itests-helpers" version="${project.version}">


### PR DESCRIPTION
Static web services fail intermitently.
As they are going to be removed, we don't want to put more effort in maintaining them.
So we just drop them off.

By now, we are only making platform not loading them, but maintaining them and the demo client.
