### PR TITLE
Fix vcpe model marshalling by adding Domain class into Jaxb context.

### DIFF
--- a/extensions/bundles/vcpe/src/main/java/org/opennaas/extensions/vcpe/model/VCPENetworkElement.java
+++ b/extensions/bundles/vcpe/src/main/java/org/opennaas/extensions/vcpe/model/VCPENetworkElement.java
@@ -6,7 +6,7 @@ import javax.xml.bind.annotation.XmlID;
 import javax.xml.bind.annotation.XmlSeeAlso;
 
 @XmlAccessorType(XmlAccessType.FIELD)
-@XmlSeeAlso({ Interface.class, Link.class, Router.class })
+@XmlSeeAlso({ Domain.class, Interface.class, Link.class, Router.class })
 public abstract class VCPENetworkElement {
 
 	@XmlID


### PR DESCRIPTION
To add Domain.class into JAXB context this patch makes use of @SeeAlso annotation.
