### PR TITLE
Move Multiple Provider vCPE related classes into 'mp' package.

### DIFF
--- a/extensions/bundles/vcpe/src/main/java/org/opennaas/extensions/vcpe/capability/builder/builders/VCPENetworkBuilderFactory.java
+++ b/extensions/bundles/vcpe/src/main/java/org/opennaas/extensions/vcpe/capability/builder/builders/VCPENetworkBuilderFactory.java
@@ -4,6 +4,8 @@
 package org.opennaas.extensions.vcpe.capability.builder.builders;
 
 import org.opennaas.core.resources.capability.CapabilityException;
+import org.opennaas.extensions.vcpe.capability.builder.builders.mp.VCPEMultipleProvider;
+import org.opennaas.extensions.vcpe.capability.builder.builders.sp.VCPESingleProvider;
 import org.opennaas.extensions.vcpe.manager.templates.ITemplate;
 
 /**

--- a/extensions/bundles/vcpe/src/main/java/org/opennaas/extensions/vcpe/capability/builder/builders/sp/VCPESingleProvider.java
+++ b/extensions/bundles/vcpe/src/main/java/org/opennaas/extensions/vcpe/capability/builder/builders/sp/VCPESingleProvider.java
@@ -1,7 +1,7 @@
 /**
  * 
  */
-package org.opennaas.extensions.vcpe.capability.builder.builders;
+package org.opennaas.extensions.vcpe.capability.builder.builders.sp;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -14,6 +14,7 @@ import org.opennaas.core.resources.protocol.ProtocolException;
 import org.opennaas.extensions.router.capability.bgp.BGPCapability;
 import org.opennaas.extensions.router.capability.bgp.IBGPCapability;
 import org.opennaas.extensions.router.model.utils.IPUtilsHelper;
+import org.opennaas.extensions.vcpe.capability.builder.builders.IVCPENetworkBuilder;
 import org.opennaas.extensions.vcpe.capability.builder.builders.helpers.AutobahnHelper;
 import org.opennaas.extensions.vcpe.capability.builder.builders.helpers.GenericHelper;
 import org.opennaas.extensions.vcpe.capability.builder.builders.helpers.IPHelper;
@@ -32,67 +33,87 @@ import org.opennaas.extensions.vcpe.model.helper.VCPENetworkModelHelper;
 /**
  * @author Jordi
  */
