### PR TITLE
Refactores IResource interface.

### DIFF
--- a/core/resources/src/main/java/org/opennaas/core/resources/IResource.java
+++ b/core/resources/src/main/java/org/opennaas/core/resources/IResource.java
@@ -2,10 +2,10 @@ package org.opennaas.core.resources;
 
 import java.util.List;
 
+import org.opennaas.core.resources.ILifecycle.State;
 import org.opennaas.core.resources.capability.ICapability;
 import org.opennaas.core.resources.descriptor.Information;
 import org.opennaas.core.resources.descriptor.ResourceDescriptor;
-import org.opennaas.core.resources.profile.IProfile;
 
 /**
  * The top level resource interface
@@ -13,11 +13,11 @@ import org.opennaas.core.resources.profile.IProfile;
  * @author Mathieu Lemay (c)2009 Inocybe Technologies inc.
  * 
  */
-public interface IResource extends ILifecycle {
+public interface IResource {
 
 	public IResourceIdentifier getResourceIdentifier();
 
-	public void setResourceIdentifier(IResourceIdentifier identifier);
+	// public void setResourceIdentifier(IResourceIdentifier identifier);
 
 	/**
 	 * Get the resource instance descriptor
@@ -26,20 +26,20 @@ public interface IResource extends ILifecycle {
 	 */
 	public ResourceDescriptor getResourceDescriptor();
 
-	/**
-	 * Set the resource descriptor
-	 * 
-	 * @param resourceDescriptor
-	 */
-	public void setResourceDescriptor(ResourceDescriptor resourceDescriptor);
+	// /**
+	// * Set the resource descriptor
+	// *
+	// * @param resourceDescriptor
+	// */
+	// public void setResourceDescriptor(ResourceDescriptor resourceDescriptor);
 
-	/**
-	 * Set all the capabilities of this resource
-	 * 
-	 * @param capabilities
-	 *            the resource capabilities
-	 */
-	public void setCapabilities(List<? extends ICapability> capabilities);
+	// /**
+	// * Set all the capabilities of this resource
+	// *
+	// * @param capabilities
+	// * the resource capabilities
+	// */
+	// public void setCapabilities(List<? extends ICapability> capabilities);
 
 	/**
 	 * Get all the capabilities of this resource
@@ -48,22 +48,22 @@ public interface IResource extends ILifecycle {
 	 */
 	public List<? extends ICapability> getCapabilities();
 
-	/**
-	 * Add a capability to this resource
-	 * 
-	 * @param capability
-	 *            the actual capability
-	 */
-	public void addCapability(ICapability capability);
-
-	/**
-	 * Remove a capability from this resource
-	 * 
-	 * @param information
-	 *            the information of the capability
-	 * @return the removed capability (null if the capability does not exist)
-	 */
-	public ICapability removeCapability(Information information);
+	// /**
+	// * Add a capability to this resource
+	// *
+	// * @param capability
+	// * the actual capability
+	// */
+	// public void addCapability(ICapability capability);
+	//
+	// /**
+	// * Remove a capability from this resource
+	// *
+	// * @param information
+	// * the information of the capability
+	// * @return the removed capability (null if the capability does not exist)
+	// */
+	// public ICapability removeCapability(Information information);
 
 	/**
 	 * Get a particular capability form this resource
@@ -100,31 +100,36 @@ public interface IResource extends ILifecycle {
 	 */
 	public ICapability getCapabilityByInterface(Class<? extends ICapability> interfaze) throws ResourceException;
 
-	/**
-	 * Start the Resource. The resource must already be instantiated and in the initialized state. This method will perform the necessary
-	 * bootstrapping to transition from INITIALIZED to ACTIVE State
-	 * 
-	 * @throws CorruptStateException
-	 */
-	public void start() throws ResourceException, CorruptStateException;
+	// /**
+	// * Start the Resource. The resource must already be instantiated and in the initialized state. This method will perform the necessary
+	// * bootstrapping to transition from INITIALIZED to ACTIVE State
+	// *
+	// * @throws CorruptStateException
+	// */
+	// public void start() throws ResourceException, CorruptStateException;
+	//
+	// /**
+	// * Stop the resource. This method will transition to the SHUTDOWN State
+	// *
+	// * @throws CorruptStateException
+	// */
+	// public void stop() throws ResourceException, CorruptStateException;
 
-	/**
-	 * Stop the resource. This method will transition to the SHUTDOWN State
-	 * 
-	 * @throws CorruptStateException
-	 */
-	public void stop() throws ResourceException, CorruptStateException;
-
-	public void setModel(IModel model);
+	// public void setModel(IModel model);
 
 	public IModel getModel();
 
-	public IProfile getProfile();
+	// public IProfile getProfile();
 
-	public void setProfile(IProfile profile);
+	// public void setProfile(IProfile profile);
 
-	public IResourceBootstrapper getBootstrapper();
+	// public IResourceBootstrapper getBootstrapper();
 
-	public void setBootstrapper(IResourceBootstrapper bootstrapper);
+	// public void setBootstrapper(IResourceBootstrapper bootstrapper);
+
+	/**
+	 * @return current Lifecycle state of this resource.
+	 */
+	public State getState();
 
 }

--- a/core/resources/src/main/java/org/opennaas/core/resources/IResourceBootstrapper.java
+++ b/core/resources/src/main/java/org/opennaas/core/resources/IResourceBootstrapper.java
@@ -2,27 +2,27 @@ package org.opennaas.core.resources;
 
 /**
  * This interface is used to implement the bootstrapping for a resource.
- *
+ * 
  * @author Scott Campbell (CRC)
- *
+ * 
  */
 public interface IResourceBootstrapper {
 
 	/**
 	 * calls an operation on the first capability in the execution workflow to initialize the resource. This is usually a Query action.
-	 *
+	 * 
 	 * @throws ResourceException
 	 */
-	public void bootstrap(IResource resource) throws ResourceException;
+	public void bootstrap(Resource resource) throws ResourceException;
 
 	/**
 	 * Reverts bootstrap operation, leaving given resource in the same state as if bootstrap had never been called.
-	 *
+	 * 
 	 * @param resource
 	 * @throws ResourceException
 	 */
-	public void revertBootstrap(IResource resource) throws ResourceException;
+	public void revertBootstrap(Resource resource) throws ResourceException;
 
-	public void resetModel (IResource resource) throws ResourceException;
+	public void resetModel(Resource resource) throws ResourceException;
 
 }

--- a/core/resources/src/main/java/org/opennaas/core/resources/Resource.java
+++ b/core/resources/src/main/java/org/opennaas/core/resources/Resource.java
@@ -11,6 +11,7 @@ import org.opennaas.core.resources.capability.ICapabilityLifecycle;
 import org.opennaas.core.resources.descriptor.Information;
 import org.opennaas.core.resources.descriptor.ResourceDescriptor;
 import org.opennaas.core.resources.profile.IProfile;
+import org.opennaas.core.resources.profile.IProfiled;
 
 /**
  * Main resource class
@@ -19,7 +20,7 @@ import org.opennaas.core.resources.profile.IProfile;
  * @author Isart Canyameres Giménez (i2cat)
  * 
  */
-public class Resource implements IResource {
+public class Resource implements IResource, ILifecycle, IProfiled {
 
 	/** The logger **/
 	Log									logger				= LogFactory.getLog(Resource.class);
@@ -163,17 +164,17 @@ public class Resource implements IResource {
 		return resourceDescriptor;
 	}
 
-	@Override
+	// @Override
 	public void setResourceDescriptor(ResourceDescriptor resourceDescriptor) {
 		this.resourceDescriptor = resourceDescriptor;
 	}
 
-	@Override
+	// @Override
 	public void setResourceIdentifier(IResourceIdentifier resourceIdentifier) {
 		this.resourceIdentifier = resourceIdentifier;
 	}
 
-	@Override
+	// @Override
 	public void addCapability(ICapability capability) {
 		if (!(capability instanceof ICapabilityLifecycle))
 			throw new IllegalArgumentException("Given capability must be of type " + ICapabilityLifecycle.class.getName());
@@ -203,7 +204,7 @@ public class Resource implements IResource {
 		return null;
 	}
 
-	@Override
+	// @Override
 	public ICapability removeCapability(Information information) {
 		ICapability capability = getCapability(information);
 		capabilities.remove(capability);
@@ -216,7 +217,7 @@ public class Resource implements IResource {
 	}
 
 	@SuppressWarnings("unchecked")
-	@Override
+	// @Override
 	public void setCapabilities(List<? extends ICapability> capabilities) {
 		for (ICapability capability : capabilities) {
 			if (!(capability instanceof ICapabilityLifecycle))
@@ -246,7 +247,7 @@ public class Resource implements IResource {
 		throw new ResourceException("Cannot find capability with interface " + interfaze);
 	}
 
-	@Override
+	// @Override
 	public void start() throws ResourceException, CorruptStateException {
 		logger.info("Resource is in " + this.getState()
 				+ " state. Trying to start it");
@@ -259,7 +260,7 @@ public class Resource implements IResource {
 		}
 	}
 
-	@Override
+	// @Override
 	public void stop() throws ResourceException, CorruptStateException {
 		logger.info("Resource is in " + this.getState()
 				+ " state. Trying to stop it");
@@ -275,7 +276,7 @@ public class Resource implements IResource {
 	/**
 	 * @return the bootstrapper
 	 */
-	@Override
+	// @Override
 	public IResourceBootstrapper getBootstrapper() {
 		return bootstrapper;
 	}
@@ -284,7 +285,7 @@ public class Resource implements IResource {
 	 * @param bootstrapper
 	 *            the bootstrapper to set
 	 */
-	@Override
+	// @Override
 	public void setBootstrapper(IResourceBootstrapper bootstrapper) {
 		this.bootstrapper = bootstrapper;
 	}
@@ -293,7 +294,7 @@ public class Resource implements IResource {
 	 * @param model
 	 *            the model to set
 	 */
-	@Override
+	// @Override
 	public void setModel(IModel model) {
 		this.model = model;
 	}
@@ -304,6 +305,11 @@ public class Resource implements IResource {
 	@Override
 	public IModel getModel() {
 		return model;
+	}
+
+	@Override
+	public boolean hasProfile() {
+		return (profile != null);
 	}
 
 	@Override

--- a/core/resources/src/main/java/org/opennaas/core/resources/ResourceRepository.java
+++ b/core/resources/src/main/java/org/opennaas/core/resources/ResourceRepository.java
@@ -226,7 +226,7 @@ public class ResourceRepository implements IResourceRepository {
 		try {
 
 			// Get the old resource
-			IResource resource = getResource(identifier);
+			Resource resource = (Resource) getResource(identifier);
 			ResourceDescriptor oldConfig = resource.getResourceDescriptor();
 
 			IResourceIdentifier resourceIdentifier = resource.getResourceIdentifier();
@@ -324,7 +324,7 @@ public class ResourceRepository implements IResourceRepository {
 		}
 	}
 
-	private IResource initResource(IResource resource, ResourceDescriptor resourceDescriptor, IResourceIdentifier resourceIdentifier)
+	private IResource initResource(Resource resource, ResourceDescriptor resourceDescriptor, IResourceIdentifier resourceIdentifier)
 			throws ResourceException, CorruptStateException {
 
 		logger.debug("Initializing resource " + resourceIdentifier.getId() + " ...");
@@ -361,7 +361,7 @@ public class ResourceRepository implements IResourceRepository {
 	private void activateResource(String resourceId) throws ResourceException, CorruptStateException {
 		logger.debug("Activating resource " + resourceId + " ...");
 
-		IResource resource = getResource(resourceId);
+		Resource resource = (Resource) getResource(resourceId);
 
 		// Each repository can override this method to add new conditions to start a resource
 		checkResourceCanBeStarted(resource);
@@ -437,7 +437,7 @@ public class ResourceRepository implements IResourceRepository {
 	private void deactivateResource(String resourceId) throws ResourceException, CorruptStateException {
 		logger.debug("Deactivating resource " + resourceId + " ...");
 
-		IResource resource = getResource(resourceId);
+		Resource resource = (Resource) getResource(resourceId);
 
 		try {
 
@@ -580,7 +580,7 @@ public class ResourceRepository implements IResourceRepository {
 		return capabilities;
 	}
 
-	private void loadProfileInResource(IResource resource, String profileId) throws ResourceException {
+	private void loadProfileInResource(Resource resource, String profileId) throws ResourceException {
 
 		try {
 			IProfileManager profileManager = Activator.getProfileManagerService();
@@ -595,7 +595,7 @@ public class ResourceRepository implements IResourceRepository {
 		}
 	}
 
-	private void unregisterProfileInResource(IResource resource) throws ResourceException {
+	private void unregisterProfileInResource(Resource resource) throws ResourceException {
 		try {
 
 			String profileId = resource.getResourceDescriptor().getProfileId();
@@ -645,7 +645,7 @@ public class ResourceRepository implements IResourceRepository {
 		logger.debug("Resource deactivated");
 	}
 
-	private void forceUnregisterProfileInResource(IResource resource) throws ResourceException {
+	private void forceUnregisterProfileInResource(Resource resource) throws ResourceException {
 		try {
 
 			String profileId = resource.getResourceDescriptor().getProfileId();

--- a/core/resources/src/main/java/org/opennaas/core/resources/capability/AbstractCapability.java
+++ b/core/resources/src/main/java/org/opennaas/core/resources/capability/AbstractCapability.java
@@ -17,6 +17,7 @@ import org.opennaas.core.resources.action.IActionSet;
 import org.opennaas.core.resources.descriptor.CapabilityDescriptor;
 import org.opennaas.core.resources.descriptor.Information;
 import org.opennaas.core.resources.profile.IProfile;
+import org.opennaas.core.resources.profile.IProfiled;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceRegistration;
 
@@ -353,16 +354,18 @@ public abstract class AbstractCapability implements ICapabilityLifecycle, IQueue
 	 *             if there is a problem instantiating the action
 	 */
 	private Action loadActionFromProfile(String actionId) throws ActionException {
-		IProfile profile = resource.getProfile();
-
-		ActionSet actionSet = null;
 		Action action = null;
 
-		if (profile != null) {
-			actionSet = (ActionSet) profile.getActionSetForCapability(capabilityId);
-			if (actionSet != null) {
-				// try to load the actionId from profile ActionSet
-				action = actionSet.obtainAction(actionId);
+		if (resource instanceof IProfiled) {
+			if (((IProfiled) resource).hasProfile()) {
+				IProfile profile = ((IProfiled) resource).getProfile();
+
+				ActionSet actionSet = null;
+				actionSet = (ActionSet) profile.getActionSetForCapability(capabilityId);
+				if (actionSet != null) {
+					// try to load the actionId from profile ActionSet
+					action = actionSet.obtainAction(actionId);
+				}
 			}
 		}
 		return action;

--- a/core/resources/src/main/java/org/opennaas/core/resources/mock/MockResource.java
+++ b/core/resources/src/main/java/org/opennaas/core/resources/mock/MockResource.java
@@ -8,9 +8,9 @@ import java.util.Map;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.opennaas.core.resources.IModel;
-import org.opennaas.core.resources.IResource;
 import org.opennaas.core.resources.IResourceBootstrapper;
 import org.opennaas.core.resources.IResourceIdentifier;
+import org.opennaas.core.resources.Resource;
 import org.opennaas.core.resources.ResourceException;
 import org.opennaas.core.resources.ResourceIdentifier;
 import org.opennaas.core.resources.capability.ICapability;
@@ -22,7 +22,7 @@ import org.opennaas.core.resources.descriptor.ResourceDescriptorConstants;
 import org.opennaas.core.resources.profile.IProfile;
 import org.opennaas.core.resources.protocol.ProtocolSessionContext;
 
-public class MockResource implements IResource {
+public class MockResource extends Resource {
 	static Log					log				= LogFactory
 														.getLog(MockResource.class);
 

--- a/core/resources/src/main/java/org/opennaas/core/resources/profile/IProfiled.java
+++ b/core/resources/src/main/java/org/opennaas/core/resources/profile/IProfiled.java
@@ -1,0 +1,23 @@
+package org.opennaas.core.resources.profile;
+
+public interface IProfiled {
+
+	/**
+	 * 
+	 * @return true if this has a profile, false otherwise. Having <code>null</code> profile is treated as no profile.
+	 */
+	public boolean hasProfile();
+
+	/**
+	 * @return stored profile, or null if this has no profile.
+	 */
+	public IProfile getProfile();
+
+	/**
+	 * Sets stored profile.
+	 * 
+	 * @param profile
+	 */
+	public void setProfile(IProfile profile);
+
+}

--- a/core/resources/src/test/java/org/opennaas/core/resources/tests/ResourceManagerTest.java
+++ b/core/resources/src/test/java/org/opennaas/core/resources/tests/ResourceManagerTest.java
@@ -75,14 +75,14 @@ public class ResourceManagerTest {
 	}
 
 	private IResource getMockResource(String type, String id) {
-		IResource mockResource = new Resource();
+		Resource mockResource = new Resource();
 		IResourceIdentifier mockResourceIdentifier = new ResourceIdentifier(type, id);
 		mockResource.setResourceIdentifier(mockResourceIdentifier);
 		return mockResource;
 	}
 
 	private IResource getMockResourceWithInformation(String type, String id) {
-		IResource mockResource = new Resource();
+		Resource mockResource = new Resource();
 		IResourceIdentifier mockResourceIdentifier = new ResourceIdentifier(type, id);
 		mockResource.setResourceIdentifier(mockResourceIdentifier);
 		ResourceDescriptor resourceDescriptor = new ResourceDescriptor();

--- a/extensions/bundles/bod.repository/src/main/java/org/opennaas/extensions/bod/repository/BoDBootstrapper.java
+++ b/extensions/bundles/bod.repository/src/main/java/org/opennaas/extensions/bod/repository/BoDBootstrapper.java
@@ -3,8 +3,8 @@ package org.opennaas.extensions.bod.repository;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.opennaas.core.resources.IModel;
-import org.opennaas.core.resources.IResource;
 import org.opennaas.core.resources.IResourceBootstrapper;
+import org.opennaas.core.resources.Resource;
 import org.opennaas.core.resources.ResourceException;
 import org.opennaas.core.resources.action.ActionException;
 import org.opennaas.core.resources.capability.AbstractCapability;
@@ -24,7 +24,7 @@ public class BoDBootstrapper implements IResourceBootstrapper {
 
 	private IModel	oldModel;
 
-	public void bootstrap(IResource resource) throws ResourceException {
+	public void bootstrap(Resource resource) throws ResourceException {
 
 		log.info("Loading bootstrap to start resource...");
 		oldModel = resource.getModel();
@@ -67,14 +67,15 @@ public class BoDBootstrapper implements IResourceBootstrapper {
 			}
 		}
 
-		if (resource.getProfile() != null) {
+		if (resource.hasProfile()) {
 			log.debug("Executing initModel from profile...");
 			resource.getProfile().initModel(resource.getModel());
 		}
+
 	}
 
 	@Override
-	public void resetModel(IResource resource) throws ResourceException {
+	public void resetModel(Resource resource) throws ResourceException {
 
 		NetworkDomain networkDomain = new NetworkDomain();
 		ResourceDescriptor resourceDescriptor = resource.getResourceDescriptor();
@@ -89,7 +90,7 @@ public class BoDBootstrapper implements IResourceBootstrapper {
 	}
 
 	@Override
-	public void revertBootstrap(IResource resource) throws ResourceException {
+	public void revertBootstrap(Resource resource) throws ResourceException {
 
 		resource.setModel(oldModel);
 	}

--- a/extensions/bundles/macbridge.ios.resource/src/main/java/org/opennaas/extensions/macbridge/ios/resource/repository/MACBridgeIOSBootstrapper.java
+++ b/extensions/bundles/macbridge.ios.resource/src/main/java/org/opennaas/extensions/macbridge/ios/resource/repository/MACBridgeIOSBootstrapper.java
@@ -5,6 +5,7 @@ import org.apache.commons.logging.LogFactory;
 import org.opennaas.core.resources.IModel;
 import org.opennaas.core.resources.IResource;
 import org.opennaas.core.resources.IResourceBootstrapper;
+import org.opennaas.core.resources.Resource;
 import org.opennaas.core.resources.ResourceException;
 import org.opennaas.core.resources.action.ActionException;
 import org.opennaas.core.resources.capability.AbstractCapability;
@@ -15,25 +16,24 @@ import org.opennaas.core.resources.protocol.ProtocolException;
 import org.opennaas.core.resources.queue.QueueResponse;
 import org.opennaas.extensions.capability.macbridge.model.MACBridge;
 import org.opennaas.extensions.queuemanager.IQueueManagerCapability;
-import org.opennaas.extensions.router.model.ComputerSystem;
 
 public class MACBridgeIOSBootstrapper implements IResourceBootstrapper {
 	Log		log	= LogFactory.getLog(MACBridgeIOSBootstrapper.class);
 	IModel	oldModel;
 
 	@Override
-	public void resetModel(IResource resource) throws ResourceException {
-		//Do nothing, don't want to reset the model (each refresh action updates)
-		//the model whenever it is executed
+	public void resetModel(Resource resource) throws ResourceException {
+		// Do nothing, don't want to reset the model (each refresh action updates)
+		// the model whenever it is executed
 	}
 
 	@Override
-	public void bootstrap(IResource resource) throws ResourceException {
+	public void bootstrap(Resource resource) throws ResourceException {
 		log.info("Loading bootstrap to start resource...");
-		if (resource.getModel() == null){
+		if (resource.getModel() == null) {
 			resource.setModel(new MACBridge());
 		}
-		
+
 		/* start its capabilities */
 		for (ICapability capab : resource.getCapabilities()) {
 			/* abstract capabilities have to be initialized */
@@ -67,7 +67,6 @@ public class MACBridgeIOSBootstrapper implements IResourceBootstrapper {
 		}
 	}
 
-
 	public void createResource(MACBridgeIOSRepository repository, ResourceDescriptor descriptor) {
 		/* Profile info is not cloned */
 		// descriptor.setProfileId(profileName);
@@ -82,9 +81,8 @@ public class MACBridgeIOSBootstrapper implements IResourceBootstrapper {
 				+ resource.getResourceDescriptor().getInformation().getName());
 	}
 
-
 	@Override
-	public void revertBootstrap(IResource resource) throws ResourceException {
+	public void revertBootstrap(Resource resource) throws ResourceException {
 		resource.setModel(oldModel);
 	}
 }

--- a/extensions/bundles/network.repository/src/main/java/org/opennaas/extensions/network/repository/NetworkBootstrapper.java
+++ b/extensions/bundles/network.repository/src/main/java/org/opennaas/extensions/network/repository/NetworkBootstrapper.java
@@ -3,8 +3,8 @@ package org.opennaas.extensions.network.repository;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.opennaas.core.resources.IModel;
-import org.opennaas.core.resources.IResource;
 import org.opennaas.core.resources.IResourceBootstrapper;
+import org.opennaas.core.resources.Resource;
 import org.opennaas.core.resources.ResourceException;
 import org.opennaas.core.resources.descriptor.Information;
 import org.opennaas.extensions.network.model.NetworkModel;
@@ -15,12 +15,12 @@ public class NetworkBootstrapper implements IResourceBootstrapper {
 	IModel	oldModel;
 
 	@Override
-	public void resetModel(IResource resource) throws ResourceException {
+	public void resetModel(Resource resource) throws ResourceException {
 		resource.setModel(new NetworkModel());
 	}
 
 	@Override
-	public void bootstrap(IResource resource) throws ResourceException {
+	public void bootstrap(Resource resource) throws ResourceException {
 		log.info("Loading bootstrap to start resource...");
 
 		oldModel = resource.getModel();
@@ -45,7 +45,7 @@ public class NetworkBootstrapper implements IResourceBootstrapper {
 	}
 
 	@Override
-	public void revertBootstrap(IResource resource) throws ResourceException {
+	public void revertBootstrap(Resource resource) throws ResourceException {
 		resource.setModel(oldModel);
 	}
 }

--- a/extensions/bundles/queuemanager/src/main/java/org/opennaas/extensions/queuemanager/QueueManager.java
+++ b/extensions/bundles/queuemanager/src/main/java/org/opennaas/extensions/queuemanager/QueueManager.java
@@ -12,6 +12,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.opennaas.core.resources.ActivatorException;
 import org.opennaas.core.resources.IResourceManager;
+import org.opennaas.core.resources.Resource;
 import org.opennaas.core.resources.ResourceException;
 import org.opennaas.core.resources.ResourceNotFoundException;
 import org.opennaas.core.resources.action.ActionException;
@@ -297,31 +298,33 @@ public class QueueManager extends AbstractCapability implements
 		clear();
 
 		/* refresh operation */
-		try {
-			// FIXME WHAT CAN WE SO IF BOOTSTRAPPER IS NULL??
-			if (resource.getBootstrapper() == null)
-				throw new ResourceException("Null Bootstrapper found. Could not reset model");
+		if (resource instanceof Resource) {
+			try {
+				// FIXME WHAT CAN WE SO IF BOOTSTRAPPER IS NULL??
+				if (((Resource) resource).getBootstrapper() == null)
+					throw new ResourceException("Null Bootstrapper found. Could not reset model");
 
-			resource.getBootstrapper().resetModel(resource);
-			sendRefresh();
+				((Resource) resource).getBootstrapper().resetModel((Resource) resource);
+				sendRefresh();
 
-		} catch (ResourceException resourceExcept) {
-			log.warn("The resource couldn't reset its model...", resourceExcept);
+			} catch (ResourceException resourceExcept) {
+				log.warn("The resource couldn't reset its model...", resourceExcept);
+			}
+
+			try {
+				ActionResponse refreshResponse = executeRefreshActions(protocolSessionManager);
+				queueResponse.setRefreshResponse(refreshResponse);
+			} catch (ActionException e) {
+				throw new CapabilityException(e);
+			}
+
+			if (((Resource) resource).getProfile() != null) {
+				log.debug("Executing initModel from profile...");
+				((Resource) resource).getProfile().initModel(resource.getModel());
+			}
+
+			initVirtualResources();
 		}
-
-		try {
-			ActionResponse refreshResponse = executeRefreshActions(protocolSessionManager);
-			queueResponse.setRefreshResponse(refreshResponse);
-		} catch (ActionException e) {
-			throw new CapabilityException(e);
-		}
-
-		if (resource.getProfile() != null) {
-			log.debug("Executing initModel from profile...");
-			resource.getProfile().initModel(resource.getModel());
-		}
-
-		initVirtualResources();
 
 		/* stop time */
 		stopTime = java.lang.System.currentTimeMillis();

--- a/extensions/bundles/roadm.repository/src/main/java/org/opennaas/extensions/roadm/repository/ROADMBootstrapper.java
+++ b/extensions/bundles/roadm.repository/src/main/java/org/opennaas/extensions/roadm/repository/ROADMBootstrapper.java
@@ -3,8 +3,8 @@ package org.opennaas.extensions.roadm.repository;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.opennaas.core.resources.IModel;
-import org.opennaas.core.resources.IResource;
 import org.opennaas.core.resources.IResourceBootstrapper;
+import org.opennaas.core.resources.Resource;
 import org.opennaas.core.resources.ResourceException;
 import org.opennaas.core.resources.action.ActionException;
 import org.opennaas.core.resources.action.ActionResponse;
@@ -22,7 +22,7 @@ public class ROADMBootstrapper implements IResourceBootstrapper {
 	private IModel	oldModel;
 
 	@Override
-	public void bootstrap(IResource resource) throws ResourceException {
+	public void bootstrap(Resource resource) throws ResourceException {
 		log.info("Loading bootstrap to start resource..");
 		oldModel = resource.getModel();
 		resource.setModel(new ProteusOpticalSwitch()); // TODO LUMINIS WORK WITH OPTICAL SWITCHES OR WITH PROTEUS OPTICAL SWITCHES
@@ -86,11 +86,12 @@ public class ROADMBootstrapper implements IResourceBootstrapper {
 	}
 
 	@Override
-	public void revertBootstrap(IResource resource) throws ResourceException {
+	public void revertBootstrap(Resource resource) throws ResourceException {
 		resource.setModel(oldModel);
 	}
 
-	public void resetModel(IResource resource) throws ResourceException {
+	@Override
+	public void resetModel(Resource resource) throws ResourceException {
 
 	}
 

--- a/extensions/bundles/router.repository/src/main/java/org/opennaas/extensions/router/repository/MantychoreBootstrapper.java
+++ b/extensions/bundles/router.repository/src/main/java/org/opennaas/extensions/router/repository/MantychoreBootstrapper.java
@@ -10,6 +10,7 @@ import org.opennaas.core.resources.IModel;
 import org.opennaas.core.resources.IResource;
 import org.opennaas.core.resources.IResourceBootstrapper;
 import org.opennaas.core.resources.IResourceManager;
+import org.opennaas.core.resources.Resource;
 import org.opennaas.core.resources.ResourceException;
 import org.opennaas.core.resources.ResourceNotFoundException;
 import org.opennaas.core.resources.action.ActionException;
@@ -29,7 +30,7 @@ public class MantychoreBootstrapper implements IResourceBootstrapper {
 	IModel	oldModel;
 
 	@Override
-	public void resetModel(IResource resource) throws ResourceException {
+	public void resetModel(Resource resource) throws ResourceException {
 		resource.setModel(new ComputerSystem());
 		((ComputerSystem) resource.getModel()).setName(resource.getResourceDescriptor().getInformation().getName());
 		if (isALogicalRouter(resource))
@@ -37,7 +38,7 @@ public class MantychoreBootstrapper implements IResourceBootstrapper {
 	}
 
 	@Override
-	public void bootstrap(IResource resource) throws ResourceException {
+	public void bootstrap(Resource resource) throws ResourceException {
 		log.info("Loading bootstrap to start resource...");
 		oldModel = resource.getModel();
 		resetModel(resource);
@@ -148,7 +149,7 @@ public class MantychoreBootstrapper implements IResourceBootstrapper {
 	}
 
 	@Override
-	public void revertBootstrap(IResource resource) throws ResourceException {
+	public void revertBootstrap(Resource resource) throws ResourceException {
 		resource.setModel(oldModel);
 	}
 

--- a/extensions/bundles/sampleresource/src/main/java/org/opennaas/extensions/sampleresource/repository/sampleResourceBootstrapper.java
+++ b/extensions/bundles/sampleresource/src/main/java/org/opennaas/extensions/sampleresource/repository/sampleResourceBootstrapper.java
@@ -3,8 +3,8 @@ package org.opennaas.extensions.sampleresource.repository;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.opennaas.core.resources.IModel;
-import org.opennaas.core.resources.IResource;
 import org.opennaas.core.resources.IResourceBootstrapper;
+import org.opennaas.core.resources.Resource;
 import org.opennaas.core.resources.ResourceException;
 import org.opennaas.extensions.sampleresource.model.SampleModel;
 
@@ -19,7 +19,7 @@ public class sampleResourceBootstrapper implements IResourceBootstrapper {
 
 	private IModel	oldModel;
 
-	public void bootstrap(IResource resource) throws ResourceException {
+	public void bootstrap(Resource resource) throws ResourceException {
 
 		log.info("Loading bootstrap to start resource...");
 		resource.setModel(new SampleModel());
@@ -28,13 +28,13 @@ public class sampleResourceBootstrapper implements IResourceBootstrapper {
 	}
 
 	@Override
-	public void resetModel(IResource resource) throws ResourceException {
+	public void resetModel(Resource resource) throws ResourceException {
 
 		resource.setModel(new SampleModel());
 	}
 
 	@Override
-	public void revertBootstrap(IResource resource) throws ResourceException {
+	public void revertBootstrap(Resource resource) throws ResourceException {
 
 		resource.setModel(oldModel);
 	}

--- a/itests/core/src/test/java/org/opennaas/itests/core/resources/CoreTest.java
+++ b/itests/core/src/test/java/org/opennaas/itests/core/resources/CoreTest.java
@@ -33,6 +33,7 @@ import org.opennaas.core.events.EventFilter;
 import org.opennaas.core.events.IEventManager;
 import org.opennaas.core.resources.IResource;
 import org.opennaas.core.resources.IResourceManager;
+import org.opennaas.core.resources.Resource;
 import org.opennaas.core.resources.ResourceException;
 import org.opennaas.core.resources.action.ActionSet;
 import org.opennaas.core.resources.action.IActionSet;
@@ -160,7 +161,7 @@ public class CoreTest
 			resourceDescriptor.setProfileId(profile.getProfileName());
 
 			// call createResource(resourceDescriptor)
-			IResource resource = resourceManager.createResource(resourceDescriptor);
+			Resource resource = (Resource) resourceManager.createResource(resourceDescriptor);
 			createProtocolForResource(resource.getResourceIdentifier().getId());
 			resourceManager.startResource(resource.getResourceIdentifier());
 
@@ -206,7 +207,7 @@ public class CoreTest
 			resourceDescriptor.setProfileId(profile.getProfileName());
 
 			// call createResource(resourceDescriptor)
-			IResource resource = resourceManager.createResource(resourceDescriptor);
+			Resource resource = (Resource) resourceManager.createResource(resourceDescriptor);
 			createProtocolForResource(resourceDescriptor.getId());
 			// log.info("UseProfileBundleTest: resource. getResourceIdentifier.getId gives us: " + resource.getResourceIdentifier().getId());
 			resourceManager.startResource(resource.getResourceIdentifier());

--- a/itests/roadm/src/test/java/org/opennaas/itests/roadm/ROADMRespositoryIntegrationTest.java
+++ b/itests/roadm/src/test/java/org/opennaas/itests/roadm/ROADMRespositoryIntegrationTest.java
@@ -21,6 +21,7 @@ import org.opennaas.core.resources.ILifecycle.State;
 import org.opennaas.core.resources.IResource;
 import org.opennaas.core.resources.IResourceManager;
 import org.opennaas.core.resources.IResourceRepository;
+import org.opennaas.core.resources.Resource;
 import org.opennaas.core.resources.ResourceException;
 import org.opennaas.core.resources.action.ActionResponse;
 import org.opennaas.core.resources.action.ActionResponse.STATUS;
@@ -142,7 +143,7 @@ public class ROADMRespositoryIntegrationTest
 		ResourceDescriptor resourceDescriptor = ResourceHelper.newResourceDescriptorProteus("roadm");
 
 		/* create resource */
-		IResource resource = repository.createResource(resourceDescriptor);
+		Resource resource = (Resource) repository.createResource(resourceDescriptor);
 
 		Assert.assertNotNull(resource.getResourceIdentifier());
 		Assert.assertNotNull(resource.getResourceDescriptor());
@@ -198,7 +199,7 @@ public class ROADMRespositoryIntegrationTest
 		ResourceDescriptor resourceDescriptor = ResourceHelper.newResourceDescriptorProteus("roadm");
 
 		/* create resource */
-		IResource resource = repository.createResource(resourceDescriptor);
+		Resource resource = (Resource) repository.createResource(resourceDescriptor);
 
 		Assert.assertNotNull(resource.getResourceIdentifier());
 		Assert.assertNotNull(resource.getResourceDescriptor());
@@ -323,7 +324,7 @@ public class ROADMRespositoryIntegrationTest
 	@Test
 	public void getStartUpRefreshActionTest() throws Exception {
 
-		mockResource.setResourceDescriptor(ResourceHelper.newResourceDescriptorProteus("roadm"));
+		((Resource) mockResource).setResourceDescriptor(ResourceHelper.newResourceDescriptorProteus("roadm"));
 
 		// Test elements not null
 		log.info("Checking connections factory");

--- a/itests/roadm/src/test/java/org/opennaas/itests/roadm/connections/ConnectionsCapabilityIntegrationTest.java
+++ b/itests/roadm/src/test/java/org/opennaas/itests/roadm/connections/ConnectionsCapabilityIntegrationTest.java
@@ -26,6 +26,7 @@ import org.opennaas.core.protocols.sessionmanager.ProtocolSessionManager;
 import org.opennaas.core.resources.IModel;
 import org.opennaas.core.resources.IResource;
 import org.opennaas.core.resources.IResourceManager;
+import org.opennaas.core.resources.Resource;
 import org.opennaas.core.resources.ResourceException;
 import org.opennaas.core.resources.action.ActionException;
 import org.opennaas.core.resources.action.ActionResponse;
@@ -290,7 +291,7 @@ public class ConnectionsCapabilityIntegrationTest
 
 		/* initialize model */
 		mockResource = resourceManager.createResource(CapabilityHelper.newResourceDescriptor("roadm"));
-		mockResource.setModel((IModel) switchFactory.newPedrosaProteusOpticalSwitch());
+		((Resource) mockResource).setModel((IModel) switchFactory.newPedrosaProteusOpticalSwitch());
 
 	}
 

--- a/itests/router/src/test/java/org/opennaas/itests/router/MantychoreRepositoryIntegrationTest.java
+++ b/itests/router/src/test/java/org/opennaas/itests/router/MantychoreRepositoryIntegrationTest.java
@@ -24,6 +24,7 @@ import org.opennaas.core.resources.IResource;
 import org.opennaas.core.resources.IResourceIdentifier;
 import org.opennaas.core.resources.IResourceManager;
 import org.opennaas.core.resources.IResourceRepository;
+import org.opennaas.core.resources.Resource;
 import org.opennaas.core.resources.ResourceException;
 import org.opennaas.core.resources.ResourceNotFoundException;
 import org.opennaas.core.resources.ResourceRepository;
@@ -157,7 +158,7 @@ public class MantychoreRepositoryIntegrationTest
 		resourceDescriptor.setCapabilityDescriptors(capabilityDescriptors);
 
 		/* create resource */
-		IResource resource = resourceManager.createResource(resourceDescriptor);
+		Resource resource = (Resource) resourceManager.createResource(resourceDescriptor);
 
 		Assert.assertNotNull(resource.getResourceIdentifier());
 		Assert.assertNotNull(resource.getResourceDescriptor());
@@ -238,7 +239,7 @@ public class MantychoreRepositoryIntegrationTest
 
 		resourceDescriptor.setCapabilityDescriptors(capabilityDescriptors);
 
-		IResource resource = resourceManager.createResource(resourceDescriptor);
+		Resource resource = (Resource) resourceManager.createResource(resourceDescriptor);
 		resource.setModel(new ComputerSystem());
 		createProtocolForResource(resource.getResourceIdentifier().getId());
 
@@ -288,7 +289,7 @@ public class MantychoreRepositoryIntegrationTest
 
 		resourceDescriptor.setCapabilityDescriptors(capabilityDescriptors);
 
-		IResource resource = resourceManager.createResource(resourceDescriptor);
+		Resource resource = (Resource) resourceManager.createResource(resourceDescriptor);
 		resource.setModel(new ComputerSystem());
 
 		/* first test, check that the resource has created all the logical resources and they have an initialized model */

--- a/itests/router/src/test/java/org/opennaas/itests/router/mock/MockBootstrapper.java
+++ b/itests/router/src/test/java/org/opennaas/itests/router/mock/MockBootstrapper.java
@@ -5,6 +5,7 @@ import org.apache.commons.logging.LogFactory;
 import org.opennaas.core.resources.IModel;
 import org.opennaas.core.resources.IResource;
 import org.opennaas.core.resources.IResourceBootstrapper;
+import org.opennaas.core.resources.Resource;
 import org.opennaas.core.resources.ResourceException;
 import org.opennaas.core.resources.action.ActionException;
 import org.opennaas.core.resources.capability.AbstractCapability;
@@ -22,13 +23,15 @@ public class MockBootstrapper implements IResourceBootstrapper {
 
 	IModel	oldModel;
 
-	public void resetModel(IResource resource) throws ResourceException {
+	@Override
+	public void resetModel(Resource resource) throws ResourceException {
 		resource.setModel(new ComputerSystem());
 		if (isALogicalRouter(resource))
 			((ComputerSystem) resource.getModel()).setElementName(resource.getResourceDescriptor().getInformation().getName());
 	}
 
-	public void bootstrap(IResource resource) throws ResourceException {
+	@Override
+	public void bootstrap(Resource resource) throws ResourceException {
 		log.info("Loading bootstrap to start resource...");
 
 		oldModel = resource.getModel();
@@ -81,7 +84,7 @@ public class MockBootstrapper implements IResourceBootstrapper {
 	}
 
 	@Override
-	public void revertBootstrap(IResource resource) throws ResourceException {
+	public void revertBootstrap(Resource resource) throws ResourceException {
 		resource.setModel(oldModel);
 	}
 


### PR DESCRIPTION
Now IResource does not inherit from ILifecycle, and it has less methods (no setters).
Profile getter/setter have been moved to IProfiled interface.

Resource class, now implements IResource, ILifecycle and IProfiled.

Some classes have been modified to use Resource instead of IResource,
mostly bootstrappers and some tests.

All tests pass. However, I haven't tested web services.
