### PR TITLE
Allow Template in VCPEManager to take autobahn client interfaces from GUI

### DIFF
--- a/clients/opennaas-gui-vcpe/src/main/java/org/opennaas/gui/vcpe/utils/model/OpennasBeanUtils.java
+++ b/clients/opennaas-gui-vcpe/src/main/java/org/opennaas/gui/vcpe/utils/model/OpennasBeanUtils.java
@@ -92,6 +92,8 @@ public class OpennasBeanUtils {
 		outIface.setIpAddress(inIface.getIpAddress());
 		outIface.setVlanId(inIface.getVlan());
 		outIface.setNameInTemplate(inIface.getTemplateName());
+		outIface.setPhysicalInterfaceName(inIface.getName());
+		outIface.setPortNumber(Integer.parseInt(inIface.getPort()));
 		return outIface;
 	}
 

--- a/extensions/bundles/vcpe/src/main/java/org/opennaas/extensions/vcpe/manager/templates/Template.java
+++ b/extensions/bundles/vcpe/src/main/java/org/opennaas/extensions/vcpe/manager/templates/Template.java
@@ -57,7 +57,7 @@ public class Template implements ITemplate {
 		model.setElements(elements);
 
 		// Generate the physical model
-		List<VCPENetworkElement> physicalElements = generatePhysicalElements();
+		List<VCPENetworkElement> physicalElements = generatePhysicalElements(initialModel);
 
 		// Generate the logical model
 		List<VCPENetworkElement> logicalElements = generateLogicalElements(initialModel);
@@ -86,18 +86,21 @@ public class Template implements ITemplate {
 		String inter1OtherName = props.getProperty("vcpenetwork.logicalrouter1.interface.inter.other.name");
 		String inter1OtherPort = props.getProperty("vcpenetwork.logicalrouter1.interface.inter.other.port");
 		Long inter1OtherVlan = Long.valueOf(props.getProperty("vcpenetwork.logicalrouter1.interface.inter.other.vlan").trim());
-		Interface inter1other = getInterface(inter1OtherName + "." + inter1OtherPort, VCPETemplate.INTER1_INTERFACE_AUTOBAHN, inter1OtherVlan, null);
+		Interface inter1other = getInterface(inter1OtherName + "." + inter1OtherPort, VCPETemplate.INTER1_INTERFACE_AUTOBAHN, inter1OtherVlan, null,
+				inter1OtherName, Integer.parseInt(inter1OtherPort));
 
 		String down1OtherName = props.getProperty("vcpenetwork.logicalrouter1.interface.down.other.name");
 		String down1OtherPort = props.getProperty("vcpenetwork.logicalrouter1.interface.down.other.port");
 		Long down1OtherVlan = Long.valueOf(props.getProperty("vcpenetwork.logicalrouter1.interface.down.other.vlan"));
-		Interface down1other = getInterface(down1OtherName + "." + down1OtherPort, VCPETemplate.DOWN1_INTERFACE_AUTOBAHN, down1OtherVlan, null);
+		Interface down1other = getInterface(down1OtherName + "." + down1OtherPort, VCPETemplate.DOWN1_INTERFACE_AUTOBAHN, down1OtherVlan, null,
+				down1OtherName, Integer.parseInt(down1OtherPort));
 
 		String up1OtherName = props.getProperty("vcpenetwork.logicalrouter1.interface.up.other.name");
 		String up1OtherPort = props.getProperty("vcpenetwork.logicalrouter1.interface.up.other.port");
 		Long up1OtherVlan = Long.valueOf(props.getProperty("vcpenetwork.logicalrouter1.interface.up.other.vlan"));
 		String up1OtherIp = props.getProperty("vcpenetwork.logicalrouter1.interface.up.other.ipaddress");
-		Interface up1other = getInterface(up1OtherName + "." + up1OtherPort, VCPETemplate.UP1_INTERFACE_PEER, up1OtherVlan, up1OtherIp);
+		Interface up1other = getInterface(up1OtherName + "." + up1OtherPort, VCPETemplate.UP1_INTERFACE_PEER, up1OtherVlan, up1OtherIp,
+				up1OtherName, Integer.parseInt(up1OtherPort));
 
 		// ----------------------------- VCPE-router2 -----------------------------
 		Router vcpe2 = (Router) VCPENetworkModelHelper.getElementByNameInTemplate(initialModel, VCPETemplate.VCPE2_ROUTER);
@@ -112,18 +115,21 @@ public class Template implements ITemplate {
 		String inter2OtherName = props.getProperty("vcpenetwork.logicalrouter2.interface.inter.other.name");
 		String inter2OtherPort = props.getProperty("vcpenetwork.logicalrouter2.interface.inter.other.port");
 		Long inter2OtherVlan = Long.valueOf(props.getProperty("vcpenetwork.logicalrouter2.interface.inter.other.vlan").trim());
-		Interface inter2other = getInterface(inter2OtherName + "." + inter2OtherPort, VCPETemplate.INTER2_INTERFACE_AUTOBAHN, inter2OtherVlan, null);
+		Interface inter2other = getInterface(inter2OtherName + "." + inter2OtherPort, VCPETemplate.INTER2_INTERFACE_AUTOBAHN, inter2OtherVlan, null,
+				inter2OtherName, Integer.parseInt(inter2OtherPort));
 
 		String down2OtherName = props.getProperty("vcpenetwork.logicalrouter2.interface.down.other.name");
 		String down2OtherPort = props.getProperty("vcpenetwork.logicalrouter2.interface.down.other.port");
 		Long down2OtherVlan = Long.valueOf(props.getProperty("vcpenetwork.logicalrouter2.interface.down.other.vlan").trim());
-		Interface down2other = getInterface(down2OtherName + "." + down2OtherPort, VCPETemplate.DOWN2_INTERFACE_AUTOBAHN, down2OtherVlan, null);
+		Interface down2other = getInterface(down2OtherName + "." + down2OtherPort, VCPETemplate.DOWN2_INTERFACE_AUTOBAHN, down2OtherVlan, null,
+				down2OtherName, Integer.parseInt(down2OtherPort));
 
 		String up2OtherName = props.getProperty("vcpenetwork.logicalrouter2.interface.up.other.name");
 		String up2OtherPort = props.getProperty("vcpenetwork.logicalrouter2.interface.up.other.port");
 		Long up2OtherVlan = Long.valueOf(props.getProperty("vcpenetwork.logicalrouter2.interface.up.other.vlan").trim());
 		String up2OtherIp = props.getProperty("vcpenetwork.logicalrouter2.interface.up.other.ipaddress");
-		Interface up2other = getInterface(up2OtherName + "." + up2OtherPort, VCPETemplate.UP2_INTERFACE_PEER, up2OtherVlan, up2OtherIp);
+		Interface up2other = getInterface(up2OtherName + "." + up2OtherPort, VCPETemplate.UP2_INTERFACE_PEER, up2OtherVlan, up2OtherIp,
+				up2OtherName, Integer.parseInt(up2OtherPort));
 
 		// Client interfaces
 		Interface client1other = (Interface) VCPENetworkModelHelper.getElementByNameInTemplate(initialModel, VCPETemplate.CLIENT1_INTERFACE_AUTOBAHN);
@@ -193,7 +199,10 @@ public class Template implements ITemplate {
 		return elements;
 	}
 
-	private List<VCPENetworkElement> generatePhysicalElements() {
+	private List<VCPENetworkElement> generatePhysicalElements(VCPENetworkModel initialModel) {
+
+		// TODO MUST CHECK CREATED ELEMENTS EXIST IN PHYSICAL TOPOLOGY
+
 		Router r1 = new Router();
 		r1.setNameInTemplate(VCPETemplate.CPE1_PHY_ROUTER);
 		r1.setName(props.getProperty("vcpenetwork.router1.name"));
@@ -218,9 +227,13 @@ public class Template implements ITemplate {
 		up1.setNameInTemplate(VCPETemplate.UP1_PHY_INTERFACE_LOCAL);
 		up1.setName(props.getProperty("vcpenetwork.router1.interface.up.name"));
 
+		// select client1 interface using initialModel
+		Interface inputClient1 = (Interface) VCPENetworkModelHelper.getElementByNameInTemplate(initialModel, VCPETemplate.CLIENT1_INTERFACE_AUTOBAHN);
+
 		Interface client1 = new Interface();
 		client1.setNameInTemplate(VCPETemplate.CLIENT1_PHY_INTERFACE_AUTOBAHN);
-		client1.setName(props.getProperty("vcpenetwork.router1.interface.client.name"));
+		client1.setName(inputClient1.getPhysicalInterfaceName());
+		// TODO check there is a physical interface in physical topology with client1.getName() name
 
 		List<Interface> r1Interfaces = new ArrayList<Interface>();
 		r1Interfaces.add(inter1);
@@ -252,9 +265,13 @@ public class Template implements ITemplate {
 		up2.setNameInTemplate(VCPETemplate.UP2_PHY_INTERFACE_LOCAL);
 		up2.setName(props.getProperty("vcpenetwork.router2.interface.up.name"));
 
+		// select client1 interface using initialModel
+		Interface inputClient2 = (Interface) VCPENetworkModelHelper.getElementByNameInTemplate(initialModel, VCPETemplate.CLIENT2_INTERFACE_AUTOBAHN);
+
 		Interface client2 = new Interface();
 		client2.setNameInTemplate(VCPETemplate.CLIENT2_PHY_INTERFACE_AUTOBAHN);
-		client2.setName(props.getProperty("vcpenetwork.router2.interface.client.name"));
+		client2.setName(inputClient2.getPhysicalInterfaceName());
+		// TODO check there is a physical interface in physical topology with client2.getName() name
 
 		List<Interface> r2Interfaces = new ArrayList<Interface>();
 		r2Interfaces.add(inter2);
@@ -293,12 +310,14 @@ public class Template implements ITemplate {
 	 * @param ipAddress
 	 * @return the interface
 	 */
-	private Interface getInterface(String name, String nameInTemplate, long vlan, String ipAddress) {
+	private Interface getInterface(String name, String nameInTemplate, long vlan, String ipAddress, String physicalInterfaceName, int portNum) {
 		Interface iface = new Interface();
 		iface.setName(name);
 		iface.setNameInTemplate(nameInTemplate);
 		iface.setIpAddress(ipAddress);
 		iface.setVlanId(vlan);
+		iface.setPhysicalInterfaceName(physicalInterfaceName);
+		iface.setPortNumber(portNum);
 		return iface;
 	}
 

--- a/extensions/bundles/vcpe/src/main/java/org/opennaas/extensions/vcpe/model/Interface.java
+++ b/extensions/bundles/vcpe/src/main/java/org/opennaas/extensions/vcpe/model/Interface.java
@@ -10,6 +10,14 @@ public class Interface extends VCPENetworkElement {
 
 	private String	ipAddress;
 
+	/**
+	 * Logical interfaces must hold a reference to the physical interface they belong to. This field provides this reference by holding the physical
+	 * interface name.
+	 */
+	private String	physicalInterfaceName;
+
+	private int		portNumber;
+
 	public long getVlanId() {
 		return vlanId;
 	}
@@ -26,11 +34,29 @@ public class Interface extends VCPENetworkElement {
 		this.ipAddress = ipAddress;
 	}
 
+	public String getPhysicalInterfaceName() {
+		return physicalInterfaceName;
+	}
+
+	public void setPhysicalInterfaceName(String physicalInterfaceName) {
+		this.physicalInterfaceName = physicalInterfaceName;
+	}
+
+	public int getPortNumber() {
+		return portNumber;
+	}
+
+	public void setPortNumber(int portNumber) {
+		this.portNumber = portNumber;
+	}
+
 	@Override
 	public int hashCode() {
 		final int prime = 31;
 		int result = super.hashCode();
 		result = prime * result + ((ipAddress == null) ? 0 : ipAddress.hashCode());
+		result = prime * result + ((physicalInterfaceName == null) ? 0 : physicalInterfaceName.hashCode());
+		result = prime * result + portNumber;
 		result = prime * result + (int) (vlanId ^ (vlanId >>> 32));
 		return result;
 	}
@@ -58,6 +84,13 @@ public class Interface extends VCPENetworkElement {
 			if (other.ipAddress != null)
 				return false;
 		} else if (!ipAddress.equals(other.ipAddress))
+			return false;
+		if (physicalInterfaceName == null) {
+			if (other.physicalInterfaceName != null)
+				return false;
+		} else if (!physicalInterfaceName.equals(other.physicalInterfaceName))
+			return false;
+		if (portNumber != other.portNumber)
 			return false;
 		if (vlanId != other.vlanId)
 			return false;


### PR DESCRIPTION
This patch gives the user flexibility to choose the client interfaces.

It is not yet save to let the user change the value in the GUI, because there is no check telling if the interface is in managed physical topology. There is no managed physical topology in VCPEManager yet.
