### PR TITLE
Update lo unit in properties file to match testbed.

### DIFF
--- a/extensions/bundles/vcpe/src/main/resources/templates/template.properties
+++ b/extensions/bundles/vcpe/src/main/resources/templates/template.properties
@@ -75,7 +75,7 @@ vcpenetwork.logicalrouter1.interface.up.ipaddress = 193.1.190.133/30
 vcpenetwork.logicalrouter1.interface.up.labelname = Up
 
 vcpenetwork.logicalrouter1.interface.lo.name = lo0
-vcpenetwork.logicalrouter1.interface.lo.port = 100
+vcpenetwork.logicalrouter1.interface.lo.port = 101
 vcpenetwork.logicalrouter1.interface.lo.vlan = 
 vcpenetwork.logicalrouter1.interface.lo.ipaddress = 193.1.190.141/30
 vcpenetwork.logicalrouter1.interface.lo.labelname = Loopback
@@ -121,7 +121,7 @@ vcpenetwork.logicalrouter2.interface.up.ipaddress = 193.1.190.129/30
 vcpenetwork.logicalrouter2.interface.up.labelname = Up
 
 vcpenetwork.logicalrouter2.interface.lo.name = lo0
-vcpenetwork.logicalrouter2.interface.lo.port = 73
+vcpenetwork.logicalrouter2.interface.lo.port = 102
 vcpenetwork.logicalrouter2.interface.lo.vlan = 
 vcpenetwork.logicalrouter2.interface.lo.ipaddress = 193.1.239.73/32
 vcpenetwork.logicalrouter2.interface.lo.labelname = Loopback


### PR DESCRIPTION
There is a logical router in testbed using lo0.73 interface.
A second logical router with the same interface cannot be created in the same physical one.

This patch changes the unit use from 73 to 102.
