### PR TITLE
Fix bug in autobahn driver using same vlans in requests with same interface

### DIFF
--- a/extensions/bundles/bod.autobahn/src/main/java/org/opennaas/extensions/bod/autobahn/bod/ParameterTranslator.java
+++ b/extensions/bundles/bod.autobahn/src/main/java/org/opennaas/extensions/bod/autobahn/bod/ParameterTranslator.java
@@ -72,9 +72,16 @@ public class ParameterTranslator {
 		return parameters;
 	}
 
-	public static PortType getPortType(AutobahnInterface i, int vlan)
+	private static PortType getPortType(AutobahnInterface i, int vlan)
 	{
-		PortType port = i.getPortType();
+		PortType originalPort = i.getPortType();
+
+		PortType port = new PortType();
+		port.setAddress(originalPort.getAddress());
+		port.setDescription(originalPort.getDescription());
+		port.setIsClient(originalPort.isIsClient());
+		port.setIsIdcp(originalPort.isIsIdcp());
+
 		if (vlan == -1) {
 			port.setMode(Mode.UNTAGGED);
 		} else {


### PR DESCRIPTION
The bug was caused by using same PortType in all requests and, worst, also setting desired vlan in this object for each request.
This caused last request vlan (the last set) being used in all requests and maintained in the model.

This patch solves the problem by creating a copy of the original PortType in each request. Also, vlan is set only in the copy
(not in the original one), maintaining original PortType unchanged.
