### PR TITLE
Update dependent logical elements from user input in build model.

### DIFF
--- a/extensions/bundles/bod.capability.l2bod/src/main/java/org/opennaas/extensions/bod/capability/l2bod/L2BoDCapability.java
+++ b/extensions/bundles/bod.capability.l2bod/src/main/java/org/opennaas/extensions/bod/capability/l2bod/L2BoDCapability.java
@@ -44,7 +44,7 @@ public class L2BoDCapability extends AbstractCapability implements IL2BoDCapabil
 	 */
 	@Override
 	public void requestConnection(RequestConnectionParameters parameters) throws CapabilityException {
-		log.info("Start of requestConnection call");
+		log.info("Start of requestConnection call. " + parameters.toString());
 		IAction action = createActionAndCheckParams(L2BoDActionSet.REQUEST_CONNECTION, parameters);
 		queueAction(action);
 		log.info("End of requestConnection call");
@@ -57,7 +57,7 @@ public class L2BoDCapability extends AbstractCapability implements IL2BoDCapabil
 	 */
 	@Override
 	public void shutDownConnection(RequestConnectionParameters parameters) throws CapabilityException {
-		log.info("Start of shutDownConnection call");
+		log.info("Start of shutDownConnection call. " + parameters.toString());
 
 		Link link = getLinkFromRequest(parameters);
 

--- a/extensions/bundles/vcpe/src/main/java/org/opennaas/extensions/vcpe/manager/templates/sp/SingleProviderTemplate.java
+++ b/extensions/bundles/vcpe/src/main/java/org/opennaas/extensions/vcpe/manager/templates/sp/SingleProviderTemplate.java
@@ -516,7 +516,7 @@ public class SingleProviderTemplate implements ITemplate {
 
 		// VRRP
 		if (inputModel.getVrrp().getGroup() != null)
-			model.getVrrp().setGroup(inputModel.getVrrp().getGroup()); // TODO MUST CHANGE BETWEEN VCPEs
+			model.getVrrp().setGroup(inputModel.getVrrp().getGroup());
 		if (inputModel.getVrrp().getPriorityMaster() != null)
 			model.getVrrp().setPriorityMaster(inputModel.getVrrp().getPriorityMaster());
 		if (inputModel.getVrrp().getPriorityBackup() != null)
@@ -532,8 +532,48 @@ public class SingleProviderTemplate implements ITemplate {
 		if (inputModel.getBgp().getCustomerPrefixes() != null && !inputModel.getBgp().getCustomerPrefixes().isEmpty())
 			model.getBgp().setCustomerPrefixes(inputModel.getBgp().getCustomerPrefixes());
 
-		// TODO mapDependantLogicalElements(model);
+		mapDependantLogicalElements(model);
 
+		return model;
+	}
+
+	private VCPENetworkModel mapDependantLogicalElements(VCPENetworkModel model) {
+		// vlans of direct links should be equal
+		model = updateInterfacesVlanFromLinks(model);
+		return model;
+	}
+
+	private VCPENetworkModel updateInterfacesVlanFromLinks(VCPENetworkModel model) {
+		List<Interface> allIfaces = VCPENetworkModelHelper.getInterfaces(model.getElements());
+		List<Interface> toUpdate = new ArrayList<Interface>(6);
+
+		toUpdate.add((Interface) VCPENetworkModelHelper.getElementByTemplateName(allIfaces, VCPETemplate.INTER1_INTERFACE_AUTOBAHN));
+		toUpdate.add((Interface) VCPENetworkModelHelper.getElementByTemplateName(allIfaces, VCPETemplate.INTER2_INTERFACE_AUTOBAHN));
+
+		toUpdate.add((Interface) VCPENetworkModelHelper.getElementByTemplateName(allIfaces, VCPETemplate.DOWN1_INTERFACE_AUTOBAHN));
+		toUpdate.add((Interface) VCPENetworkModelHelper.getElementByTemplateName(allIfaces, VCPETemplate.DOWN2_INTERFACE_AUTOBAHN));
+
+		// TODO Question: should the appl be able to modify up peer vlans (they are in core router)???
+		toUpdate.add((Interface) VCPENetworkModelHelper.getElementByTemplateName(allIfaces, VCPETemplate.UP1_INTERFACE_PEER));
+		toUpdate.add((Interface) VCPENetworkModelHelper.getElementByTemplateName(allIfaces, VCPETemplate.UP2_INTERFACE_PEER));
+
+		List<Link> allLinks = VCPENetworkModelHelper.getLinks(model.getElements());
+		List<Link> toUpdateLinks = new ArrayList<Link>(6);
+		toUpdateLinks.add((Link) VCPENetworkModelHelper.getElementByTemplateName(allLinks, VCPETemplate.INTER1_LINK_LOCAL));
+		toUpdateLinks.add((Link) VCPENetworkModelHelper.getElementByTemplateName(allLinks, VCPETemplate.INTER2_LINK_LOCAL));
+		toUpdateLinks.add((Link) VCPENetworkModelHelper.getElementByTemplateName(allLinks, VCPETemplate.DOWN1_LINK_LOCAL));
+		toUpdateLinks.add((Link) VCPENetworkModelHelper.getElementByTemplateName(allLinks, VCPETemplate.DOWN2_LINK_LOCAL));
+		// TODO Question: should the appl be able to modify up peer vlans???
+		toUpdateLinks.add((Link) VCPENetworkModelHelper.getElementByTemplateName(allLinks, VCPETemplate.UP1_LINK));
+		toUpdateLinks.add((Link) VCPENetworkModelHelper.getElementByTemplateName(allLinks, VCPETemplate.UP2_LINK));
+
+		for (Link link : toUpdateLinks) {
+			if (toUpdate.contains(link.getSource())) {
+				VCPENetworkModelHelper.updateIfaceVLANFromLink(link.getSource(), link);
+			} else {
+				VCPENetworkModelHelper.updateIfaceVLANFromLink(link.getSink(), link);
+			}
+		}
 		return model;
 	}
 

--- a/extensions/bundles/vcpe/src/main/java/org/opennaas/extensions/vcpe/manager/templates/sp/VCPETemplateSuggestor.java
+++ b/extensions/bundles/vcpe/src/main/java/org/opennaas/extensions/vcpe/manager/templates/sp/VCPETemplateSuggestor.java
@@ -497,17 +497,15 @@ public class VCPETemplateSuggestor {
 	/**
 	 * Sets iface vlan according to the other endpoint of given link.
 	 * 
+	 * @param phyElement
 	 * @param iface
 	 * @param link
 	 * @param suggestedVLANS
 	 */
 	private void updateIfaceVLANFromLink(VCPENetworkElement phyElement, Interface iface, Link link, Map<String, List<Long>> suggestedVLANs) {
-		if (link.getSource().equals(iface))
-			iface.setVlan(link.getSink().getVlan());
-		else
-			iface.setVlan(link.getSource().getVlan());
+		long vlan = VCPENetworkModelHelper.updateIfaceVLANFromLink(iface, link);
 
-		markAsSuggestedVlan(phyElement, iface, iface.getVlan(), suggestedVLANs);
+		markAsSuggestedVlan(phyElement, iface, vlan, suggestedVLANs);
 	}
 
 	private boolean isAlreadySuggestedVlan(VCPENetworkElement phyElement, Interface iface, long vlan, Map<String, List<Long>> suggestedVLANS) {

--- a/extensions/bundles/vcpe/src/main/java/org/opennaas/extensions/vcpe/model/helper/VCPENetworkModelHelper.java
+++ b/extensions/bundles/vcpe/src/main/java/org/opennaas/extensions/vcpe/model/helper/VCPENetworkModelHelper.java
@@ -433,4 +433,21 @@ public class VCPENetworkModelHelper {
 		iface.setPort(port);
 		return iface;
 	}
+
+	/**
+	 * Sets iface vlan according to the other endpoint of given link.
+	 * 
+	 * @param iface
+	 *            to update
+	 * @param link
+	 *            to get vlan from
+	 */
+	public static long updateIfaceVLANFromLink(Interface iface, Link link) {
+		if (link.getSource().equals(iface))
+			iface.setVlan(link.getSink().getVlan());
+		else
+			iface.setVlan(link.getSource().getVlan());
+
+		return iface.getVlan();
+	}
 }


### PR DESCRIPTION
Direct links must have same vlan in both endpoints.
hus, when the user changes the vlan in an endpoint of a link,
opennaas should update the other endpoint with user given vlan.
