### PR TITLE
Configure BGP with ip addresses from user input.

### DIFF
--- a/clients/opennaas-gui-vcpe/src/main/java/org/opennaas/gui/vcpe/utils/model/OpennaasBeanUtils.java
+++ b/clients/opennaas-gui-vcpe/src/main/java/org/opennaas/gui/vcpe/utils/model/OpennaasBeanUtils.java
@@ -4,6 +4,7 @@
 package org.opennaas.gui.vcpe.utils.model;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.opennaas.extensions.vcpe.manager.templates.sp.SPTemplateConstants;
@@ -56,7 +57,9 @@ public class OpennaasBeanUtils {
 		List<VCPENetworkElement> elements = new ArrayList<VCPENetworkElement>();
 		modelOut.setElements(elements);
 		// Core Router
-		org.opennaas.extensions.vcpe.model.Router routerCore = getPhysicalRouter(modelIn.getRouterCore());
+		List<String> logicalInterfacesTemplateNames = Arrays.asList(SPTemplateConstants.UP1_INTERFACE_PEER, SPTemplateConstants.UP2_INTERFACE_PEER);
+		org.opennaas.extensions.vcpe.model.Router routerCore = getPhysicalRouterWithSomeLogicalInterfaces(modelIn.getRouterCore(),
+				logicalInterfacesTemplateNames);
 		// LogicalRouters
 		org.opennaas.extensions.vcpe.model.Router logicalRouterMaster = getLROpennaas(modelIn.getName(), SPTemplateConstants.VCPE1_ROUTER,
 				modelIn.getLogicalRouterMaster());
@@ -206,6 +209,31 @@ public class OpennaasBeanUtils {
 			for (int i = 0; i < phyRouterIn.getInterfaces().size(); i++) {
 				org.opennaas.extensions.vcpe.model.Interface inter = getPhysicalInterface(phyRouterIn.getInterfaces().get(i));
 				interfaces.add(inter);
+			}
+		}
+		return phyRouterOut;
+	}
+
+	/**
+	 * @param physicalRouterCore
+	 * @return
+	 */
+	public static org.opennaas.extensions.vcpe.model.Router getPhysicalRouterWithSomeLogicalInterfaces(PhysicalRouter phyRouterIn,
+			List<String> logicalInterfacesTemplateNames) {
+		org.opennaas.extensions.vcpe.model.Router phyRouterOut = new org.opennaas.extensions.vcpe.model.Router();
+		if (phyRouterIn != null) {
+			phyRouterOut.setName(phyRouterIn.getName());
+			phyRouterOut.setTemplateName(phyRouterIn.getTemplateName());
+			// Interfaces
+			List<org.opennaas.extensions.vcpe.model.Interface> interfaces = new ArrayList<org.opennaas.extensions.vcpe.model.Interface>();
+			phyRouterOut.setInterfaces(interfaces);
+			for (int i = 0; i < phyRouterIn.getInterfaces().size(); i++) {
+				if (logicalInterfacesTemplateNames != null && logicalInterfacesTemplateNames.contains(phyRouterIn.getInterfaces().get(i))) {
+					interfaces.add(getLogicalInterface(phyRouterIn.getInterfaces().get(i)));
+				} else {
+					interfaces.add(getPhysicalInterface(phyRouterIn.getInterfaces().get(i)));
+				}
+
 			}
 		}
 		return phyRouterOut;

--- a/extensions/bundles/vcpe/src/main/java/org/opennaas/extensions/vcpe/manager/templates/sp/SingleProviderTemplate.java
+++ b/extensions/bundles/vcpe/src/main/java/org/opennaas/extensions/vcpe/manager/templates/sp/SingleProviderTemplate.java
@@ -433,6 +433,29 @@ public class SingleProviderTemplate implements ITemplate {
 
 		// TODO update ALL elements with data in inputModel (everything may have changed)
 
+		// Core router
+		Router coreinput = (Router) VCPENetworkModelHelper.getElementByTemplateName(inputModel, SPTemplateConstants.CORE_PHY_ROUTER);
+		Router core = (Router) VCPENetworkModelHelper.getElementByTemplateName(model, SPTemplateConstants.CORE_PHY_ROUTER);
+
+		Interface coremasterinput = (Interface) VCPENetworkModelHelper.getElementByTemplateName(coreinput.getInterfaces(),
+				SPTemplateConstants.UP1_INTERFACE_PEER);
+		Interface coremaster = (Interface) VCPENetworkModelHelper.getElementByTemplateName(core.getInterfaces(),
+				SPTemplateConstants.UP1_INTERFACE_PEER);
+
+		Interface corebkpinput = (Interface) VCPENetworkModelHelper.getElementByTemplateName(coreinput.getInterfaces(),
+				SPTemplateConstants.UP2_INTERFACE_PEER);
+		Interface corebkp = (Interface) VCPENetworkModelHelper.getElementByTemplateName(core.getInterfaces(),
+				SPTemplateConstants.UP2_INTERFACE_PEER);
+
+		if (coremasterinput != null) {
+			VCPENetworkModelHelper.updateInterface(coremaster, coremasterinput.getName(), coremasterinput.getVlan(), coremasterinput.getIpAddress(),
+					coremasterinput.getPhysicalInterfaceName(), coremasterinput.getPort());
+		}
+		if (corebkpinput != null) {
+			VCPENetworkModelHelper.updateInterface(corebkp, corebkpinput.getName(), corebkpinput.getVlan(), corebkpinput.getIpAddress(),
+					corebkpinput.getPhysicalInterfaceName(), corebkpinput.getPort());
+		}
+
 		// LR1
 		Router vcpe1input = (Router) VCPENetworkModelHelper.getElementByTemplateName(inputModel, SPTemplateConstants.VCPE1_ROUTER);
 		Router vcpe1 = (Router) VCPENetworkModelHelper.getElementByTemplateName(model, SPTemplateConstants.VCPE1_ROUTER);


### PR DESCRIPTION
This patch causes BGB configuration for SP-VCPE template to be updated with user provided IP addresses.

To do so, logical interfaces in core router are sent to OpenNaaS from the GUI (within create method),
and afterwards, model used to configure BGP is updated with data of recevived core router logical interfaces.

With the values correclty updated in the model, configuring BGP from the model requires no change.

Fixes issue OPENNAAS-873
Together with #512 fixes bug OPENNAAS-848

This pull request replaces #514
