### PR TITLE
Remove vCPE when there is an error in buildModel.

### DIFF
--- a/extensions/bundles/vcpe/src/main/java/org/opennaas/extensions/vcpe/manager/VCPENetworkManager.java
+++ b/extensions/bundles/vcpe/src/main/java/org/opennaas/extensions/vcpe/manager/VCPENetworkManager.java
@@ -227,10 +227,12 @@ public class VCPENetworkManager implements IVCPENetworkManager {
 	private Boolean build(VCPENetworkModel vcpeNetworkModel) {
 		IResource resource = null;
 		try {
-			ITemplate template = TemplateSelector.getTemplate(vcpeNetworkModel.getTemplateType());
-			VCPENetworkModel model = template.buildModel(vcpeNetworkModel);
 			resource = Activator.getResourceManagerService()
 					.getResourceById(vcpeNetworkModel.getId());
+
+			ITemplate template = TemplateSelector.getTemplate(vcpeNetworkModel.getTemplateType());
+			VCPENetworkModel model = template.buildModel(vcpeNetworkModel);
+
 			// Execute the capability and generate the real environment
 			IVCPENetworkBuilderCapability vcpeNetworkBuilderCapability = (IVCPENetworkBuilderCapability) resource
 					.getCapabilityByInterface(IVCPENetworkBuilderCapability.class);


### PR DESCRIPTION
In VCPENetworkManager build method, an error during template.buildModel
causes resource not being removed. Although it should be.

Removing operations are only called when the resource is set, but setting
happens after trying to build the model. Thus, an error in buildModel prevents
the resource to be set and removing operations skipped.

This patch avoid skipping the "rollback" by setting the resource before any
other operation is called in build method.

Solves issue: http://jira.i2cat.net:8080/browse/OPENNAAS-849
