### PR TITLE
Move Cim2NdlMapper from router.model to network.capability.basic.

### DIFF
--- a/core/features/src/main/resources/features.xml
+++ b/core/features/src/main/resources/features.xml
@@ -36,10 +36,6 @@
 
 	<feature name="opennaas-cim" version="${project.version}">
 		<feature version="${opennaas.version}">org.opennaas.core</feature>
-
-		<!-- The core model unfortunately depends on the network model
-		     - it should be the other way around. -->
-		<bundle>mvn:org.opennaas/org.opennaas.extensions.network.model/${project.version}</bundle>
 		<bundle>mvn:org.opennaas/org.opennaas.extensions.router.model/${project.version}</bundle>
 
 		<!-- QueueManager should probably be part of org.opennaas.core,
@@ -115,11 +111,13 @@
 	<feature name="opennaas-network" version="${project.version}">
 		<feature version="${project.version}">opennaas-cim</feature>
 
+		<bundle>mvn:org.opennaas/org.opennaas.extensions.network.model/${project.version}</bundle>
 		<bundle>mvn:org.opennaas/org.opennaas.extensions.network.repository/${project.version}</bundle>
 		<bundle>mvn:org.opennaas/org.opennaas.extensions.network.capability.basic/${project.version}</bundle>
 		<bundle>mvn:org.opennaas/org.opennaas.extensions.network.capability.queue/${project.version}</bundle>
 		<bundle>mvn:org.opennaas/org.opennaas.extensions.network.capability.ospf/${project.version}</bundle>
-		<bundle>mvn:org.opennaas/org.opennaas.extensions.router.capability.ospf/${project.version}</bundle>
+		<bundle dependency="true">mvn:org.opennaas/org.opennaas.extensions.router.capability.ospf/${project.version}</bundle>
+		
 	</feature>
 
 	<feature name="opennaas-bod" version="${project.version}">
@@ -127,6 +125,7 @@
 
 		<bundle dependency="true">mvn:joda-time/joda-time/${jodatime.version}</bundle>
 		<bundle dependency="true">mvn:com.googlecode.guava-osgi/guava-osgi/${guava.version}</bundle>
+		<bundle dependency="true">mvn:org.opennaas/org.opennaas.extensions.network.model/${project.version}</bundle>
 
 		<bundle>mvn:org.opennaas/org.opennaas.extensions.bod.repository/${project.version}</bundle>
 		<bundle>mvn:org.opennaas/org.opennaas.extensions.bod.capability.l2bod/${project.version}</bundle>

--- a/extensions/bundles/bod.repository/pom.xml
+++ b/extensions/bundles/bod.repository/pom.xml
@@ -20,7 +20,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.opennaas</groupId>
-			<artifactId>org.opennaas.extensions.router.model</artifactId>
+			<artifactId>org.opennaas.extensions.network.model</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.opennaas</groupId>

--- a/extensions/bundles/network.capability.basic/pom.xml
+++ b/extensions/bundles/network.capability.basic/pom.xml
@@ -22,12 +22,11 @@
 			<groupId>org.opennaas</groupId>
 			<artifactId>org.opennaas.extensions.network.model</artifactId>
 		</dependency>
-		<!-- FIXME remove when Model2NdlMapper is in IModel instead of mantychore.model -->
 		<dependency>
 			<groupId>org.opennaas</groupId>
 			<artifactId>org.opennaas.extensions.router.model</artifactId>
 		</dependency>
-		<!-- FIXME capability should not depend on repo, mapper should be moved-->
+		<!-- FIXME capability should not depend on repo, ModelToDescriptorMapper should be moved-->
 		<dependency>
 			<groupId>org.opennaas</groupId>
 			<artifactId>org.opennaas.extensions.network.repository</artifactId>

--- a/extensions/bundles/network.capability.basic/src/main/java/org/opennaas/extensions/network/capability/basic/NetworkBasicCapability.java
+++ b/extensions/bundles/network.capability.basic/src/main/java/org/opennaas/extensions/network/capability/basic/NetworkBasicCapability.java
@@ -17,6 +17,7 @@ import org.opennaas.core.resources.capability.AbstractCapability;
 import org.opennaas.core.resources.capability.CapabilityException;
 import org.opennaas.core.resources.descriptor.CapabilityDescriptor;
 import org.opennaas.core.resources.descriptor.network.NetworkTopology;
+import org.opennaas.extensions.network.capability.basic.mappers.Cim2NdlMapper;
 import org.opennaas.extensions.network.model.NetworkModel;
 import org.opennaas.extensions.network.model.NetworkModelHelper;
 import org.opennaas.extensions.network.model.topology.Interface;
