### PR TITLE
Update BGP VLT to place peer-as tag inside neighbour.

### DIFF
--- a/extensions/bundles/fragment.velocity/src/main/resources/VM_files/configureBGP.vm
+++ b/extensions/bundles/fragment.velocity/src/main/resources/VM_files/configureBGP.vm
@@ -62,14 +62,9 @@
 									#set($hasRemoteAS = false)
 								#end
 								#if($hasRemoteAS)
-									#set($remoteAS = $bgpPep.getRemoteAS())
+									<peer-as>$bgpPep.getRemoteAS()</peer-as>
 								#end
 							</neighbor>
-						#end
-						##peer-as is specified per PEP in CIM model
-						#if (! $remoteAS)
-						#else
-						<peer-as>$remoteAS</peer-as>
 						#end
 						## SET GROUP TYPE ACCORDING TO PEPS
 						<type>$bgpType</type>

--- a/extensions/bundles/router.actionsets.junos/src/main/resources/VM_files/configureBGP.vm
+++ b/extensions/bundles/router.actionsets.junos/src/main/resources/VM_files/configureBGP.vm
@@ -62,14 +62,9 @@
 									#set($hasRemoteAS = false)
 								#end
 								#if($hasRemoteAS)
-									#set($remoteAS = $bgpPep.getRemoteAS())
+									<peer-as>$bgpPep.getRemoteAS()</peer-as>
 								#end
 							</neighbor>
-						#end
-						##peer-as is specified per PEP in CIM model
-						#if (! $remoteAS)
-						#else
-						<peer-as>$remoteAS</peer-as>
 						#end
 						## SET GROUP TYPE ACCORDING TO PEPS
 						<type>$bgpType</type>


### PR DESCRIPTION
This allows peer-as specification per bgp neighbor.
