### PR TITLE
AbstractCapability throws nullpointerexception if the descriptor of the resource haven't type or name.

### DIFF
--- a/core/resources/src/main/java/org/opennaas/core/resources/capability/AbstractCapability.java
+++ b/core/resources/src/main/java/org/opennaas/core/resources/capability/AbstractCapability.java
@@ -74,14 +74,24 @@ public abstract class AbstractCapability implements ICapabilityLifecycle, IQueue
 	 * @return the resource name through the resource descriptor
 	 */
 	public String getResourceName() {
-		return resource.getResourceDescriptor().getInformation().getName();
+		String resourceName = "";
+		if (resource.getResourceDescriptor() != null
+				&& resource.getResourceDescriptor().getInformation() != null) {
+			resourceName = resource.getResourceDescriptor().getInformation().getType();
+		}
+		return resourceName;
 	}
 
 	/**
 	 * @return the resource name through the resource descriptor
 	 */
 	public String getResourceType() {
-		return resource.getResourceDescriptor().getInformation().getType();
+		String resourceType = "";
+		if (resource.getResourceDescriptor() != null
+				&& resource.getResourceDescriptor().getInformation() != null) {
+			resourceType = resource.getResourceDescriptor().getInformation().getType();
+		}
+		return resourceType;
 	}
 
 	// IQueueingCapability methods


### PR DESCRIPTION
AbstractCapability throws nullpointerexception if the descriptor of the resource haven't type or name.
