### PR TITLE
Support for protocols not needing authentication.

### DIFF
--- a/extensions/bundles/bod.autobahn/src/main/java/org/opennaas/extensions/bod/autobahn/protocol/AutobahnProtocolSession.java
+++ b/extensions/bundles/bod.autobahn/src/main/java/org/opennaas/extensions/bod/autobahn/protocol/AutobahnProtocolSession.java
@@ -75,7 +75,7 @@ public class AutobahnProtocolSession implements IProtocolSession
 	public void connect() throws ProtocolException
 	{
 		uapService =
-			createUserAccessPointService(getServiceUri() + "uap2");
+			createUserAccessPointService(getServiceUri() + "uap");
 		administrationService =
 			createAdministrationService(getServiceUri() + "administration");
 		status = CONNECTED;


### PR DESCRIPTION
There're some protocols (like autobahn) not needing an authentication system. protocols:context command has been edited, defining the "noauth" as new authentication type.
