### PR TITLE
Skip autobahn circuit creation.

### DIFF
--- a/extensions/bundles/vcpe/src/main/java/org/opennaas/extensions/vcpe/capability/builder/VCPENetworkBuilder.java
+++ b/extensions/bundles/vcpe/src/main/java/org/opennaas/extensions/vcpe/capability/builder/VCPENetworkBuilder.java
@@ -178,13 +178,13 @@ public class VCPENetworkBuilder extends AbstractCapability implements IVCPENetwo
 
 		log.debug("building scenario in resource" + resource.getResourceDescriptor().getInformation().getName());
 
-		createExternalLinks(resource, desiredScenario);
-
-		try {
-			executeAutobahn(desiredScenario);
-		} catch (ProtocolException e) {
-			throw new ResourceException(e);
-		}
+		// createExternalLinks(resource, desiredScenario);
+		//
+		// try {
+		// executeAutobahn(desiredScenario);
+		// } catch (ProtocolException e) {
+		// throw new ResourceException(e);
+		// }
 
 		createSubInterfaces(resource, desiredScenario);
 
@@ -234,13 +234,13 @@ public class VCPENetworkBuilder extends AbstractCapability implements IVCPENetwo
 			throw new ResourceException(e);
 		}
 
-		destroyExternalLinks(resource, currentScenario);
-
-		try {
-			executeAutobahn(currentScenario);
-		} catch (ProtocolException e) {
-			throw new ResourceException(e);
-		}
+		// destroyExternalLinks(resource, currentScenario);
+		//
+		// try {
+		// executeAutobahn(currentScenario);
+		// } catch (ProtocolException e) {
+		// throw new ResourceException(e);
+		// }
 
 		removeResources(currentScenario);
 


### PR DESCRIPTION
Due to a long delay in circuit creation (15 minutes) vcpe creation takes too long.
The demo can not take so much time, so we skip atomatic circuit creation.
