### PR TITLE
Add FIXME description in CLIProtocolSession.

### DIFF
--- a/extensions/bundles/protocols.cli/src/main/java/org/opennaas/extensions/protocols/cli/CLIProtocolSession.java
+++ b/extensions/bundles/protocols.cli/src/main/java/org/opennaas/extensions/protocols/cli/CLIProtocolSession.java
@@ -91,7 +91,9 @@ public class CLIProtocolSession implements IProtocolSession{
     
     private void initializePromptsAndErrorPatterns(){
     	prompts = new ArrayList<String>();
-    	//TODO hardcoded since some of these parameters are not allowed in a URL
+    	// TODO hardcoded since some of these parameters are not allowed in a URL
+    	// FIXME Harcoded for catalyst session context, it may change for other resources!!!
+    	// TODO need to find a way to specify these delimiters in catalyst ProtocolSessionContext
     	prompts.add("#");
     	prompts.add(":");
     	prompts.add(">");


### PR DESCRIPTION
Prompt values are used as delimiters for cli output.
Hence, having a delimiter used in the output will cause the output to be cut.

Delimiters shoud be specified per resource type, or per session in its
ProtocolSessionContext.

Delimiters currently harcoded in CLIProtocolSession correspond to
cisco catalyst prompt, but should not be used in CLI sesions to other
resources.