-public class VCPEMultipleProvider implements IVCPENetworkBuilder {
+public class VCPESingleProvider implements IVCPENetworkBuilder {
 
-	private Log	log	= LogFactory.getLog(VCPEMultipleProvider.class);
+	private Log	log	= LogFactory.getLog(VCPESingleProvider.class);
 
 	/*
 	 * (non-Javadoc)
 	 * 
-	 * @see org.opennaas.extensions.vcpe.capability.builder.builders.IVCPENetworkBuilder#build(org.opennaas.core.resources.IResource,
-	 * org.opennaas.extensions.vcpe.model.VCPENetworkModel)
+	 * @see org.opennaas.extensions.vcpe.capability.builder.builders.IVCPENetworkBuilder#build(org.opennaas.extensions.vcpe.model.VCPENetworkModel)
 	 */
 	@Override
 	public VCPENetworkModel build(IResource vcpe, VCPENetworkModel desiredScenario) throws ResourceException {
-		log.info("Build a vCPE multiple provider network of the resource: " + ((VCPENetworkModel) vcpe.getModel()).getId());
+		log.info("Build a vCPE single provider network of the resource: " + ((VCPENetworkModel) vcpe.getModel()).getId());
 
-		// Create and execute autobahn links
-		createExternalLinks(vcpe, desiredScenario);
-		executeAutobahn(desiredScenario);
+		boolean linksCreated = false;
+		boolean lrsCreated = false;
 
-		// Create logical routers in physical and start
-		createLogicalRouters(vcpe, desiredScenario);
-		executePhysicalRouters(desiredScenario);
-		startLogicalRouters(vcpe, desiredScenario);
+		try {
+			// Create and execute autobahn links
+			createExternalLinks(vcpe, desiredScenario);
+			executeAutobahn(desiredScenario);
+			linksCreated = true;
 
-		// Configure subinterfaces
-		createSubInterfaces(vcpe, desiredScenario);
-		assignIPAddresses(vcpe, desiredScenario);
-		executeLogicalRouters(desiredScenario);
+			// Create logical routers in physical and start
+			createLogicalRouters(vcpe, desiredScenario);
+			executePhysicalRouters(desiredScenario);
+			lrsCreated = true;
+			startLogicalRouters(vcpe, desiredScenario);
 
-		// Configure routing protocols
-		configureVRRP(vcpe, desiredScenario);
-		executeLogicalRouters(desiredScenario);
+			// Configure subinterfaces
+			createSubInterfaces(vcpe, desiredScenario);
+			assignIPAddresses(vcpe, desiredScenario);
+			executeLogicalRouters(desiredScenario);
 
-		// TODO return created model, not the desired one
-		vcpe.setModel(desiredScenario);
-		((VCPENetworkModel) vcpe.getModel()).setCreated(true);
+			// Configure routing protocols
+			configureEGP(vcpe, desiredScenario);
+			configureVRRP(vcpe, desiredScenario);
+			executeLogicalRouters(desiredScenario);
 
-		return (VCPENetworkModel) vcpe.getModel();
+			// TODO return created model, not the desired one
+			vcpe.setModel(desiredScenario);
+			((VCPENetworkModel) vcpe.getModel()).setCreated(true);
 
+			return (VCPENetworkModel) vcpe.getModel();
+
+		} catch (ResourceException e) {
+			destroy(vcpe, desiredScenario, lrsCreated, linksCreated);
+			throw e;
+		}
 	}
 
 	/*
 	 * (non-Javadoc)
 	 * 
-	 * @see org.opennaas.extensions.vcpe.capability.builder.builders.IVCPENetworkBuilder#destroy(org.opennaas.core.resources.IResource,
-	 * org.opennaas.extensions.vcpe.model.VCPENetworkModel)
+	 * @see org.opennaas.extensions.vcpe.capability.builder.builders.IVCPENetworkBuilder#destroy()
 	 */
 	@Override
 	public VCPENetworkModel destroy(IResource vcpe, VCPENetworkModel currentScenario) throws ResourceException {
+		return destroy(vcpe, currentScenario, true, true);
+	}
+
+	private VCPENetworkModel destroy(IResource vcpe, VCPENetworkModel currentScenario, boolean destroyLRs, boolean destroyLinks)
+			throws ResourceException {
 		log.info("Destroy a vCPE Network of the resource: " + ((VCPENetworkModel) vcpe.getModel()).getId());
 
-		// Destroy logical routers and this will destroy
-		// their subinterfaces and routing protocols
-		stopLogicalRouters(vcpe, currentScenario);
-		removeLogicalRouters(vcpe, currentScenario);
-		executePhysicalRouters(currentScenario);
+		if (destroyLRs) {
+			// Destroy logical routers and this will destroy
+			// their subinterfaces and routing protocols
+			stopLogicalRouters(vcpe, currentScenario);
+			removeLogicalRouters(vcpe, currentScenario);
+			executePhysicalRouters(currentScenario);
+		}
 
-		// Destroy autobahn links
-		destroyExternalLinks(vcpe, currentScenario);
-		executeAutobahn(currentScenario);
+		if (destroyLinks) {
+			// Destroy autobahn links
+			destroyExternalLinks(vcpe, currentScenario);
+			executeAutobahn(currentScenario);
+		}
 
-		removeResources(currentScenario);
+		if (destroyLRs) {
+			removeResources(currentScenario);
+		}
 
 		// return the model after deleting all LR and subInterfaces from it
 		VCPENetworkModel model = new VCPENetworkModel();

--- a/extensions/bundles/vcpe/src/main/java/org/opennaas/extensions/vcpe/manager/templates/TemplateSelector.java
+++ b/extensions/bundles/vcpe/src/main/java/org/opennaas/extensions/vcpe/manager/templates/TemplateSelector.java
@@ -4,7 +4,7 @@
 package org.opennaas.extensions.vcpe.manager.templates;
 
 import org.opennaas.extensions.vcpe.manager.VCPENetworkManagerException;
-import org.opennaas.extensions.vcpe.manager.templates.sp.MultipleProviderTemplate;
+import org.opennaas.extensions.vcpe.manager.templates.mp.MultipleProviderTemplate;
 import org.opennaas.extensions.vcpe.manager.templates.sp.SingleProviderTemplate;
 
 /**


### PR DESCRIPTION
BGP model in MultipleProviderTemplate is not build any more (it is left as it comes from the user).
To build it, it was using SP template dependent classes whose structure makes no sense in MP template.
If MP template requires BGP, it's own way to configure it must be implemented.
