### PR TITLE
Check ethernet-tagging encapsulation only in ethernet interfaces.

### DIFF
--- a/extensions/bundles/router.actionsets.junos/src/main/java/org/opennaas/extensions/router/junos/actionssets/actions/chassis/ConfigureSubInterfaceAction.java
+++ b/extensions/bundles/router.actionsets.junos/src/main/java/org/opennaas/extensions/router/junos/actionssets/actions/chassis/ConfigureSubInterfaceAction.java
@@ -60,22 +60,30 @@ public class ConfigureSubInterfaceAction extends JunosAction {
 		if (eth.getName() == null || eth.getName().isEmpty())
 			throw new ActionException(UNVALID_NAME);
 
-		/**
-		 * FIXME. Function should check encapsulation of the physical interface when OpenNaaS support it. For the moment, it's enough to check if the
-		 * params does not contain a vlanEndpoint (which means that the vlanID was not set and the portNumber must be 0)
-		 */
-		if ((eth.getPortNumber() != 0) && (eth.getProtocolEndpoint().isEmpty()))
-			throw new ActionException(UNTAGGED_INTERFACE_ERROR);
-
 		if (eth.getName().startsWith("gr-"))
 			setTemplate("/VM_files/configureGRELogicalInterface.vm");
 
-		else if (eth.getProtocolEndpoint().isEmpty())
-			setTemplate("/VM_files/configureEthWithoutVLAN.vm");
+		else {
 
-		else
-			setTemplate("/VM_files/configureEthVLAN.vm");
+			if (isEthernetInterface(eth)) {
+				/**
+				 * FIXME. Function should check encapsulation of the physical interface when OpenNaaS support it. For the moment, it's enough to check
+				 * if the params does not contain a vlanEndpoint (which means that the vlanID was not set and the portNumber must be 0)
+				 */
+				if ((eth.getPortNumber() != 0) && (eth.getProtocolEndpoint().isEmpty()))
+					throw new ActionException(UNTAGGED_INTERFACE_ERROR);
+			}
 
+			if (eth.getProtocolEndpoint().isEmpty())
+				setTemplate("/VM_files/configureEthWithoutVLAN.vm");
+			else
+				setTemplate("/VM_files/configureEthVLAN.vm");
+		}
+
+	}
+
+	private boolean isEthernetInterface(EthernetPort eth) {
+		return (eth.getName().startsWith("fe") || eth.getName().startsWith("ge"));
 	}
 
 	@Override


### PR DESCRIPTION
There is a check preventing the creation of subinterfaces with unit different than 0
when no ethernet-tagging is specified in the physical interface.

This check was introduced when solving issue:
http://jira.i2cat.net:8080/browse/OPENNAAS-338

In pull request
https://github.com/dana-i2cat/opennaas/pull/278

More precisely on commits:
8911c1bf0d8f2c2fcf3597b88cbba3d190b81a6f
6b502d7e63df5a725de1b28e8a9d89234817af3f

Some interfaces may have subinterfaces without requiring ethernet-tagging.
It is the case of logical interfaces, such as the ones used in gre tunnels.

This patch changes the check to be performed only in ethernet interfaces.
This patch allows the following command to work:
chassis:createsubinterface router:name gr-1/2/0.1