@@ -25,7 +26,6 @@ import org.opennaas.extensions.network.model.topology.NetworkConnection;
 import org.opennaas.extensions.network.model.topology.NetworkElement;
 import org.opennaas.extensions.network.repository.NetworkMapperModelToDescriptor;
 import org.opennaas.extensions.router.model.ManagedElement;
-import org.opennaas.extensions.router.model.mappers.Cim2NdlMapper;
 
 public class NetworkBasicCapability extends AbstractCapability implements INetworkBasicCapability {
 

--- a/extensions/bundles/network.capability.basic/src/main/java/org/opennaas/extensions/network/capability/basic/mappers/Cim2NdlMapper.java
+++ b/extensions/bundles/network.capability.basic/src/main/java/org/opennaas/extensions/network/capability/basic/mappers/Cim2NdlMapper.java
@@ -1,4 +1,4 @@
-package org.opennaas.extensions.router.model.mappers;
+package org.opennaas.extensions.network.capability.basic.mappers;
 
 import java.util.ArrayList;
 import java.util.Collection;

--- a/extensions/bundles/network.capability.basic/src/test/java/org/opennaas/extensions/network/capability/basic/tests/Cim2NdlMapperTest.java
+++ b/extensions/bundles/network.capability.basic/src/test/java/org/opennaas/extensions/network/capability/basic/tests/Cim2NdlMapperTest.java
@@ -1,10 +1,11 @@
-package org.opennaas.extensions.router.model.tests;
+package org.opennaas.extensions.network.capability.basic.tests;
 
 import java.util.List;
 
 import junit.framework.Assert;
 
 import org.junit.Test;
+import org.opennaas.extensions.network.capability.basic.mappers.Cim2NdlMapper;
 import org.opennaas.extensions.network.model.NetworkModel;
 import org.opennaas.extensions.network.model.NetworkModelHelper;
 import org.opennaas.extensions.network.model.technology.ethernet.EthernetLayer;
@@ -21,7 +22,6 @@ import org.opennaas.extensions.router.model.IPProtocolEndpoint;
 import org.opennaas.extensions.router.model.LogicalTunnelPort;
 import org.opennaas.extensions.router.model.System;
 import org.opennaas.extensions.router.model.VLANEndpoint;
-import org.opennaas.extensions.router.model.mappers.Cim2NdlMapper;
 
 public class Cim2NdlMapperTest {
 

--- a/extensions/bundles/network.capability.ospf/pom.xml
+++ b/extensions/bundles/network.capability.ospf/pom.xml
@@ -18,6 +18,10 @@
 			<groupId>org.opennaas</groupId>
 			<artifactId>org.opennaas.extensions.router.capability.ospf</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.opennaas</groupId>
+			<artifactId>org.opennaas.extensions.network.model</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/extensions/bundles/network.capability.queue/pom.xml
+++ b/extensions/bundles/network.capability.queue/pom.xml
@@ -26,6 +26,10 @@
 			<groupId>org.opennaas</groupId>
 			<artifactId>org.opennaas.extensions.queuemanager</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.opennaas</groupId>
+			<artifactId>org.opennaas.extensions.network.model</artifactId>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/extensions/bundles/router.model/pom.xml
+++ b/extensions/bundles/router.model/pom.xml
@@ -19,11 +19,6 @@
 			<groupId>org.opennaas</groupId>
 			<artifactId>org.opennaas.core.resources</artifactId>
 		</dependency>
-		<!-- FIXME remove when toNDL is in IModel instead of in ManagedElement -->
-		<dependency>
-			<groupId>org.opennaas</groupId>
-			<artifactId>org.opennaas.extensions.network.model</artifactId>
-		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/itests/bod/pom.xml
+++ b/itests/bod/pom.xml
@@ -20,6 +20,10 @@
 			<groupId>org.opennaas</groupId>
   			<artifactId>org.opennaas.extensions.bod.capability.l2bod</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.opennaas</groupId>
+			<artifactId>org.opennaas.extensions.network.model</artifactId>
+		</dependency>
 		
 		<!--  FIXME check if necessary and delete otherwise -->
 		<dependency>
@@ -38,6 +42,7 @@
 			<groupId>org.opennaas.itests</groupId>
 			<artifactId>org.opennaas.itests.helpers</artifactId>
 		</dependency>
+		
 		
 	</dependencies>
 


### PR DESCRIPTION
Dependency is inverted and router.model knows nothing about networks.
Furthermore, network.model remains unaware of router.model.

Translation from router model to network model is done in network.capability.basic,
so this capability has dependencies to both models.
There are other network capabilities with references to both models,
if they make use of router.model to make calls to router capabilities.

This patch moves the mapper and updates dependencies in features as well as pom files.
Integration tests pass with clean m2 repo.
