### PR TITLE
Fail when template id is unknown.

### DIFF
--- a/extensions/bundles/vcpe/src/main/java/org/opennaas/extensions/vcpe/capability/builder/builders/VCPENetworkBuilderFactory.java
+++ b/extensions/bundles/vcpe/src/main/java/org/opennaas/extensions/vcpe/capability/builder/builders/VCPENetworkBuilderFactory.java
@@ -3,6 +3,7 @@
  */
 package org.opennaas.extensions.vcpe.capability.builder.builders;
 
+import org.opennaas.core.resources.capability.CapabilityException;
 import org.opennaas.extensions.vcpe.manager.templates.ITemplate;
 
 /**
@@ -16,13 +17,17 @@ public class VCPENetworkBuilderFactory {
 	 * @param criteria
 	 * @return the builder
 	 */
-	public static IVCPENetworkBuilder getBuilder(String templateName) {
+	public static IVCPENetworkBuilder getBuilder(String templateName) throws CapabilityException {
 		IVCPENetworkBuilder builder = null;
 		if (templateName.equals(ITemplate.SP_VCPE_TEMPLATE)) {
 			builder = new VCPESingleProvider();
 		} else if (templateName.equals(ITemplate.MP_VCPE_TEMPLATE)) {
 			builder = new VCPEMultipleProvider();
 		}
+		
+		if (builder == null)
+			throw new CapabilityException("Failed to get builder. Unknown templateId: " + templateName);
+		
 		return builder;
 	}
 }

--- a/extensions/bundles/vcpe/src/main/java/org/opennaas/extensions/vcpe/manager/templates/TemplateSelector.java
+++ b/extensions/bundles/vcpe/src/main/java/org/opennaas/extensions/vcpe/manager/templates/TemplateSelector.java
@@ -19,10 +19,14 @@ public class TemplateSelector {
 	 * @throws VCPENetworkManagerException
 	 */
 	public static ITemplate getTemplate(String templateId) throws VCPENetworkManagerException {
-		ITemplate iTemplate = new SingleProviderTemplate();
+		ITemplate iTemplate = null;
 		if (templateId.equals(ITemplate.SP_VCPE_TEMPLATE)) {
 			iTemplate = new SingleProviderTemplate();
 		}
+		
+		if (iTemplate == null)
+			throw new VCPENetworkManagerException("Failed to get template. Unknown templateId: " + templateId);
+		
 		return iTemplate;
 	}
 }


### PR DESCRIPTION
TemplateSelector and BuilderFactory throws an exception
if an unknown templateID is given to them.
