### PR TITLE
Autobahn stores vlan in RequestParameters adecuately.

### DIFF
--- a/extensions/bundles/bod.autobahn/src/main/java/org/opennaas/extensions/bod/autobahn/bod/GetTopologyAction.java
+++ b/extensions/bundles/bod.autobahn/src/main/java/org/opennaas/extensions/bod/autobahn/bod/GetTopologyAction.java
@@ -159,8 +159,8 @@ public class GetTopologyAction extends AutobahnAction
 			ReservationType reservation)
 	{
 
-		AutobahnInterface sourceClientIface = createClientInterface(source, reservation.getStartPort());
-		AutobahnInterface sinkClientIface = createClientInterface(sink, reservation.getEndPort());
+		AutobahnInterface sourceClientIface = createClientInterface(source, reservation.getStartPort(), reservation.getUserStartVlan());
+		AutobahnInterface sinkClientIface = createClientInterface(sink, reservation.getEndPort(), reservation.getUserEndVlan());
 
 		AutobahnLink link = new AutobahnLink();
 		link.setName(service.getBodID());
@@ -177,9 +177,9 @@ public class GetTopologyAction extends AutobahnAction
 		return link;
 	}
 
-	private AutobahnInterface createClientInterface(AutobahnInterface iface, PortType port) {
+	private AutobahnInterface createClientInterface(AutobahnInterface iface, PortType port, int vlan) {
 		AutobahnInterface clientInterface;
-		if (port.getVlan() >= 0) {
+		if (vlan >= 0) {
 			clientInterface = ParameterTranslator.createInterface(port, iface.isLocal());
 			// there may be two interfaces with same name if generated name is a valid autobahn id
 			clientInterface.setName(port.getAddress() + "." + port.getVlan());

--- a/extensions/bundles/bod.autobahn/src/main/java/org/opennaas/extensions/bod/autobahn/bod/ParameterTranslator.java
+++ b/extensions/bundles/bod.autobahn/src/main/java/org/opennaas/extensions/bod/autobahn/bod/ParameterTranslator.java
@@ -57,12 +57,18 @@ public class ParameterTranslator {
 
 		Interface interface1 = ParameterTranslator.getAutobahnInterfaceFromPortType(reservationRequest.getStartPort(), interfaces);
 		Interface interface2 = ParameterTranslator.getAutobahnInterfaceFromPortType(reservationRequest.getEndPort(), interfaces);
-		int vlanId = ParameterTranslator.getVlan(reservationRequest.getStartPort());
+		int srcVlanId = -1;
+		if (reservationRequest.getUserStartVlan() != 0)
+			srcVlanId = reservationRequest.getUserStartVlan();
+		int dstVlanId = -1;
+		if (reservationRequest.getUserEndVlan() != 0)
+			dstVlanId = reservationRequest.getUserEndVlan();
 		long capacity = reservationRequest.getCapacity();
 		DateTime startTime = ParameterTranslator.toDateTime(reservationRequest.getStartTime());
 		DateTime endTime = ParameterTranslator.toDateTime(reservationRequest.getEndTime());
 
-		RequestConnectionParameters parameters = new RequestConnectionParameters(interface1, interface2, capacity, vlanId, startTime, endTime);
+		RequestConnectionParameters parameters = new RequestConnectionParameters(interface1, interface2, capacity, srcVlanId, dstVlanId, startTime,
+				endTime);
 		return parameters;
 	}
 

--- a/extensions/bundles/bod.autobahn/src/main/java/org/opennaas/extensions/bod/autobahn/commands/CancelServiceCommand.java
+++ b/extensions/bundles/bod.autobahn/src/main/java/org/opennaas/extensions/bod/autobahn/commands/CancelServiceCommand.java
@@ -137,6 +137,7 @@ public class CancelServiceCommand extends AutobahnCommand
 	private void waitUntilOrFailure(State state)
 			throws ActionException, UserAccessPointException_Exception
 		{
+			log.debug("Waiting for Service " + serviceId + " to be " + state);
 			State lastState = State.ACCEPTED;
 			while (true) {
 				ReservationResponse reservation = getReservation();


### PR DESCRIPTION
The way to request a connection is giving the vlan in PortType.
However, when the connection is already created and we obtain it from autobahn,
vlans are specified not in PortType but in userStartVlan and userEndVlan fields of each ReservationRequest.

This patch uses these fields to populate RequestParameters accordingly.
