### PR TITLE
Implement getLogicalInfrastructureSuggestion in basic template.

### DIFF
--- a/extensions/bundles/vcpe/src/main/java/org/opennaas/extensions/vcpe/manager/IVCPENetworkManager.java
+++ b/extensions/bundles/vcpe/src/main/java/org/opennaas/extensions/vcpe/manager/IVCPENetworkManager.java
@@ -89,6 +89,23 @@ public interface IVCPENetworkManager {
 	public VCPENetworkModel getPhyInfrastructureSuggestion(@QueryParam("templateType") String templateType) throws VCPENetworkManagerException;
 
 	/**
+	 * Get a suggestion for the logical infrastructure
+	 * 
+	 * @param templateType
+	 *            whose physical infrastructure is desired.
+	 * @param physicalInfrastructure
+	 *            supporting the logical infrastructure to obtain.
+	 * @return the suggested logical infrastructure
+	 * @throws VCPENetworkManagerException
+	 */
+	@Path("/getLogicalInfrastructureSuggestion")
+	@POST
+	@Produces(MediaType.APPLICATION_XML)
+	@Consumes(MediaType.APPLICATION_XML)
+	public VCPENetworkModel getLogicalInfrastructureSuggestion(@QueryParam("templateType") String templateType,
+			VCPENetworkModel physicalInfrastructure) throws VCPENetworkManagerException;
+
+	/**
 	 * Check if a VLAN is available or not in a interface
 	 * 
 	 * @param vcpeId

--- a/extensions/bundles/vcpe/src/main/java/org/opennaas/extensions/vcpe/manager/VCPENetworkManager.java
+++ b/extensions/bundles/vcpe/src/main/java/org/opennaas/extensions/vcpe/manager/VCPENetworkManager.java
@@ -133,6 +133,18 @@ public class VCPENetworkManager implements IVCPENetworkManager {
 		return phySuggestion;
 	}
 
+	/**
+	 * @return
+	 * @throws VCPENetworkManagerException
+	 */
+	@Override
+	public VCPENetworkModel getLogicalInfrastructureSuggestion(String templateType, VCPENetworkModel physical) throws VCPENetworkManagerException {
+
+		ITemplate template = TemplateSelector.getTemplate(templateType);
+		VCPENetworkModel suggestion = template.getLogicalInfrastructureSuggestion(physical);
+		return suggestion;
+	}
+
 	/*
 	 * (non-Javadoc)
 	 * 

--- a/extensions/bundles/vcpe/src/main/java/org/opennaas/extensions/vcpe/manager/templates/ITemplate.java
+++ b/extensions/bundles/vcpe/src/main/java/org/opennaas/extensions/vcpe/manager/templates/ITemplate.java
@@ -24,4 +24,6 @@ public interface ITemplate {
 
 	public VCPENetworkModel getPhysicalInfrastructureSuggestion() throws VCPENetworkManagerException;
 
+	public VCPENetworkModel getLogicalInfrastructureSuggestion(VCPENetworkModel physicalInfrastructure) throws VCPENetworkManagerException;
+
 }

--- a/extensions/bundles/vcpe/src/main/java/org/opennaas/extensions/vcpe/manager/templates/Template.java
+++ b/extensions/bundles/vcpe/src/main/java/org/opennaas/extensions/vcpe/manager/templates/Template.java
@@ -18,6 +18,7 @@ import org.opennaas.extensions.vcpe.model.BGP;
 import org.opennaas.extensions.vcpe.model.Domain;
 import org.opennaas.extensions.vcpe.model.Interface;
 import org.opennaas.extensions.vcpe.model.Link;
+import org.opennaas.extensions.vcpe.model.LogicalRouter;
 import org.opennaas.extensions.vcpe.model.Router;
 import org.opennaas.extensions.vcpe.model.VCPENetworkElement;
 import org.opennaas.extensions.vcpe.model.VCPENetworkModel;
@@ -72,25 +73,22 @@ public class Template implements ITemplate {
 		model.setClientIpRange(initialModel.getClientIpRange());
 		model.setTemplateType(initialModel.getTemplateType());
 
-		List<VCPENetworkElement> elements = new ArrayList<VCPENetworkElement>();
-		model.setElements(elements);
-
+		// FIXME TEMPORAL CODE. REMOVE WHEN REFACTOR IS COMPLETED. initialModel will be a complete model.
 		// Generate the physical model
-		List<VCPENetworkElement> physicalElements = generateAndMapPhysicalElements(initialModel).getElements();
-
+		VCPENetworkModel phy = generateAndMapPhysicalElements(initialModel);
 		// checkPhysicalAvailability(physicalElements, managerModel);
-
 		// Generate the logical model
-		List<VCPENetworkElement> logicalElements = generateLogicalElements(initialModel);
+		VCPENetworkModel logical = generateAndMapLogicalElements(phy, initialModel);
 
 		// set VRRP configuration
-		model.setVrrp(configureVRRP(initialModel));
-
-		model.setBgp(generateBGPConfig(initialModel));
+		// model.setVrrp(configureVRRP(logical));
+		model.setVrrp(logical.getVrrp());
+		model.setBgp(generateBGPConfig(logical));
 
 		// Add all elements
-		elements.addAll(physicalElements);
-		elements.addAll(logicalElements);
+		List<VCPENetworkElement> elements = new ArrayList<VCPENetworkElement>();
+		model.setElements(elements);
+		elements.addAll(logical.getElements());
 		return model;
 	}
 
@@ -102,6 +100,671 @@ public class Template implements ITemplate {
 		VCPENetworkModel mappedFromProperties = mapPhysicalElementsFromProperties(generated, props);
 		// TODO MUST CHECK MAPPED ELEMENTS EXIST IN PHYSICAL TOPOLOGY
 		return mappedFromProperties;
+	}
+
+	@Override
+	public VCPENetworkModel getLogicalInfrastructureSuggestion(VCPENetworkModel physicalInfrastructure) {
+
+		VCPENetworkModel generated = generateLogicalElements();
+		// TODO suggested mapping should be more intelligent, not properties driven
+		VCPENetworkModel mappedFromProperties = mapLogicalElementsFromProperties(generated, props);
+		VCPENetworkModel mappedWithPhy = mapLogicalAndPhysical(physicalInfrastructure, mappedFromProperties);
+		// TODO MUST CHECK MAPPED ELEMENTS EXIST IN PHYSICAL INFRASTRUCTURE
+		return mappedWithPhy;
+	}
+
+	// FIXME TEMPORAL METHOD. REMOVE WHEN REFACTOR IS FINISHED
+	private VCPENetworkModel generateAndMapPhysicalElements(VCPENetworkModel initialModel) {
+
+		VCPENetworkModel generated = generatePhysicalElements();
+		VCPENetworkModel mappedFromProperties = mapPhysicalElementsFromProperties(generated, props);
+		VCPENetworkModel mapped = mapPhysicalElementsFromInputModel(mappedFromProperties, initialModel);
+		// TODO MUST CHECK MAPPED ELEMENTS EXIST IN PHYSICAL TOPOLOGY
+		return mapped;
+	}
+
+	// FIXME TEMPORAL METHOD. REMOVE WHEN REFACTOR IS FINISHED
+	private VCPENetworkModel generateAndMapLogicalElements(VCPENetworkModel phy, VCPENetworkModel initialModel) {
+
+		VCPENetworkModel suggested = getLogicalInfrastructureSuggestion(phy);
+		VCPENetworkModel mapped = mapLogicalElementsFromInputModel(suggested, initialModel);
+		// TODO MUST CHECK MAPPED ELEMENTS EXIST IN PHYSICAL TOPOLOGY
+		return mapped;
+	}
+
+	private VCPENetworkModel generatePhysicalElements() {
+
+		Router core = new Router();
+		core.setTemplateName(VCPETemplate.CORE_PHY_ROUTER);
+
+		Interface coreMaster = new Interface();
+		coreMaster.setTemplateName(VCPETemplate.CORE_PHY_INTERFACE_MASTER);
+
+		Interface coreBkp = new Interface();
+		coreBkp.setTemplateName(VCPETemplate.CORE_PHY_INTERFACE_BKP);
+
+		Interface coreLo = new Interface();
+		coreLo.setTemplateName(VCPETemplate.CORE_PHY_LO_INTERFACE);
+
+		List<Interface> coreInterfaces = new ArrayList<Interface>();
+		coreInterfaces.add(coreMaster);
+		coreInterfaces.add(coreBkp);
+		coreInterfaces.add(coreLo);
+		core.setInterfaces(coreInterfaces);
+
+		Router r1 = new Router();
+		r1.setTemplateName(VCPETemplate.CPE1_PHY_ROUTER);
+
+		Interface inter1 = new Interface();
+		inter1.setTemplateName(VCPETemplate.INTER1_PHY_INTERFACE_LOCAL);
+
+		Interface inter1other = new Interface();
+		inter1other.setTemplateName(VCPETemplate.INTER1_PHY_INTERFACE_AUTOBAHN);
+
+		Interface down1 = new Interface();
+		down1.setTemplateName(VCPETemplate.DOWN1_PHY_INTERFACE_LOCAL);
+
+		Interface down1other = new Interface();
+		down1other.setTemplateName(VCPETemplate.DOWN1_PHY_INTERFACE_AUTOBAHN);
+
+		Interface up1 = new Interface();
+		up1.setTemplateName(VCPETemplate.UP1_PHY_INTERFACE_LOCAL);
+
+		Interface client1 = new Interface();
+		client1.setTemplateName(VCPETemplate.CLIENT1_PHY_INTERFACE_AUTOBAHN);
+
+		Interface lo1 = new Interface();
+		lo1.setTemplateName(VCPETemplate.LO1_PHY_INTERFACE);
+
+		List<Interface> r1Interfaces = new ArrayList<Interface>();
+		r1Interfaces.add(inter1);
+		r1Interfaces.add(down1);
+		r1Interfaces.add(up1);
+		r1Interfaces.add(lo1);
+		r1.setInterfaces(r1Interfaces);
+
+		Router r2 = new Router();
+		r2.setTemplateName(VCPETemplate.CPE2_PHY_ROUTER);
+
+		Interface inter2 = new Interface();
+		inter2.setTemplateName(VCPETemplate.INTER2_PHY_INTERFACE_LOCAL);
+
+		Interface inter2other = new Interface();
+		inter2other.setTemplateName(VCPETemplate.INTER2_PHY_INTERFACE_AUTOBAHN);
+
+		Interface down2 = new Interface();
+		down2.setTemplateName(VCPETemplate.DOWN2_PHY_INTERFACE_LOCAL);
+
+		Interface down2other = new Interface();
+		down2other.setTemplateName(VCPETemplate.DOWN2_PHY_INTERFACE_AUTOBAHN);
+
+		Interface up2 = new Interface();
+		up2.setTemplateName(VCPETemplate.UP2_PHY_INTERFACE_LOCAL);
+
+		Interface client2 = new Interface();
+		client2.setTemplateName(VCPETemplate.CLIENT2_PHY_INTERFACE_AUTOBAHN);
+
+		Interface lo2 = new Interface();
+		lo2.setTemplateName(VCPETemplate.LO2_PHY_INTERFACE);
+
+		List<Interface> r2Interfaces = new ArrayList<Interface>();
+		r2Interfaces.add(inter2);
+		r2Interfaces.add(down2);
+		r2Interfaces.add(up2);
+		r2Interfaces.add(lo2);
+		r2.setInterfaces(r2Interfaces);
+
+		Domain autobahn = new Domain();
+		autobahn.setTemplateName(VCPETemplate.AUTOBAHN);
+
+		List<Interface> autobahnInterfaces = new ArrayList<Interface>();
+		autobahnInterfaces.add(inter1other);
+		autobahnInterfaces.add(inter2other);
+		autobahnInterfaces.add(down1other);
+		autobahnInterfaces.add(down2other);
+		autobahnInterfaces.add(client1);
+		autobahnInterfaces.add(client2);
+		autobahn.setInterfaces(autobahnInterfaces);
+
+		List<VCPENetworkElement> elements = new ArrayList<VCPENetworkElement>();
+		elements.add(core);
+		elements.addAll(core.getInterfaces());
+		elements.add(r1);
+		elements.addAll(r1.getInterfaces());
+		elements.add(r2);
+		elements.addAll(r2.getInterfaces());
+		elements.add(autobahn);
+		elements.addAll(autobahn.getInterfaces());
+
+		VCPENetworkModel model = new VCPENetworkModel();
+		model.setElements(elements);
+		model.setTemplateType(getTemplateType());
+		model.setCreated(false);
+
+		return model;
+	}
+
+	private VCPENetworkModel generateLogicalElements() {
+
+		// LogicalRouter 1
+		Router vcpe1 = new LogicalRouter();
+		vcpe1.setTemplateName(VCPETemplate.VCPE1_ROUTER);
+
+		List<Interface> interfaces = new ArrayList<Interface>();
+		vcpe1.setInterfaces(interfaces);
+		Interface inter1 = new Interface();
+		Interface down1 = new Interface();
+		Interface up1 = new Interface();
+		Interface lo1 = new Interface();
+		interfaces.add(inter1);
+		interfaces.add(down1);
+		interfaces.add(up1);
+		interfaces.add(lo1);
+
+		inter1.setTemplateName(VCPETemplate.INTER1_INTERFACE_LOCAL);
+		down1.setTemplateName(VCPETemplate.DOWN1_INTERFACE_LOCAL);
+		up1.setTemplateName(VCPETemplate.UP1_INTERFACE_LOCAL);
+		lo1.setTemplateName(VCPETemplate.LO1_INTERFACE);
+
+		// LogicalRouter 2
+		Router vcpe2 = new LogicalRouter();
+		vcpe2.setTemplateName(VCPETemplate.VCPE2_ROUTER);
+
+		interfaces = new ArrayList<Interface>();
+		vcpe2.setInterfaces(interfaces);
+		Interface inter2 = new Interface();
+		Interface down2 = new Interface();
+		Interface up2 = new Interface();
+		Interface lo2 = new Interface();
+		interfaces.add(inter2);
+		interfaces.add(down2);
+		interfaces.add(up2);
+		interfaces.add(lo2);
+
+		inter2.setTemplateName(VCPETemplate.INTER2_INTERFACE_LOCAL);
+		down2.setTemplateName(VCPETemplate.DOWN2_INTERFACE_LOCAL);
+		up2.setTemplateName(VCPETemplate.UP2_INTERFACE_LOCAL);
+		lo2.setTemplateName(VCPETemplate.LO2_INTERFACE);
+
+		// BoD
+		// Notice these logical interfaces are not inside a BoD object (by now)
+		List<Interface> bodInterfaces = new ArrayList<Interface>();
+		Interface inter1other = new Interface();
+		Interface down1other = new Interface();
+		Interface inter2other = new Interface();
+		Interface down2other = new Interface();
+		Interface client1other = new Interface();
+		Interface client2other = new Interface();
+		bodInterfaces.add(inter1other);
+		bodInterfaces.add(down1other);
+		bodInterfaces.add(inter2other);
+		bodInterfaces.add(down2other);
+		bodInterfaces.add(client1other);
+		bodInterfaces.add(client2other);
+
+		inter1other.setTemplateName(VCPETemplate.INTER1_INTERFACE_AUTOBAHN);
+		down1other.setTemplateName(VCPETemplate.DOWN1_INTERFACE_AUTOBAHN);
+		inter2other.setTemplateName(VCPETemplate.INTER2_INTERFACE_AUTOBAHN);
+		down2other.setTemplateName(VCPETemplate.DOWN2_INTERFACE_AUTOBAHN);
+		client1other.setTemplateName(VCPETemplate.CLIENT1_INTERFACE_AUTOBAHN);
+		client2other.setTemplateName(VCPETemplate.CLIENT2_INTERFACE_AUTOBAHN);
+
+		// noc network interface
+		// Notice these logical interfaces are not inside a router object (by now)
+		Interface up1other = new Interface();
+		Interface up2other = new Interface();
+
+		up1other.setTemplateName(VCPETemplate.UP1_INTERFACE_PEER);
+		up2other.setTemplateName(VCPETemplate.UP2_INTERFACE_PEER);
+
+		// LINKS
+
+		// Inter links
+		Link linkInter1local = getLink(null, VCPETemplate.INTER1_LINK_LOCAL, VCPETemplate.LINK_TYPE_ETH, inter1, inter1other);
+		Link linkInter1other = getLink(null, VCPETemplate.INTER_LINK_AUTOBAHN, VCPETemplate.LINK_TYPE_AUTOBAHN, inter1other, inter2other);
+		Link linkInter2local = getLink(null, VCPETemplate.INTER2_LINK_LOCAL, VCPETemplate.LINK_TYPE_ETH, inter2, inter2other);
+
+		// Down links
+		Link linkDown1local = getLink(null, VCPETemplate.DOWN1_LINK_LOCAL, VCPETemplate.LINK_TYPE_ETH, down1, down1other);
+		Link linkDown1other = getLink(null, VCPETemplate.DOWN1_LINK_AUTOBAHN, VCPETemplate.LINK_TYPE_AUTOBAHN, down1other, client1other);
+
+		Link linkDown2local = getLink(null, VCPETemplate.DOWN2_LINK_LOCAL, VCPETemplate.LINK_TYPE_ETH, down2, down2other);
+		Link linkDown2other = getLink(null, VCPETemplate.DOWN2_LINK_AUTOBAHN, VCPETemplate.LINK_TYPE_AUTOBAHN, down2other, client2other);
+
+		// Up links
+		Link linkUp1 = getLink(null, VCPETemplate.UP1_LINK, VCPETemplate.LINK_TYPE_LT, up1, up1other);
+		Link linkUp2 = getLink(null, VCPETemplate.UP2_LINK, VCPETemplate.LINK_TYPE_LT, up2, up2other);
+
+		// Virtual links
+		Link linkInter = getLink(null, VCPETemplate.INTER_LINK, VCPETemplate.LINK_TYPE_VIRTUAL, inter1, inter2);
+		List<Link> subLinks = new ArrayList<Link>();
+		subLinks.add(linkInter1local);
+		subLinks.add(linkInter1other);
+		subLinks.add(linkInter2local);
+		linkInter.setImplementedBy(subLinks);
+		Link linkdown1 = getLink(null, VCPETemplate.DOWN1_LINK, VCPETemplate.LINK_TYPE_VIRTUAL, down1, client1other);
+		subLinks = new ArrayList<Link>();
+		subLinks.add(linkDown1local);
+		subLinks.add(linkDown1other);
+		linkdown1.setImplementedBy(subLinks);
+		Link linkdown2 = getLink(null, VCPETemplate.DOWN2_LINK, VCPETemplate.LINK_TYPE_VIRTUAL, down2, client2other);
+		subLinks.add(linkDown2local);
+		subLinks.add(linkDown2other);
+		linkdown2.setImplementedBy(subLinks);
+
+		List<VCPENetworkElement> elements = new ArrayList<VCPENetworkElement>();
+		elements.add(vcpe1);
+		elements.addAll(vcpe1.getInterfaces());
+		elements.add(vcpe2);
+		elements.addAll(vcpe2.getInterfaces());
+		elements.addAll(bodInterfaces);
+		elements.add(up1other);
+		elements.add(up2other);
+		elements.add(linkInter);
+		elements.addAll(linkInter.getImplementedBy());
+		elements.add(linkdown1);
+		elements.addAll(linkdown1.getImplementedBy());
+		elements.add(linkdown2);
+		elements.addAll(linkdown2.getImplementedBy());
+		elements.add(linkUp1);
+		elements.add(linkUp2);
+
+		// configure VRRP
+		VRRP vrrp = new VRRP();
+		vrrp.setMasterRouter(vcpe1);
+		vrrp.setMasterInterface(down1);
+		vrrp.setBackupRouter(vcpe2);
+		vrrp.setBackupInterface(down2);
+
+		VCPENetworkModel model = new VCPENetworkModel();
+		model.setElements(elements);
+		model.setTemplateType(getTemplateType());
+		model.setCreated(false);
+		model.setVrrp(vrrp);
+		model.setBgp(new BGP());
+
+		return model;
+	}
+
+	private VCPENetworkModel mapPhysicalElementsFromProperties(VCPENetworkModel model, Properties props) {
+
+		Router core = (Router) VCPENetworkModelHelper.getElementByTemplateName(model, VCPETemplate.CORE_PHY_ROUTER);
+		core.setName(props.getProperty("vcpenetwork.routercore.name"));
+
+		Interface coremaster = (Interface) VCPENetworkModelHelper.getElementByTemplateName(core.getInterfaces(),
+				VCPETemplate.CORE_PHY_INTERFACE_MASTER);
+		coremaster.setName(props.getProperty("vcpenetwork.routercore.interface.master.name"));
+		coremaster.setPhysicalInterfaceName(props.getProperty("vcpenetwork.routercore.interface.master.name"));
+
+		Interface corebkp = (Interface) VCPENetworkModelHelper.getElementByTemplateName(core.getInterfaces(), VCPETemplate.CORE_PHY_INTERFACE_BKP);
+		corebkp.setName(props.getProperty("vcpenetwork.routercore.interface.bkp.name"));
+		corebkp.setPhysicalInterfaceName(props.getProperty("vcpenetwork.routercore.interface.bkp.name"));
+
+		Interface corelo = (Interface) VCPENetworkModelHelper.getElementByTemplateName(core.getInterfaces(), VCPETemplate.CORE_PHY_LO_INTERFACE);
+		corelo.setName(props.getProperty("vcpenetwork.routercore.interface.lo.name"));
+		corelo.setPhysicalInterfaceName(props.getProperty("vcpenetwork.routercore.interface.lo.name"));
+
+		// Router1
+		Router r1 = (Router) VCPENetworkModelHelper.getElementByTemplateName(model, VCPETemplate.CPE1_PHY_ROUTER);
+		r1.setName(props.getProperty("vcpenetwork.router1.name"));
+
+		Interface inter1 = (Interface) VCPENetworkModelHelper.getElementByTemplateName(r1.getInterfaces(), VCPETemplate.INTER1_PHY_INTERFACE_LOCAL);
+		inter1.setName(props.getProperty("vcpenetwork.router1.interface.inter.name"));
+		inter1.setPhysicalInterfaceName(props.getProperty("vcpenetwork.router1.interface.inter.name"));
+
+		Interface down1 = (Interface) VCPENetworkModelHelper.getElementByTemplateName(r1.getInterfaces(), VCPETemplate.DOWN1_PHY_INTERFACE_LOCAL);
+		down1.setName(props.getProperty("vcpenetwork.router1.interface.down.name"));
+		down1.setPhysicalInterfaceName(props.getProperty("vcpenetwork.router1.interface.down.name"));
+
+		Interface up1 = (Interface) VCPENetworkModelHelper.getElementByTemplateName(r1.getInterfaces(), VCPETemplate.UP1_PHY_INTERFACE_LOCAL);
+		up1.setName(props.getProperty("vcpenetwork.router1.interface.up.name"));
+		up1.setPhysicalInterfaceName(props.getProperty("vcpenetwork.router1.interface.up.name"));
+
+		Interface lo1 = (Interface) VCPENetworkModelHelper.getElementByTemplateName(r1.getInterfaces(), VCPETemplate.LO1_PHY_INTERFACE);
+		lo1.setName(props.getProperty("vcpenetwork.router1.interface.lo.name"));
+		lo1.setPhysicalInterfaceName(props.getProperty("vcpenetwork.router1.interface.lo.name"));
+
+		// Router2
+		Router r2 = (Router) VCPENetworkModelHelper.getElementByTemplateName(model, VCPETemplate.CPE2_PHY_ROUTER);
+		r2.setName(props.getProperty("vcpenetwork.router2.name"));
+
+		Interface inter2 = (Interface) VCPENetworkModelHelper.getElementByTemplateName(r2.getInterfaces(), VCPETemplate.INTER2_PHY_INTERFACE_LOCAL);
+		inter2.setName(props.getProperty("vcpenetwork.router2.interface.inter.name"));
+		inter2.setPhysicalInterfaceName(props.getProperty("vcpenetwork.router2.interface.inter.name"));
+
+		Interface down2 = (Interface) VCPENetworkModelHelper.getElementByTemplateName(r2.getInterfaces(), VCPETemplate.DOWN2_PHY_INTERFACE_LOCAL);
+		down2.setName(props.getProperty("vcpenetwork.router2.interface.down.name"));
+		down2.setPhysicalInterfaceName(props.getProperty("vcpenetwork.router2.interface.down.name"));
+
+		Interface up2 = (Interface) VCPENetworkModelHelper.getElementByTemplateName(r2.getInterfaces(), VCPETemplate.UP2_PHY_INTERFACE_LOCAL);
+		up2.setName(props.getProperty("vcpenetwork.router2.interface.up.name"));
+		up2.setPhysicalInterfaceName(props.getProperty("vcpenetwork.router2.interface.up.name"));
+
+		Interface lo2 = (Interface) VCPENetworkModelHelper.getElementByTemplateName(r2.getInterfaces(), VCPETemplate.LO2_PHY_INTERFACE);
+		lo2.setName(props.getProperty("vcpenetwork.router2.interface.lo.name"));
+		lo2.setPhysicalInterfaceName(props.getProperty("vcpenetwork.router2.interface.lo.name"));
+
+		// BoD
+		Domain autobahn = (Domain) VCPENetworkModelHelper.getElementByTemplateName(model, VCPETemplate.AUTOBAHN);
+		autobahn.setName(props.getProperty("vcpenetwork.bod.name"));
+
+		Interface inter1other = (Interface) VCPENetworkModelHelper.getElementByTemplateName(autobahn.getInterfaces(),
+				VCPETemplate.INTER1_PHY_INTERFACE_AUTOBAHN);
+		inter1other.setName(props.getProperty("vcpenetwork.router1.interface.inter.other.name"));
+		inter1other.setPhysicalInterfaceName(props.getProperty("vcpenetwork.router1.interface.inter.other.name"));
+
+		Interface down1other = (Interface) VCPENetworkModelHelper.getElementByTemplateName(autobahn.getInterfaces(),
+				VCPETemplate.DOWN1_PHY_INTERFACE_AUTOBAHN);
+		down1other.setName(props.getProperty("vcpenetwork.router1.interface.down.other.name"));
+		down1other.setPhysicalInterfaceName(props.getProperty("vcpenetwork.router1.interface.down.other.name"));
+
+		Interface inter2other = (Interface) VCPENetworkModelHelper.getElementByTemplateName(autobahn.getInterfaces(),
+				VCPETemplate.INTER2_PHY_INTERFACE_AUTOBAHN);
+		inter2other.setName(props.getProperty("vcpenetwork.router2.interface.inter.other.name"));
+		inter2other.setPhysicalInterfaceName(props.getProperty("vcpenetwork.router2.interface.inter.other.name"));
+
+		Interface down2other = (Interface) VCPENetworkModelHelper.getElementByTemplateName(autobahn.getInterfaces(),
+				VCPETemplate.DOWN2_PHY_INTERFACE_AUTOBAHN);
+		down2other.setName(props.getProperty("vcpenetwork.router2.interface.down.other.name"));
+		down2other.setPhysicalInterfaceName(props.getProperty("vcpenetwork.router2.interface.down.other.name"));
+
+		// TODO BoD client interfaces
+		// NOT SUGGESTED (they change in every client)
+
+		return model;
+	}
+
+	private VCPENetworkModel mapLogicalElementsFromProperties(VCPENetworkModel model, Properties props) {
+
+		// Logical Router 1
+		Router vcpe1 = (Router) VCPENetworkModelHelper.getElementByTemplateName(model, VCPETemplate.VCPE1_ROUTER);
+		vcpe1.setName(props.getProperty("vcpenetwork.logicalrouter1.name"));
+
+		Interface ifaceInter = (Interface) VCPENetworkModelHelper
+				.getElementByTemplateName(vcpe1.getInterfaces(), VCPETemplate.INTER1_INTERFACE_LOCAL);
+		ifaceInter.setPhysicalInterfaceName(props.getProperty("vcpenetwork.logicalrouter1.interface.inter.name"));
+		ifaceInter.setPort(Integer.parseInt(props.getProperty("vcpenetwork.logicalrouter1.interface.inter.port").trim()));
+		ifaceInter.setVlan(Integer.parseInt(props.getProperty("vcpenetwork.logicalrouter1.interface.inter.vlan").trim()));
+		ifaceInter.setIpAddress(props.getProperty("vcpenetwork.logicalrouter1.interface.inter.ipaddress"));
+		ifaceInter.setName(ifaceInter.getPhysicalInterfaceName() + "." + ifaceInter.getPort());
+
+		Interface ifaceDown = (Interface) VCPENetworkModelHelper.getElementByTemplateName(vcpe1.getInterfaces(), VCPETemplate.DOWN1_INTERFACE_LOCAL);
+		ifaceDown.setPhysicalInterfaceName(props.getProperty("vcpenetwork.logicalrouter1.interface.down.name"));
+		ifaceDown.setPort(Integer.parseInt(props.getProperty("vcpenetwork.logicalrouter1.interface.down.port").trim()));
+		ifaceDown.setVlan(Integer.parseInt(props.getProperty("vcpenetwork.logicalrouter1.interface.down.vlan").trim()));
+		ifaceDown.setIpAddress(props.getProperty("vcpenetwork.logicalrouter1.interface.down.ipaddress"));
+		ifaceDown.setName(ifaceDown.getPhysicalInterfaceName() + "." + ifaceDown.getPort());
+
+		Interface ifaceUp = (Interface) VCPENetworkModelHelper.getElementByTemplateName(vcpe1.getInterfaces(), VCPETemplate.UP1_INTERFACE_LOCAL);
+		ifaceUp.setPhysicalInterfaceName(props.getProperty("vcpenetwork.logicalrouter1.interface.up.name"));
+		ifaceUp.setPort(Integer.parseInt(props.getProperty("vcpenetwork.logicalrouter1.interface.up.port").trim()));
+		ifaceUp.setVlan(Integer.parseInt(props.getProperty("vcpenetwork.logicalrouter1.interface.up.vlan").trim()));
+		ifaceUp.setIpAddress(props.getProperty("vcpenetwork.logicalrouter1.interface.up.ipaddress"));
+		ifaceUp.setName(ifaceUp.getPhysicalInterfaceName() + "." + ifaceUp.getPort());
+
+		Interface ifaceLo = (Interface) VCPENetworkModelHelper.getElementByTemplateName(vcpe1.getInterfaces(), VCPETemplate.LO1_INTERFACE);
+		ifaceLo.setPhysicalInterfaceName(props.getProperty("vcpenetwork.logicalrouter1.interface.lo.name"));
+		ifaceLo.setPort(Integer.parseInt(props.getProperty("vcpenetwork.logicalrouter1.interface.lo.port").trim()));
+		ifaceLo.setIpAddress(props.getProperty("vcpenetwork.logicalrouter1.interface.lo.ipaddress"));
+		ifaceLo.setName(ifaceLo.getPhysicalInterfaceName() + "." + ifaceLo.getPort());
+
+		// Logical Router 2
+		Router vcpe2 = (Router) VCPENetworkModelHelper.getElementByTemplateName(model, VCPETemplate.VCPE2_ROUTER);
+		vcpe2.setName(props.getProperty("vcpenetwork.logicalrouter2.name"));
+
+		ifaceInter = (Interface) VCPENetworkModelHelper.getElementByTemplateName(vcpe2.getInterfaces(), VCPETemplate.INTER2_INTERFACE_LOCAL);
+		ifaceInter.setPhysicalInterfaceName(props.getProperty("vcpenetwork.logicalrouter2.interface.inter.name"));
+		ifaceInter.setPort(Integer.parseInt(props.getProperty("vcpenetwork.logicalrouter2.interface.inter.port").trim()));
+		ifaceInter.setVlan(Integer.parseInt(props.getProperty("vcpenetwork.logicalrouter2.interface.inter.vlan").trim()));
+		ifaceInter.setIpAddress(props.getProperty("vcpenetwork.logicalrouter2.interface.inter.ipaddress"));
+		ifaceInter.setName(ifaceInter.getPhysicalInterfaceName() + "." + ifaceInter.getPort());
+
+		ifaceDown = (Interface) VCPENetworkModelHelper.getElementByTemplateName(vcpe2.getInterfaces(), VCPETemplate.DOWN2_INTERFACE_LOCAL);
+		ifaceDown.setPhysicalInterfaceName(props.getProperty("vcpenetwork.logicalrouter2.interface.down.name"));
+		ifaceDown.setPort(Integer.parseInt(props.getProperty("vcpenetwork.logicalrouter2.interface.down.port").trim()));
+		ifaceDown.setVlan(Integer.parseInt(props.getProperty("vcpenetwork.logicalrouter2.interface.down.vlan").trim()));
+		ifaceDown.setIpAddress(props.getProperty("vcpenetwork.logicalrouter2.interface.down.ipaddress"));
+		ifaceDown.setName(ifaceDown.getPhysicalInterfaceName() + "." + ifaceDown.getPort());
+
+		ifaceUp = (Interface) VCPENetworkModelHelper.getElementByTemplateName(vcpe2.getInterfaces(), VCPETemplate.UP2_INTERFACE_LOCAL);
+		ifaceUp.setPhysicalInterfaceName(props.getProperty("vcpenetwork.logicalrouter2.interface.up.name"));
+		ifaceUp.setPort(Integer.parseInt(props.getProperty("vcpenetwork.logicalrouter2.interface.up.port").trim()));
+		ifaceUp.setVlan(Integer.parseInt(props.getProperty("vcpenetwork.logicalrouter2.interface.up.vlan").trim()));
+		ifaceUp.setIpAddress(props.getProperty("vcpenetwork.logicalrouter2.interface.up.ipaddress"));
+		ifaceUp.setName(ifaceUp.getPhysicalInterfaceName() + "." + ifaceUp.getPort());
+
+		ifaceLo = (Interface) VCPENetworkModelHelper.getElementByTemplateName(vcpe2.getInterfaces(), VCPETemplate.LO2_INTERFACE);
+		ifaceLo.setPhysicalInterfaceName(props.getProperty("vcpenetwork.logicalrouter2.interface.lo.name"));
+		ifaceLo.setPort(Integer.parseInt(props.getProperty("vcpenetwork.logicalrouter2.interface.lo.port").trim()));
+		ifaceLo.setIpAddress(props.getProperty("vcpenetwork.logicalrouter2.interface.lo.ipaddress"));
+		ifaceLo.setName(ifaceLo.getPhysicalInterfaceName() + "." + ifaceLo.getPort());
+
+		// BoD
+		Interface ifaceClient1 = (Interface) VCPENetworkModelHelper.getElementByTemplateName(model, VCPETemplate.CLIENT1_INTERFACE_AUTOBAHN);
+		ifaceClient1.setPhysicalInterfaceName(props.getProperty("vcpenetwork.logicalrouter1.interface.client.name"));
+		ifaceClient1.setPort(Integer.parseInt(props.getProperty("vcpenetwork.logicalrouter1.interface.client.port").trim()));
+		ifaceClient1.setVlan(Integer.parseInt(props.getProperty("vcpenetwork.logicalrouter1.interface.client.vlan").trim()));
+		ifaceClient1.setName(ifaceClient1.getPhysicalInterfaceName() + "." + ifaceClient1.getPort());
+
+		Interface ifaceClient2 = (Interface) VCPENetworkModelHelper.getElementByTemplateName(model, VCPETemplate.CLIENT2_INTERFACE_AUTOBAHN);
+		ifaceClient2.setPhysicalInterfaceName(props.getProperty("vcpenetwork.logicalrouter2.interface.client.name"));
+		ifaceClient2.setPort(Integer.parseInt(props.getProperty("vcpenetwork.logicalrouter2.interface.client.port").trim()));
+		ifaceClient2.setVlan(Integer.parseInt(props.getProperty("vcpenetwork.logicalrouter2.interface.client.vlan").trim()));
+		ifaceClient2.setName(ifaceClient2.getPhysicalInterfaceName() + "." + ifaceClient2.getPort());
+
+		Interface inter1other = (Interface) VCPENetworkModelHelper.getElementByTemplateName(model, VCPETemplate.INTER1_INTERFACE_AUTOBAHN);
+		inter1other.setPhysicalInterfaceName(props.getProperty("vcpenetwork.logicalrouter1.interface.inter.other.name"));
+		inter1other.setPort(Integer.parseInt(props.getProperty("vcpenetwork.logicalrouter1.interface.inter.other.port").trim()));
+		inter1other.setVlan(Integer.parseInt(props.getProperty("vcpenetwork.logicalrouter1.interface.inter.other.vlan").trim()));
+		inter1other.setName(inter1other.getPhysicalInterfaceName() + "." + inter1other.getPort());
+
+		Interface down1other = (Interface) VCPENetworkModelHelper.getElementByTemplateName(model, VCPETemplate.DOWN1_INTERFACE_AUTOBAHN);
+		down1other.setPhysicalInterfaceName(props.getProperty("vcpenetwork.logicalrouter1.interface.down.other.name"));
+		down1other.setPort(Integer.parseInt(props.getProperty("vcpenetwork.logicalrouter1.interface.down.other.port").trim()));
+		down1other.setVlan(Integer.parseInt(props.getProperty("vcpenetwork.logicalrouter1.interface.down.other.vlan").trim()));
+		down1other.setName(down1other.getPhysicalInterfaceName() + "." + down1other.getPort());
+
+		Interface inter2other = (Interface) VCPENetworkModelHelper.getElementByTemplateName(model, VCPETemplate.INTER2_INTERFACE_AUTOBAHN);
+		inter2other.setPhysicalInterfaceName(props.getProperty("vcpenetwork.logicalrouter2.interface.inter.other.name"));
+		inter2other.setPort(Integer.parseInt(props.getProperty("vcpenetwork.logicalrouter2.interface.inter.other.port").trim()));
+		inter2other.setVlan(Integer.parseInt(props.getProperty("vcpenetwork.logicalrouter2.interface.inter.other.vlan").trim()));
+		inter2other.setName(inter2other.getPhysicalInterfaceName() + "." + inter2other.getPort());
+
+		Interface down2other = (Interface) VCPENetworkModelHelper.getElementByTemplateName(model, VCPETemplate.DOWN2_INTERFACE_AUTOBAHN);
+		down2other.setPhysicalInterfaceName(props.getProperty("vcpenetwork.logicalrouter2.interface.down.other.name"));
+		down2other.setPort(Integer.parseInt(props.getProperty("vcpenetwork.logicalrouter2.interface.down.other.port").trim()));
+		down2other.setVlan(Integer.parseInt(props.getProperty("vcpenetwork.logicalrouter2.interface.down.other.vlan").trim()));
+		down2other.setName(down2other.getPhysicalInterfaceName() + "." + down2other.getPort());
+
+		// Noc network
+		Interface up1other = (Interface) VCPENetworkModelHelper.getElementByTemplateName(model, VCPETemplate.UP1_INTERFACE_PEER);
+		up1other.setPhysicalInterfaceName(props.getProperty("vcpenetwork.logicalrouter1.interface.up.other.name"));
+		up1other.setPort(Integer.parseInt(props.getProperty("vcpenetwork.logicalrouter1.interface.up.other.port").trim()));
+		up1other.setVlan(Integer.parseInt(props.getProperty("vcpenetwork.logicalrouter1.interface.up.other.vlan").trim()));
+		up1other.setIpAddress(props.getProperty("vcpenetwork.logicalrouter1.interface.up.other.ipaddress"));
+		up1other.setName(up1other.getPhysicalInterfaceName() + "." + up1other.getPort());
+
+		Interface up2other = (Interface) VCPENetworkModelHelper.getElementByTemplateName(model, VCPETemplate.UP2_INTERFACE_PEER);
+		up2other.setPhysicalInterfaceName(props.getProperty("vcpenetwork.logicalrouter2.interface.up.other.name"));
+		up2other.setPort(Integer.parseInt(props.getProperty("vcpenetwork.logicalrouter2.interface.up.other.port").trim()));
+		up2other.setVlan(Integer.parseInt(props.getProperty("vcpenetwork.logicalrouter2.interface.up.other.vlan").trim()));
+		up2other.setIpAddress(props.getProperty("vcpenetwork.logicalrouter2.interface.up.other.ipaddress"));
+		up2other.setName(up2other.getPhysicalInterfaceName() + "." + up2other.getPort());
+
+		// VRRP
+		int vrrpGoup = Integer.parseInt(props.getProperty("vcpenetwork.vrrp.group").trim());
+		int masterVRRPPriority = Integer.parseInt(props.getProperty("vcpenetwork.vrrp.master.priority").trim());
+		int backupVRRPPriority = Integer.parseInt(props.getProperty("vcpenetwork.vrrp.backup.priority").trim());
+		model.getVrrp().setGroup(vrrpGoup);
+		model.getVrrp().setPriorityMaster(masterVRRPPriority);
+		model.getVrrp().setPriorityBackup(backupVRRPPriority);
+		model.getVrrp().setVirtualIPAddress(props.getProperty("vcpenetwork.vrrp.virtualIPAddress"));
+
+		// BGP
+		model.getBgp().setClientASNumber(props.getProperty("vcpenetwork.bgp.clientASNumber"));
+		model.getBgp().setNocASNumber(props.getProperty("vcpenetwork.bgp.nocASNumber"));
+		List<String> clientPrefixes = new ArrayList<String>();
+		clientPrefixes.add(props.getProperty("vcpenetwork.bgp.clientPrefixes"));
+		model.getBgp().setCustomerPrefixes(clientPrefixes);
+
+		// VCPE
+		model.setClientIpRange(props.getProperty("vcpenetwork.client.iprange"));
+
+		return model;
+	}
+
+	private VCPENetworkModel mapPhysicalElementsFromInputModel(VCPENetworkModel model, VCPENetworkModel inputModel) {
+
+		// TODO update ALL elements with data in inputModel (everything may have changed)
+
+		// select client1 interface using inputModel
+		Interface inputClient1 = (Interface) VCPENetworkModelHelper.getElementByTemplateName(inputModel,
+				VCPETemplate.CLIENT1_INTERFACE_AUTOBAHN);
+
+		Interface client1 = (Interface) VCPENetworkModelHelper.getElementByTemplateName(model, VCPETemplate.CLIENT1_PHY_INTERFACE_AUTOBAHN);
+		client1.setName(inputClient1.getName());
+		client1.setPhysicalInterfaceName(inputClient1.getPhysicalInterfaceName());
+
+		// select client2 interface using inputModel
+		Interface inputClient2 = (Interface) VCPENetworkModelHelper.getElementByTemplateName(inputModel,
+				VCPETemplate.CLIENT2_INTERFACE_AUTOBAHN);
+
+		Interface client2 = (Interface) VCPENetworkModelHelper.getElementByTemplateName(model, VCPETemplate.CLIENT2_PHY_INTERFACE_AUTOBAHN);
+		client2.setName(inputClient2.getName());
+		client2.setPhysicalInterfaceName(inputClient2.getPhysicalInterfaceName());
+
+		return model;
+	}
+
+	private VCPENetworkModel mapLogicalElementsFromInputModel(VCPENetworkModel model, VCPENetworkModel inputModel) {
+
+		// TODO update ALL elements with data in inputModel (everything may have changed)
+
+		// LR1
+		Router vcpe1input = (Router) VCPENetworkModelHelper.getElementByTemplateName(inputModel, VCPETemplate.VCPE1_ROUTER);
+		Router vcpe1 = (Router) VCPENetworkModelHelper.getElementByTemplateName(model, VCPETemplate.VCPE1_ROUTER);
+		vcpe1.setName(vcpe1input.getName() + "-" + inputModel.getName());
+
+		Interface inter1input = (Interface) VCPENetworkModelHelper.getElementByTemplateName(vcpe1input.getInterfaces(),
+				VCPETemplate.INTER1_INTERFACE_LOCAL);
+		Interface down1input = (Interface) VCPENetworkModelHelper.getElementByTemplateName(vcpe1input.getInterfaces(),
+				VCPETemplate.DOWN1_INTERFACE_LOCAL);
+		Interface up1input = (Interface) VCPENetworkModelHelper
+				.getElementByTemplateName(vcpe1input.getInterfaces(), VCPETemplate.UP1_INTERFACE_LOCAL);
+		Interface lo1input = (Interface) VCPENetworkModelHelper
+				.getElementByTemplateName(vcpe1input.getInterfaces(), VCPETemplate.LO1_INTERFACE);
+
+		Interface inter1 = (Interface) VCPENetworkModelHelper.getElementByTemplateName(vcpe1.getInterfaces(), VCPETemplate.INTER1_INTERFACE_LOCAL);
+		Interface down1 = (Interface) VCPENetworkModelHelper.getElementByTemplateName(vcpe1.getInterfaces(), VCPETemplate.DOWN1_INTERFACE_LOCAL);
+		Interface up1 = (Interface) VCPENetworkModelHelper.getElementByTemplateName(vcpe1.getInterfaces(), VCPETemplate.UP1_INTERFACE_LOCAL);
+		Interface lo1 = (Interface) VCPENetworkModelHelper.getElementByTemplateName(vcpe1.getInterfaces(), VCPETemplate.LO1_INTERFACE);
+
+		if (inter1input != null)
+			updateInterface(inter1, inter1input.getName(), inter1input.getVlan(), inter1input.getIpAddress(), inter1input.getPhysicalInterfaceName(),
+					inter1input.getPort());
+		if (down1input != null)
+			updateInterface(down1, down1input.getName(), down1input.getVlan(), down1input.getIpAddress(), down1input.getPhysicalInterfaceName(),
+					down1input.getPort());
+		if (up1input != null)
+			updateInterface(up1, up1input.getName(), up1input.getVlan(), up1input.getIpAddress(), up1input.getPhysicalInterfaceName(),
+					up1input.getPort());
+		if (lo1input != null)
+			updateInterface(lo1, lo1input.getName(), lo1input.getVlan(), lo1input.getIpAddress(), lo1input.getPhysicalInterfaceName(),
+					lo1input.getPort());
+
+		// LR2
+		Router vcpe2input = (Router) VCPENetworkModelHelper.getElementByTemplateName(inputModel, VCPETemplate.VCPE2_ROUTER);
+		Router vcpe2 = (Router) VCPENetworkModelHelper.getElementByTemplateName(model, VCPETemplate.VCPE2_ROUTER);
+		vcpe2.setName(vcpe2input.getName() + "-" + inputModel.getName());
+
+		Interface inter2input = (Interface) VCPENetworkModelHelper.getElementByTemplateName(vcpe2input.getInterfaces(),
+				VCPETemplate.INTER2_INTERFACE_LOCAL);
+		Interface down2input = (Interface) VCPENetworkModelHelper.getElementByTemplateName(vcpe2input.getInterfaces(),
+				VCPETemplate.DOWN2_INTERFACE_LOCAL);
+		Interface up2input = (Interface) VCPENetworkModelHelper
+				.getElementByTemplateName(vcpe2input.getInterfaces(), VCPETemplate.UP2_INTERFACE_LOCAL);
+		Interface lo2input = (Interface) VCPENetworkModelHelper
+				.getElementByTemplateName(vcpe2input.getInterfaces(), VCPETemplate.LO2_INTERFACE);
+
+		Interface inter2 = (Interface) VCPENetworkModelHelper.getElementByTemplateName(vcpe2.getInterfaces(), VCPETemplate.INTER2_INTERFACE_LOCAL);
+		Interface down2 = (Interface) VCPENetworkModelHelper.getElementByTemplateName(vcpe2.getInterfaces(), VCPETemplate.DOWN2_INTERFACE_LOCAL);
+		Interface up2 = (Interface) VCPENetworkModelHelper.getElementByTemplateName(vcpe2.getInterfaces(), VCPETemplate.UP2_INTERFACE_LOCAL);
+		Interface lo2 = (Interface) VCPENetworkModelHelper.getElementByTemplateName(vcpe2.getInterfaces(), VCPETemplate.LO2_INTERFACE);
+
+		if (inter2input != null)
+			updateInterface(inter2, inter2input.getName(), inter2input.getVlan(), inter2input.getIpAddress(), inter2input.getPhysicalInterfaceName(),
+					inter2input.getPort());
+		if (down2input != null)
+			updateInterface(down2, down2input.getName(), down2input.getVlan(), down2input.getIpAddress(), down2input.getPhysicalInterfaceName(),
+					down2input.getPort());
+		if (up2input != null)
+			updateInterface(up2, up2input.getName(), up2input.getVlan(), up2input.getIpAddress(), up2input.getPhysicalInterfaceName(),
+					up2input.getPort());
+		if (lo2input != null)
+			updateInterface(lo2, lo2input.getName(), lo2input.getVlan(), lo2input.getIpAddress(), lo2input.getPhysicalInterfaceName(),
+					lo2input.getPort());
+
+		// BOD
+		Interface client1input = (Interface) VCPENetworkModelHelper.getElementByTemplateName(inputModel, VCPETemplate.CLIENT1_INTERFACE_AUTOBAHN);
+		Interface client2input = (Interface) VCPENetworkModelHelper.getElementByTemplateName(inputModel, VCPETemplate.CLIENT2_INTERFACE_AUTOBAHN);
+
+		Interface client1 = (Interface) VCPENetworkModelHelper.getElementByTemplateName(model, VCPETemplate.CLIENT1_INTERFACE_AUTOBAHN);
+		Interface client2 = (Interface) VCPENetworkModelHelper.getElementByTemplateName(model, VCPETemplate.CLIENT2_INTERFACE_AUTOBAHN);
+
+		updateInterface(client1, client1input.getName(), client1input.getVlan(), client1input.getIpAddress(),
+				client1input.getPhysicalInterfaceName(), client1input.getPort());
+		updateInterface(client2, client2input.getName(), client2input.getVlan(), client2input.getIpAddress(),
+				client2input.getPhysicalInterfaceName(), client2input.getPort());
+
+		// VRRP
+		if (inputModel.getVrrp().getGroup() != null)
+			model.getVrrp().setGroup(inputModel.getVrrp().getGroup()); // TODO MUST CHANGE BETWEEN VCPEs
+		if (inputModel.getVrrp().getPriorityMaster() != null)
+			model.getVrrp().setPriorityMaster(inputModel.getVrrp().getPriorityMaster());
+		if (inputModel.getVrrp().getPriorityBackup() != null)
+			model.getVrrp().setPriorityBackup(inputModel.getVrrp().getPriorityBackup());
+		if (inputModel.getVrrp().getVirtualIPAddress() != null)
+			model.getVrrp().setVirtualIPAddress(inputModel.getVrrp().getVirtualIPAddress());
+
+		// BGP
+		if (inputModel.getBgp().getClientASNumber() != null)
+			model.getBgp().setClientASNumber(inputModel.getBgp().getClientASNumber());
+		if (inputModel.getBgp().getNocASNumber() != null)
+			model.getBgp().setNocASNumber(inputModel.getBgp().getNocASNumber());
+		if (inputModel.getBgp().getCustomerPrefixes() != null && !inputModel.getBgp().getCustomerPrefixes().isEmpty())
+			model.getBgp().setCustomerPrefixes(inputModel.getBgp().getCustomerPrefixes());
+
+		// TODO mapDependantLogicalElements(model);
+
+		return model;
+	}
+
+	private VCPENetworkModel mapLogicalAndPhysical(VCPENetworkModel physicalInfrastructure, VCPENetworkModel logicalInfrastructure) {
+
+		// put all physical elements in logicalInfrastructure
+		logicalInfrastructure.getElements().addAll(physicalInfrastructure.getElements());
+
+		// put up logical interfaces into core router
+		Router core = (Router) VCPENetworkModelHelper.getElementByTemplateName(logicalInfrastructure, VCPETemplate.CORE_PHY_ROUTER);
+		core.getInterfaces().add((Interface) VCPENetworkModelHelper.getElementByTemplateName(logicalInfrastructure, VCPETemplate.UP1_INTERFACE_PEER));
+		core.getInterfaces().add((Interface) VCPENetworkModelHelper.getElementByTemplateName(logicalInfrastructure, VCPETemplate.UP2_INTERFACE_PEER));
+
+		// put bod logical interfaces into bod
+		Domain bod = (Domain) VCPENetworkModelHelper.getElementByTemplateName(logicalInfrastructure, VCPETemplate.AUTOBAHN);
+		bod.getInterfaces().add(
+				(Interface) VCPENetworkModelHelper.getElementByTemplateName(logicalInfrastructure, VCPETemplate.CLIENT1_INTERFACE_AUTOBAHN));
+		bod.getInterfaces().add(
+				(Interface) VCPENetworkModelHelper.getElementByTemplateName(logicalInfrastructure, VCPETemplate.CLIENT2_INTERFACE_AUTOBAHN));
+		bod.getInterfaces().add(
+				(Interface) VCPENetworkModelHelper.getElementByTemplateName(logicalInfrastructure, VCPETemplate.INTER1_INTERFACE_AUTOBAHN));
+		bod.getInterfaces().add(
+				(Interface) VCPENetworkModelHelper.getElementByTemplateName(logicalInfrastructure, VCPETemplate.DOWN1_INTERFACE_AUTOBAHN));
+		bod.getInterfaces().add(
+				(Interface) VCPENetworkModelHelper.getElementByTemplateName(logicalInfrastructure, VCPETemplate.INTER2_INTERFACE_AUTOBAHN));
+		bod.getInterfaces().add(
+				(Interface) VCPENetworkModelHelper.getElementByTemplateName(logicalInfrastructure, VCPETemplate.DOWN2_INTERFACE_AUTOBAHN));
+
+		return logicalInfrastructure;
 	}
 
 	/**
@@ -253,225 +916,6 @@ public class Template implements ITemplate {
 		return elements;
 	}
 
-	private VCPENetworkModel generateAndMapPhysicalElements(VCPENetworkModel initialModel) {
-
-		VCPENetworkModel generated = generatePhysicalElements();
-		VCPENetworkModel mappedFromProperties = mapPhysicalElementsFromProperties(generated, props);
-		VCPENetworkModel mapped = mapPhysicalElementsFromInputModel(mappedFromProperties, initialModel);
-		// TODO MUST CHECK MAPPED ELEMENTS EXIST IN PHYSICAL TOPOLOGY
-		return mapped;
-	}
-
-	private VCPENetworkModel mapPhysicalElementsFromInputModel(VCPENetworkModel model, VCPENetworkModel inputModel) {
-
-		// TODO update ALL elements with data in inputModel (everything may have changed)
-
-		// select client1 interface using inputModel
-		Interface inputClient1 = (Interface) VCPENetworkModelHelper.getElementByTemplateName(inputModel,
-				VCPETemplate.CLIENT1_INTERFACE_AUTOBAHN);
-
-		Interface client1 = (Interface) VCPENetworkModelHelper.getElementByTemplateName(model, VCPETemplate.CLIENT1_PHY_INTERFACE_AUTOBAHN);
-		client1.setName(inputClient1.getPhysicalInterfaceName());
-
-		// select client2 interface using inputModel
-		Interface inputClient2 = (Interface) VCPENetworkModelHelper.getElementByTemplateName(inputModel,
-				VCPETemplate.CLIENT2_INTERFACE_AUTOBAHN);
-
-		Interface client2 = (Interface) VCPENetworkModelHelper.getElementByTemplateName(model, VCPETemplate.CLIENT2_PHY_INTERFACE_AUTOBAHN);
-		client2.setName(inputClient2.getPhysicalInterfaceName());
-
-		return model;
-	}
-
-	private VCPENetworkModel mapPhysicalElementsFromProperties(VCPENetworkModel model, Properties props) {
-
-		Router core = (Router) VCPENetworkModelHelper.getElementByTemplateName(model, VCPETemplate.CORE_PHY_ROUTER);
-		core.setName(props.getProperty("vcpenetwork.routercore.name"));
-
-		Interface coremaster = (Interface) VCPENetworkModelHelper.getElementByTemplateName(model, VCPETemplate.CORE_PHY_INTERFACE_MASTER);
-		coremaster.setName(props.getProperty("vcpenetwork.routercore.interface.master.name"));
-		coremaster.setPhysicalInterfaceName(props.getProperty("vcpenetwork.routercore.interface.master.name"));
-
-		Interface corebkp = (Interface) VCPENetworkModelHelper.getElementByTemplateName(model, VCPETemplate.CORE_PHY_INTERFACE_BKP);
-		corebkp.setName(props.getProperty("vcpenetwork.routercore.interface.bkp.name"));
-		corebkp.setPhysicalInterfaceName(props.getProperty("vcpenetwork.routercore.interface.bkp.name"));
-
-		Interface corelo = (Interface) VCPENetworkModelHelper.getElementByTemplateName(model, VCPETemplate.CORE_PHY_LO_INTERFACE);
-		corelo.setName(props.getProperty("vcpenetwork.routercore.interface.lo.name"));
-		corelo.setPhysicalInterfaceName(props.getProperty("vcpenetwork.routercore.interface.lo.name"));
-
-		Router r1 = (Router) VCPENetworkModelHelper.getElementByTemplateName(model, VCPETemplate.CPE1_PHY_ROUTER);
-		r1.setName(props.getProperty("vcpenetwork.router1.name"));
-
-		Interface inter1 = (Interface) VCPENetworkModelHelper.getElementByTemplateName(model, VCPETemplate.INTER1_PHY_INTERFACE_LOCAL);
-		inter1.setName(props.getProperty("vcpenetwork.router1.interface.inter.name"));
-		inter1.setPhysicalInterfaceName(props.getProperty("vcpenetwork.router1.interface.inter.name"));
-
-		Interface inter1other = (Interface) VCPENetworkModelHelper.getElementByTemplateName(model, VCPETemplate.INTER1_PHY_INTERFACE_AUTOBAHN);
-		inter1other.setName(props.getProperty("vcpenetwork.router1.interface.inter.other.name"));
-		inter1other.setPhysicalInterfaceName(props.getProperty("vcpenetwork.router1.interface.inter.other.name"));
-
-		Interface down1 = (Interface) VCPENetworkModelHelper.getElementByTemplateName(model, VCPETemplate.DOWN1_PHY_INTERFACE_LOCAL);
-		down1.setName(props.getProperty("vcpenetwork.router1.interface.down.name"));
-		down1.setPhysicalInterfaceName(props.getProperty("vcpenetwork.router1.interface.down.name"));
-
-		Interface down1other = (Interface) VCPENetworkModelHelper.getElementByTemplateName(model, VCPETemplate.DOWN1_PHY_INTERFACE_AUTOBAHN);
-		down1other.setName(props.getProperty("vcpenetwork.router1.interface.down.other.name"));
-		down1other.setPhysicalInterfaceName(props.getProperty("vcpenetwork.router1.interface.down.other.name"));
-
-		Interface up1 = (Interface) VCPENetworkModelHelper.getElementByTemplateName(model, VCPETemplate.UP1_PHY_INTERFACE_LOCAL);
-		up1.setName(props.getProperty("vcpenetwork.router1.interface.up.name"));
-		up1.setPhysicalInterfaceName(props.getProperty("vcpenetwork.router1.interface.up.name"));
-
-		Interface lo1 = (Interface) VCPENetworkModelHelper.getElementByTemplateName(model, VCPETemplate.LO1_PHY_INTERFACE);
-		lo1.setName(props.getProperty("vcpenetwork.router1.interface.lo.name"));
-		lo1.setPhysicalInterfaceName(props.getProperty("vcpenetwork.router1.interface.lo.name"));
-
-		Router r2 = (Router) VCPENetworkModelHelper.getElementByTemplateName(model, VCPETemplate.CPE2_PHY_ROUTER);
-		r2.setName(props.getProperty("vcpenetwork.router2.name"));
-
-		Interface inter2 = (Interface) VCPENetworkModelHelper.getElementByTemplateName(model, VCPETemplate.INTER2_PHY_INTERFACE_LOCAL);
-		inter2.setName(props.getProperty("vcpenetwork.router2.interface.inter.name"));
-		inter2.setPhysicalInterfaceName(props.getProperty("vcpenetwork.router2.interface.inter.name"));
-
-		Interface inter2other = (Interface) VCPENetworkModelHelper.getElementByTemplateName(model, VCPETemplate.INTER2_PHY_INTERFACE_AUTOBAHN);
-		inter2other.setName(props.getProperty("vcpenetwork.router2.interface.inter.other.name"));
-		inter2other.setPhysicalInterfaceName(props.getProperty("vcpenetwork.router2.interface.inter.other.name"));
-
-		Interface down2 = (Interface) VCPENetworkModelHelper.getElementByTemplateName(model, VCPETemplate.DOWN2_PHY_INTERFACE_LOCAL);
-		down2.setName(props.getProperty("vcpenetwork.router2.interface.down.name"));
-		down2.setPhysicalInterfaceName(props.getProperty("vcpenetwork.router2.interface.down.name"));
-
-		Interface down2other = (Interface) VCPENetworkModelHelper.getElementByTemplateName(model, VCPETemplate.DOWN2_PHY_INTERFACE_AUTOBAHN);
-		down2other.setName(props.getProperty("vcpenetwork.router2.interface.down.other.name"));
-		down2other.setPhysicalInterfaceName(props.getProperty("vcpenetwork.router2.interface.down.other.name"));
-
-		Interface up2 = (Interface) VCPENetworkModelHelper.getElementByTemplateName(model, VCPETemplate.UP2_PHY_INTERFACE_LOCAL);
-		up2.setName(props.getProperty("vcpenetwork.router2.interface.up.name"));
-		up2.setPhysicalInterfaceName(props.getProperty("vcpenetwork.router2.interface.up.name"));
-
-		Interface lo2 = (Interface) VCPENetworkModelHelper.getElementByTemplateName(model, VCPETemplate.LO2_PHY_INTERFACE);
-		lo2.setName(props.getProperty("vcpenetwork.router2.interface.lo.name"));
-		lo2.setPhysicalInterfaceName(props.getProperty("vcpenetwork.router2.interface.lo.name"));
-
-		Domain autobahn = (Domain) VCPENetworkModelHelper.getElementByTemplateName(model, VCPETemplate.AUTOBAHN);
-		autobahn.setName(props.getProperty("vcpenetwork.bod.name"));
-
-		return model;
-	}
-
-	private VCPENetworkModel generatePhysicalElements() {
-
-		Router core = new Router();
-		core.setTemplateName(VCPETemplate.CORE_PHY_ROUTER);
-
-		Interface coreMaster = new Interface();
-		coreMaster.setTemplateName(VCPETemplate.CORE_PHY_INTERFACE_MASTER);
-
-		Interface coreBkp = new Interface();
-		coreBkp.setTemplateName(VCPETemplate.CORE_PHY_INTERFACE_BKP);
-
-		Interface coreLo = new Interface();
-		coreLo.setTemplateName(VCPETemplate.CORE_PHY_LO_INTERFACE);
-
-		List<Interface> coreInterfaces = new ArrayList<Interface>();
-		coreInterfaces.add(coreMaster);
-		coreInterfaces.add(coreBkp);
-		coreInterfaces.add(coreLo);
-		core.setInterfaces(coreInterfaces);
-
-		Router r1 = new Router();
-		r1.setTemplateName(VCPETemplate.CPE1_PHY_ROUTER);
-
-		Interface inter1 = new Interface();
-		inter1.setTemplateName(VCPETemplate.INTER1_PHY_INTERFACE_LOCAL);
-
-		Interface inter1other = new Interface();
-		inter1other.setTemplateName(VCPETemplate.INTER1_PHY_INTERFACE_AUTOBAHN);
-
-		Interface down1 = new Interface();
-		down1.setTemplateName(VCPETemplate.DOWN1_PHY_INTERFACE_LOCAL);
-
-		Interface down1other = new Interface();
-		down1other.setTemplateName(VCPETemplate.DOWN1_PHY_INTERFACE_AUTOBAHN);
-
-		Interface up1 = new Interface();
-		up1.setTemplateName(VCPETemplate.UP1_PHY_INTERFACE_LOCAL);
-
-		Interface client1 = new Interface();
-		client1.setTemplateName(VCPETemplate.CLIENT1_PHY_INTERFACE_AUTOBAHN);
-
-		Interface lo1 = new Interface();
-		lo1.setTemplateName(VCPETemplate.LO1_PHY_INTERFACE);
-
-		List<Interface> r1Interfaces = new ArrayList<Interface>();
-		r1Interfaces.add(inter1);
-		r1Interfaces.add(down1);
-		r1Interfaces.add(up1);
-		r1Interfaces.add(lo1);
-		r1.setInterfaces(r1Interfaces);
-
-		Router r2 = new Router();
-		r2.setTemplateName(VCPETemplate.CPE2_PHY_ROUTER);
-
-		Interface inter2 = new Interface();
-		inter2.setTemplateName(VCPETemplate.INTER2_PHY_INTERFACE_LOCAL);
-
-		Interface inter2other = new Interface();
-		inter2other.setTemplateName(VCPETemplate.INTER2_PHY_INTERFACE_AUTOBAHN);
-
-		Interface down2 = new Interface();
-		down2.setTemplateName(VCPETemplate.DOWN2_PHY_INTERFACE_LOCAL);
-
-		Interface down2other = new Interface();
-		down2other.setTemplateName(VCPETemplate.DOWN2_PHY_INTERFACE_AUTOBAHN);
-
-		Interface up2 = new Interface();
-		up2.setTemplateName(VCPETemplate.UP2_PHY_INTERFACE_LOCAL);
-
-		Interface client2 = new Interface();
-		client2.setTemplateName(VCPETemplate.CLIENT2_PHY_INTERFACE_AUTOBAHN);
-
-		Interface lo2 = new Interface();
-		lo2.setTemplateName(VCPETemplate.LO2_PHY_INTERFACE);
-
-		List<Interface> r2Interfaces = new ArrayList<Interface>();
-		r2Interfaces.add(inter2);
-		r2Interfaces.add(down2);
-		r2Interfaces.add(up2);
-		r2Interfaces.add(lo2);
-		r2.setInterfaces(r2Interfaces);
-
-		Domain autobahn = new Domain();
-		autobahn.setTemplateName(VCPETemplate.AUTOBAHN);
-
-		List<Interface> autobahnInterfaces = new ArrayList<Interface>();
-		autobahnInterfaces.add(inter1other);
-		autobahnInterfaces.add(inter2other);
-		autobahnInterfaces.add(down1other);
-		autobahnInterfaces.add(down2other);
-		autobahnInterfaces.add(client1);
-		autobahnInterfaces.add(client2);
-		autobahn.setInterfaces(autobahnInterfaces);
-
-		List<VCPENetworkElement> elements = new ArrayList<VCPENetworkElement>();
-		elements.add(core);
-		elements.addAll(core.getInterfaces());
-		elements.add(r1);
-		elements.addAll(r1.getInterfaces());
-		elements.add(r2);
-		elements.addAll(r2.getInterfaces());
-		elements.add(autobahn);
-		elements.addAll(autobahn.getInterfaces());
-
-		VCPENetworkModel model = new VCPENetworkModel();
-		model.setElements(elements);
-		model.setTemplateType(getTemplateType());
-		model.setCreated(false);
-
-		return model;
-	}
-
 	private VRRP configureVRRP(VCPENetworkModel model) {
 		// VRRP group
 		int vrrpGoup = Integer.parseInt(props.getProperty("vcpenetwork.vrrp.group"));
@@ -483,7 +927,7 @@ public class Template implements ITemplate {
 		// get master router and interface
 		Router masterRouter = (Router) VCPENetworkModelHelper.getElementByTemplateName(model, VCPETemplate.VCPE1_ROUTER);
 		Interface masterInterface = (Interface) VCPENetworkModelHelper.getElementByTemplateName(model, VCPETemplate.DOWN1_INTERFACE_LOCAL);
-		masterRouter.getName();
+
 		// get backup router and interface
 		Router backupRouter = (Router) VCPENetworkModelHelper.getElementByTemplateName(model, VCPETemplate.VCPE2_ROUTER);
 		Interface backupInterface = (Interface) VCPENetworkModelHelper.getElementByTemplateName(model, VCPETemplate.DOWN2_INTERFACE_LOCAL);
@@ -613,6 +1057,22 @@ public class Template implements ITemplate {
 		Interface iface = new Interface();
 		iface.setName(name);
 		iface.setTemplateName(templateName);
+		iface.setIpAddress(ipAddress);
+		iface.setVlan(vlan);
+		iface.setPhysicalInterfaceName(physicalInterfaceName);
+		iface.setPort(port);
+		return iface;
+	}
+
+	/**
+	 * @param name
+	 * @param templateName
+	 * @param vlan
+	 * @param ipAddress
+	 * @return the interface
+	 */
+	private Interface updateInterface(Interface iface, String name, long vlan, String ipAddress, String physicalInterfaceName, int port) {
+		iface.setName(name);
 		iface.setIpAddress(ipAddress);
 		iface.setVlan(vlan);
 		iface.setPhysicalInterfaceName(physicalInterfaceName);

--- a/extensions/bundles/vcpe/src/main/resources/templates/template.properties
+++ b/extensions/bundles/vcpe/src/main/resources/templates/template.properties
@@ -1,6 +1,6 @@
 ####################################### VCPENetwork #######################################
 vcpenetwork.template = basic.template
-vcpenetwork.client.iprange = 192.0.2.0/24
+vcpenetwork.client.iprange = 193.1.190.128/26
 
 ###########################################################################################
 ######################################### Physical ########################################
@@ -16,7 +16,7 @@ vcpenetwork.routercore.interface.lo.name = lo0
 ######################################### Router 1 ########################################
 vcpenetwork.router1.name = myre
 
-vcpenetwork.router1.interface.inter.name = ge-2/3/1
+vcpenetwork.router1.interface.inter.name = ge-2/0/1
 vcpenetwork.router1.interface.inter.other.name = HEANET.pc.7235713c
 
 vcpenetwork.router1.interface.down.name = ge-2/0/0
@@ -91,7 +91,6 @@ vcpenetwork.logicalrouter1.interface.lo.vlan =
 vcpenetwork.logicalrouter1.interface.lo.ipaddress = 193.1.190.141/30
 vcpenetwork.logicalrouter1.interface.lo.labelname = Loopback
 
-## Ignored
 vcpenetwork.logicalrouter1.interface.up.other.name = fe-0/3/0
 vcpenetwork.logicalrouter1.interface.up.other.port = 12
 vcpenetwork.logicalrouter1.interface.up.other.vlan = 12
@@ -99,7 +98,7 @@ vcpenetwork.logicalrouter1.interface.up.other.ipaddress = 193.1.190.134/30
 vcpenetwork.logicalrouter1.interface.up.other.labelname = Up other
 
 
-####################################### Logical Router2 ###################################
+##################################### Logical Router2 #####################################
 vcpenetwork.logicalrouter2.name = LR-backup
 vcpenetwork.logicalrouter2.interface.inter.name = ge-1/0/7
 vcpenetwork.logicalrouter2.interface.inter.port = 2041
@@ -137,21 +136,33 @@ vcpenetwork.logicalrouter2.interface.lo.vlan =
 vcpenetwork.logicalrouter2.interface.lo.ipaddress = 193.1.239.73/32
 vcpenetwork.logicalrouter2.interface.lo.labelname = Loopback
 
-#Ignored
 vcpenetwork.logicalrouter2.interface.up.other.name = ge-0/2/0
 vcpenetwork.logicalrouter2.interface.up.other.port = 71
 vcpenetwork.logicalrouter2.interface.up.other.vlan = 71
 vcpenetwork.logicalrouter2.interface.up.other.ipaddress = 193.1.190.130/30
 vcpenetwork.logicalrouter2.interface.up.other.labelname = Up other
 
+####################################### Client ############################################
+vcpenetwork.logicalrouter1.interface.client.name = GEANT.pc.43838714
+vcpenetwork.logicalrouter1.interface.client.port = 2020
+vcpenetwork.logicalrouter1.interface.client.vlan = 2020
 
-######################################### VRRP ########################################
+vcpenetwork.logicalrouter2.interface.client.name = HEANET.pc.a3bce684
+vcpenetwork.logicalrouter2.interface.client.port = 2040
+vcpenetwork.logicalrouter2.interface.client.vlan = 2040
+
+######################################### VRRP ############################################
 vcpenetwork.vrrp.group = 201
 vcpenetwork.vrrp.master.priority = 200
 vcpenetwork.vrrp.backup.priority = 100
+vcpenetwork.vrrp.virtualIPAddress = 193.1.190.161
 
+####################################### BGP ###############################################
+vcpenetwork.bgp.clientASNumber = 65533
+vcpenetwork.bgp.nocASNumber = 65166
+vcpenetwork.bgp.clientPrefixes = 193.1.190.128/26
 
-######################################### Links ########################################
+######################################### Links ###########################################
 vcpenetwork.logicalrouter1.link.inter.other.id = autobahnID:request:0000001
 vcpenetwork.logicalrouter1.link.down.other.id = autobahnID:request:0000002
 vcpenetwork.logicalrouter2.link.down.other.id = autobahnID:request:0000003


### PR DESCRIPTION
Suggestion is based on a properties file.
Template methods building logical infrastructure in buildModel have been refactored in order to reuse the code.
Some temporary methods have been created for maintaining current buildModel functionality (marked with a FIXME)

getLogicalInfrastructureSuggestion returns a VCPENetworkModel with a complete model (physical and logical infrastructure with VRRP and BGP).

Related to issue: http://jira.i2cat.net:8080/browse/OPENNAAS-830
