### PR TITLE
Use one single physical router in mp-vcpe physical insfrastructure.

### DIFF
--- a/extensions/bundles/vcpe/src/main/java/org/opennaas/extensions/vcpe/manager/templates/mp/MPTemplateModelBuilder.java
+++ b/extensions/bundles/vcpe/src/main/java/org/opennaas/extensions/vcpe/manager/templates/mp/MPTemplateModelBuilder.java
@@ -1,9 +1,9 @@
 package org.opennaas.extensions.vcpe.manager.templates.mp;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
-import org.opennaas.extensions.vcpe.model.Domain;
 import org.opennaas.extensions.vcpe.model.IPNetworkDomain;
 import org.opennaas.extensions.vcpe.model.Interface;
 import org.opennaas.extensions.vcpe.model.Link;
@@ -32,104 +32,27 @@ public class MPTemplateModelBuilder {
 
 		List<Interface> interfaces;
 
-		// create networks
-		IPNetworkDomain wan1 = new IPNetworkDomain();
-		wan1.setTemplateName(TemplateConstants.WAN1);
-
-		IPNetworkDomain wan2 = new IPNetworkDomain();
-		wan2.setTemplateName(TemplateConstants.WAN2);
-
-		IPNetworkDomain client = new IPNetworkDomain();
-		client.setTemplateName(TemplateConstants.LAN_CLIENT);
-
-		// create interfaces for networks
-		Interface wan1down = createInterface(TemplateConstants.WAN1_PHY_IFACE_DOWN);
-		Interface wan2down = createInterface(TemplateConstants.WAN2_PHY_IFACE_DOWN);
-		Interface clientLanUp = createInterface(TemplateConstants.LAN_CLIENT_PHY_IFACE_UP);
+		// Physical Router
+		Router phyRouter = new PhysicalRouter();
+		phyRouter.setTemplateName(TemplateConstants.ROUTER_1_PHY);
 
 		interfaces = new ArrayList<Interface>();
-		interfaces.add(wan1down);
-		wan1.setInterfaces(interfaces);
+		phyRouter.setInterfaces(interfaces);
 
-		interfaces = new ArrayList<Interface>();
-		interfaces.add(wan2down);
-		wan2.setInterfaces(interfaces);
-
-		interfaces = new ArrayList<Interface>();
-		interfaces.add(clientLanUp);
-		client.setInterfaces(interfaces);
-
-		// LogicalRouter 1
-		Router lr1 = new PhysicalRouter();
-		lr1.setTemplateName(TemplateConstants.LR_1_PHY_ROUTER);
-
-		interfaces = new ArrayList<Interface>();
-		lr1.setInterfaces(interfaces);
-
-		Interface lr1Up = createInterface(TemplateConstants.LR_1_PHY_IFACE_UP);
-		Interface lr1Down = createInterface(TemplateConstants.LR_1_PHY_IFACE_DOWN);
-		Interface lr1Lo = createInterface(TemplateConstants.LR_1_PHY_IFACE_LO);
-		interfaces.add(lr1Up);
-		interfaces.add(lr1Down);
-		interfaces.add(lr1Lo);
-
-		// LogicalRouter 2
-		Router lr2 = new PhysicalRouter();
-		lr2.setTemplateName(TemplateConstants.LR_2_PHY_ROUTER);
-
-		interfaces = new ArrayList<Interface>();
-		lr2.setInterfaces(interfaces);
-
-		Interface lr2Up = createInterface(TemplateConstants.LR_2_PHY_IFACE_UP);
-		Interface lr2Down = createInterface(TemplateConstants.LR_2_PHY_IFACE_DOWN);
-		Interface lr2Lo = createInterface(TemplateConstants.LR_2_PHY_IFACE_LO);
-		interfaces.add(lr2Up);
-		interfaces.add(lr2Down);
-		interfaces.add(lr2Lo);
-
-		// Client Logical Router
-		Router lrclient = new PhysicalRouter();
-		lrclient.setTemplateName(TemplateConstants.LR_CLIENT_PHY_ROUTER);
-
-		interfaces = new ArrayList<Interface>();
-		lrclient.setInterfaces(interfaces);
-
-		Interface lrclientUp1 = createInterface(TemplateConstants.LR_CLIENT_PHY_IFACE_UP1);
-		Interface lrclientUp2 = createInterface(TemplateConstants.LR_CLIENT_PHY_IFACE_UP2);
-		Interface lrclientDown = createInterface(TemplateConstants.LR_CLIENT_PHY_IFACE_DOWN);
-		Interface lrclientLo = createInterface(TemplateConstants.LR_CLIENT_PHY_IFACE_LO);
-		interfaces.add(lrclientUp1);
-		interfaces.add(lrclientUp2);
-		interfaces.add(lrclientDown);
-		interfaces.add(lrclientLo);
-
-		// TODO link type should be an enumeration in Link
-		// Links
-		Link wan1Link = VCPENetworkModelHelper.createLink(null, TemplateConstants.LINK_WAN1_PHY, "eth", lr1Up, wan1down);
-		Link wan2Link = VCPENetworkModelHelper.createLink(null, TemplateConstants.LINK_WAN2_PHY, "eth", lr2Up, wan2down);
-		Link clientLink = VCPENetworkModelHelper.createLink(null, TemplateConstants.LINK_LAN_CLIENT_PHY, "eth", lrclientDown, clientLanUp);
-
-		Link intern1Link = VCPENetworkModelHelper.createLink(null, TemplateConstants.LINK_LR_1_LR_CLIENT_PHY, "lt", lr1Down, lrclientUp1);
-		Link intern2Link = VCPENetworkModelHelper.createLink(null, TemplateConstants.LINK_LR_2_LR_CLIENT_PHY, "lt", lr2Down, lrclientUp2);
+		Interface phyRouterUp1 = createInterface(TemplateConstants.ROUTER_1_PHY_IFACE_UP1);
+		Interface phyRouterUp2 = createInterface(TemplateConstants.ROUTER_1_PHY_IFACE_UP2);
+		Interface phyRouterDown = createInterface(TemplateConstants.ROUTER_1_PHY_IFACE_DOWN);
+		Interface phyRouterLo = createInterface(TemplateConstants.ROUTER_1_PHY_IFACE_LO);
+		Interface phyRouterLt = createInterface(TemplateConstants.ROUTER_1_PHY_IFACE_LT);
+		interfaces.add(phyRouterUp1);
+		interfaces.add(phyRouterUp2);
+		interfaces.add(phyRouterDown);
+		interfaces.add(phyRouterLo);
+		interfaces.add(phyRouterLt);
 
 		List<VCPENetworkElement> elements = new ArrayList<VCPENetworkElement>();
-		elements.add(wan1);
-		elements.addAll(wan1.getInterfaces());
-		elements.add(wan2);
-		elements.addAll(wan2.getInterfaces());
-		elements.add(client);
-		elements.addAll(client.getInterfaces());
-		elements.add(lr1);
-		elements.addAll(lr1.getInterfaces());
-		elements.add(lr2);
-		elements.addAll(lr2.getInterfaces());
-		elements.add(lrclient);
-		elements.addAll(lrclient.getInterfaces());
-		elements.add(wan1Link);
-		elements.add(wan2Link);
-		elements.add(clientLink);
-		elements.add(intern1Link);
-		elements.add(intern2Link);
+		elements.add(phyRouter);
+		elements.addAll(phyRouter.getInterfaces());
 
 		VCPENetworkModel model = new VCPENetworkModel();
 		model.setElements(elements);
@@ -145,9 +68,23 @@ public class MPTemplateModelBuilder {
 	 */
 	public static VCPENetworkModel generateLogicalElements() {
 
+		// create networks
+		IPNetworkDomain wan1 = new IPNetworkDomain();
+		wan1.setTemplateName(TemplateConstants.WAN1);
+
+		IPNetworkDomain wan2 = new IPNetworkDomain();
+		wan2.setTemplateName(TemplateConstants.WAN2);
+
+		IPNetworkDomain client = new IPNetworkDomain();
+		client.setTemplateName(TemplateConstants.LAN_CLIENT);
+
 		Interface wan1down = createInterface(TemplateConstants.WAN1_IFACE_DOWN);
 		Interface wan2down = createInterface(TemplateConstants.WAN2_IFACE_DOWN);
 		Interface clientLanUp = createInterface(TemplateConstants.LAN_CLIENT_IFACE_UP);
+
+		wan1.setInterfaces(Arrays.asList(wan1down));
+		wan2.setInterfaces(Arrays.asList(wan2down));
+		client.setInterfaces(Arrays.asList(clientLanUp));
 
 		// LogicalRouter 1
 		Router lr1 = new LogicalRouter();
@@ -202,9 +139,12 @@ public class MPTemplateModelBuilder {
 		Link intern2Link = VCPENetworkModelHelper.createLink(null, TemplateConstants.LINK_LR_2_LR_CLIENT, "lt", lr2Down, lrclientUp2);
 
 		List<VCPENetworkElement> elements = new ArrayList<VCPENetworkElement>();
-		elements.add(wan1down);
-		elements.add(wan2down);
-		elements.add(clientLanUp);
+		elements.add(wan1);
+		elements.addAll(wan1.getInterfaces());
+		elements.add(wan2);
+		elements.addAll(wan2.getInterfaces());
+		elements.add(client);
+		elements.addAll(client.getInterfaces());
 		elements.add(lr1);
 		elements.addAll(lr1.getInterfaces());
 		elements.add(lr2);
@@ -237,35 +177,18 @@ public class MPTemplateModelBuilder {
 		// put all physical elements in logicalInfrastructure
 		logicalInfrastructure.getElements().addAll(physicalInfrastructure.getElements());
 
-		// put logical interfaces into corresponding networks
-		Domain net;
-		Interface iface;
-
-		net = (Domain) VCPENetworkModelHelper.getElementByTemplateName(physicalInfrastructure, TemplateConstants.WAN1);
-		iface = (Interface) VCPENetworkModelHelper.getElementByTemplateName(logicalInfrastructure, TemplateConstants.WAN1_IFACE_DOWN);
-		net.getInterfaces().add(iface);
-
-		net = (Domain) VCPENetworkModelHelper.getElementByTemplateName(physicalInfrastructure, TemplateConstants.WAN2);
-		iface = (Interface) VCPENetworkModelHelper.getElementByTemplateName(logicalInfrastructure, TemplateConstants.WAN2_IFACE_DOWN);
-		net.getInterfaces().add(iface);
-
-		net = (Domain) VCPENetworkModelHelper.getElementByTemplateName(physicalInfrastructure, TemplateConstants.LAN_CLIENT);
-		iface = (Interface) VCPENetworkModelHelper.getElementByTemplateName(logicalInfrastructure, TemplateConstants.LAN_CLIENT_IFACE_UP);
-		net.getInterfaces().add(iface);
-
 		// Assign logical routers to physical ones
 		Router phyRouter;
 		LogicalRouter logRouter;
 
-		phyRouter = (Router) VCPENetworkModelHelper.getElementByTemplateName(physicalInfrastructure, TemplateConstants.LR_1_PHY_ROUTER);
+		phyRouter = (Router) VCPENetworkModelHelper.getElementByTemplateName(physicalInfrastructure, TemplateConstants.ROUTER_1_PHY);
+
 		logRouter = (LogicalRouter) VCPENetworkModelHelper.getElementByTemplateName(logicalInfrastructure, TemplateConstants.LR_1_ROUTER);
 		logRouter.setPhysicalRouter(phyRouter);
 
-		phyRouter = (Router) VCPENetworkModelHelper.getElementByTemplateName(logicalInfrastructure, TemplateConstants.LR_2_PHY_ROUTER);
 		logRouter = (LogicalRouter) VCPENetworkModelHelper.getElementByTemplateName(logicalInfrastructure, TemplateConstants.LR_2_ROUTER);
 		logRouter.setPhysicalRouter(phyRouter);
 
-		phyRouter = (Router) VCPENetworkModelHelper.getElementByTemplateName(logicalInfrastructure, TemplateConstants.LR_CLIENT_PHY_ROUTER);
 		logRouter = (LogicalRouter) VCPENetworkModelHelper.getElementByTemplateName(logicalInfrastructure, TemplateConstants.LR_CLIENT_ROUTER);
 		logRouter.setPhysicalRouter(phyRouter);
 

--- a/extensions/bundles/vcpe/src/main/java/org/opennaas/extensions/vcpe/manager/templates/mp/TemplateConstants.java
+++ b/extensions/bundles/vcpe/src/main/java/org/opennaas/extensions/vcpe/manager/templates/mp/TemplateConstants.java
@@ -6,121 +6,55 @@ public class TemplateConstants {
 	 * Template Name Space. This namespace is meant to be unique in whole OpenNaaS. Particularly, there MUST not exist any other vcpe template using
 	 * the same namespace.
 	 */
-	public static final String	TEMPLATE_NS					= "org.opennaas.extensions.vcpe.manager.templates.mp";
+	public static final String	TEMPLATE_NS				= "org.opennaas.extensions.vcpe.manager.templates.mp";
 
 	// ////////////////////
 	// PHYSICAL ELEMENTS //
 	// ////////////////////
 
-	// Nets
-	/**
-	 * Network of provider 1
-	 */
-	public static final String	WAN1						= TEMPLATE_NS + "net.wan.1";
-	/**
-	 * Network of provider 2
-	 */
-	public static final String	WAN2						= TEMPLATE_NS + "net.wan.2";
-	/**
-	 * Client institution LAN
-	 */
-	public static final String	LAN_CLIENT					= TEMPLATE_NS + "net.lan.client";
-
-	// Interfaces in nets
-	/**
-	 * Physical interface in WAN1 connected to the vCPE
-	 */
-	public static final String	WAN1_PHY_IFACE_DOWN			= TEMPLATE_NS + "net.wan.1.iface.phy.down";
-	/**
-	 * Physical interface in WAN2 connected to the vCPE
-	 */
-	public static final String	WAN2_PHY_IFACE_DOWN			= TEMPLATE_NS + "net.wan.2.iface.phy.down";
-	/**
-	 * Physical interface in LAn_CLIENT connected to the vCPE
-	 */
-	public static final String	LAN_CLIENT_PHY_IFACE_UP		= TEMPLATE_NS + "net.lan.client.iface.phy.up";
-
 	// LRs
 	/**
-	 * Physical router hosting LR_1_ROUTER
+	 * Physical router hosting LR_1_ROUTER, LR_2_ROUTER and LR_CLIENT_ROUTER
 	 */
-	public static final String	LR_1_PHY_ROUTER				= TEMPLATE_NS + "vcpe.lr.1.phy";
-	/**
-	 * Physical router hosting LR_2_ROUTER
-	 */
-	public static final String	LR_2_PHY_ROUTER				= TEMPLATE_NS + "vcpe.lr.2.phy";
-	/**
-	 * Physical router hosting LR_CLIENT_ROUTER
-	 */
-	public static final String	LR_CLIENT_PHY_ROUTER		= TEMPLATE_NS + "vcpe.lr.client.phy";
+	public static final String	ROUTER_1_PHY			= TEMPLATE_NS + "vcpe.router.1.phy";
 
-	// Interfaces in LRs
+	// Interfaces in ROUTER_1_PHY
 	/**
-	 * Physical interface in LR_1_PHY_ROUTER connected to WAN1_PHY_IFACE_DOWN
+	 * Physical interface in ROUTER_1_PHY connected to WAN1
 	 */
-	public static final String	LR_1_PHY_IFACE_UP			= TEMPLATE_NS + "vcpe.lr.1.phy.iface.phy.up";
+	public static final String	ROUTER_1_PHY_IFACE_UP1	= TEMPLATE_NS + "vcpe.router.1.phy.iface.phy.up1";
 	/**
-	 * Physical interface in LR_1_PHY_ROUTER connected to LR_CLIENT_PHY_IFACE_UP1
+	 * Physical interface in ROUTER_1_PHY connected to WAN2
 	 */
-	public static final String	LR_1_PHY_IFACE_DOWN			= TEMPLATE_NS + "vcpe.lr.1.phy.iface.phy.down";
+	public static final String	ROUTER_1_PHY_IFACE_UP2	= TEMPLATE_NS + "vcpe.router.1.phy.iface.phy.up2";
 	/**
-	 * Physical loopback interface in LR_1_PHY_ROUTER
+	 * Physical interface in ROUTER_1_PHY connected to LAN_CLIENT
 	 */
-	public static final String	LR_1_PHY_IFACE_LO			= TEMPLATE_NS + "vcpe.lr.1.phy.iface.phy.lo";
-
+	public static final String	ROUTER_1_PHY_IFACE_DOWN	= TEMPLATE_NS + "vcpe.router.1.phy.iface.phy.down";
 	/**
-	 * Physical interface in LR_2_PHY_ROUTER connected to WAN2_PHY_IFACE_DOWN
+	 * Physical loopback interface in ROUTER_1_PHY
 	 */
-	public static final String	LR_2_PHY_IFACE_UP			= TEMPLATE_NS + "vcpe.lr.2.phy.iface.phy.up";
+	public static final String	ROUTER_1_PHY_IFACE_LO	= TEMPLATE_NS + "vcpe.router.1.phy.iface.phy.lo";
 	/**
-	 * Physical interface in LR_2_PHY_ROUTER connected to LR_CLIENT_PHY_IFACE_UP2
+	 * Physical logical tunnel interface in ROUTER_1_PHY used to connect LRs between each others. It will host links LINK_LR_1_LR_CLIENT and
+	 * LINK_LR_2_LR_CLIENT.
 	 */
-	public static final String	LR_2_PHY_IFACE_DOWN			= TEMPLATE_NS + "vcpe.lr.2.phy.iface.phy.down";
-	/**
-	 * Physical loopback interface in LR_2_PHY_ROUTER
-	 */
-	public static final String	LR_2_PHY_IFACE_LO			= TEMPLATE_NS + "vcpe.lr.2.phy.iface.phy.lo";
-
-	/**
-	 * Physical interface in LR_CLIENT_PHY_ROUTER connected to LR_1_PHY_IFACE_DOWN
-	 */
-	public static final String	LR_CLIENT_PHY_IFACE_UP1		= TEMPLATE_NS + "vcpe.lr.client.phy.iface.phy.up1";
-	/**
-	 * Physical interface in LR_CLIENT_PHY_ROUTER connected to LR_2_PHY_IFACE_DOWN
-	 */
-	public static final String	LR_CLIENT_PHY_IFACE_UP2		= TEMPLATE_NS + "vcpe.lr.client.phy.iface.phy.up2";
-	/**
-	 * Physical interface in LR_CLIENT_PHY_ROUTER connected to LAN_CLIENT_PHY_IFACE_UP
-	 */
-	public static final String	LR_CLIENT_PHY_IFACE_DOWN	= TEMPLATE_NS + "vcpe.lr.client.phy.iface.phy.down";
-	/**
-	 * Physical loopback interface in LR_CLIENT_PHY_ROUTER
-	 */
-	public static final String	LR_CLIENT_PHY_IFACE_LO		= TEMPLATE_NS + "vcpe.lr.client.phy.iface.phy.lo";
+	public static final String	ROUTER_1_PHY_IFACE_LT	= TEMPLATE_NS + "vcpe.router.1.phy.iface.phy.lt";
 
 	// Links
+	// MP template assumes following physical links exists in reality, although not used in the model.
 	/**
-	 * Physical link connecting WAN1_PHY_IFACE_DOWN and LR_1_PHY_IFACE_UP
+	 * Physical link connecting WAN1 and ROUTER_1_PHY_IFACE_UP1
 	 */
-	public static final String	LINK_WAN1_PHY				= TEMPLATE_NS + "link.phy.wan.1";
+	public static final String	LINK_WAN1_PHY			= TEMPLATE_NS + "link.phy.wan.1";
 	/**
-	 * Physical link connecting WAN2_PHY_IFACE_DOWN and LR_2_PHY_IFACE_UP
+	 * Physical link connecting WAN2 and ROUTER_1_PHY_IFACE_UP2
 	 */
-	public static final String	LINK_WAN2_PHY				= TEMPLATE_NS + "link.phy.wan.2";
+	public static final String	LINK_WAN2_PHY			= TEMPLATE_NS + "link.phy.wan.2";
 	/**
-	 * Physical link connecting LR_CLIENT_PHY_IFACE_DOWN and LAN_CLIENT_PHY_IFACE_UP
+	 * Physical link connecting ROUTER_1_PHY_IFACE_DOWN and LAN_CLIENT
 	 */
-	public static final String	LINK_LAN_CLIENT_PHY			= TEMPLATE_NS + "link.phy.lan.client";
-
-	// intern links of the vCPE (between LRs)
-	/**
-	 * Physical link connecting LR_1_PHY_IFACE_DOWN and LR_CLIENT_PHY_IFACE_UP1
-	 */
-	public static final String	LINK_LR_1_LR_CLIENT_PHY		= TEMPLATE_NS + "link.phy.intern.1";
-	/**
-	 * Physical link connecting LR_2_PHY_IFACE_DOWN and LR_CLIENT_PHY_IFACE_UP2
-	 */
-	public static final String	LINK_LR_2_LR_CLIENT_PHY		= TEMPLATE_NS + "link.phy.intern.2";
+	public static final String	LINK_LAN_CLIENT_PHY		= TEMPLATE_NS + "link.phy.lan.client";
 
 	// ///////////////////
 	// LOGICAL ELEMENTS //
@@ -128,104 +62,118 @@ public class TemplateConstants {
 
 	// Nets
 	/**
-	 * Logical interface configured in WAN1_PHY_IFACE_DOWN
+	 * Network of provider 1
 	 */
-	public static final String	WAN1_IFACE_DOWN				= TEMPLATE_NS + "net.wan.1.iface.logical.down";
+	public static final String	WAN1					= TEMPLATE_NS + "net.wan.1";
 	/**
-	 * Logical interface configured in WAN2_PHY_IFACE_DOWN
+	 * Network of provider 2
 	 */
-	public static final String	WAN2_IFACE_DOWN				= TEMPLATE_NS + "net.wan.2.iface.logical.down";
+	public static final String	WAN2					= TEMPLATE_NS + "net.wan.2";
 	/**
-	 * Logical interface configured in LAN_CLIENT_PHY_IFACE_UP
+	 * Client institution LAN
 	 */
-	public static final String	LAN_CLIENT_IFACE_UP			= TEMPLATE_NS + "net.lan.client.iface.logical.up";
+	public static final String	LAN_CLIENT				= TEMPLATE_NS + "net.lan.client";
+	/**
+	 * Logical interface in WAN1. It is connected to LR_1_IFACE_UP through LINK_WAN1
+	 */
+	public static final String	WAN1_IFACE_DOWN			= TEMPLATE_NS + "net.wan.1.iface.logical.down";
+	/**
+	 * Logical interface in WAN2. It is connected to LR_2_IFACE_UP through LINK_WAN2
+	 */
+	public static final String	WAN2_IFACE_DOWN			= TEMPLATE_NS + "net.wan.2.iface.logical.down";
+	/**
+	 * Logical interface LAN_CLIENT. It is connected to LR_CLIENT_IFACE_DOWN through LINK_LAN_CLIENT
+	 */
+	public static final String	LAN_CLIENT_IFACE_UP		= TEMPLATE_NS + "net.lan.client.iface.logical.up";
 
 	// LRs
 	/**
 	 * Logical Router hosted by LR_1_PHY_ROUTER. It contains 3 interfaces: - LR_1_IFACE_UP - LR_1_IFACE_DOWN - LR_1_IFACE_LO This LR is connected to
 	 * WAN1 (through LR_1_IFACE_UP), and to LR_CLIENT_ROUTER (through LR_1_IFACE_DOWN)
 	 */
-	public static final String	LR_1_ROUTER					= TEMPLATE_NS + "vcpe.lr.1";
+	public static final String	LR_1_ROUTER				= TEMPLATE_NS + "vcpe.lr.1";
 	/**
 	 * Logical Router hosted by LR_2_PHY_ROUTER. It contains 3 interfaces: - LR_2_IFACE_UP - LR_2_IFACE_DOWN - LR_2_IFACE_LO This LR is connected to
 	 * WAN2 (through LR_2_IFACE_UP), and to LR_CLIENT_ROUTER (through LR_2_IFACE_DOWN)
 	 */
-	public static final String	LR_2_ROUTER					= TEMPLATE_NS + "vcpe.lr.2";
+	public static final String	LR_2_ROUTER				= TEMPLATE_NS + "vcpe.lr.2";
 	/**
 	 * Logical Router hosted by LR_CLIENT_PHY_ROUTER. It contains 4 interfaces: - LR_CLIENT_IFACE_UP1 - LR_CLIENT_IFACE_UP2 - LR_CLIENT_IFACE_DOWN -
 	 * LR_CLIENT_IFACE_LO This LR is connected to LR_1_ROUTER (through LR_CLIENT_IFACE_UP1), to LR_2_ROUTER (through LR_CLIENT_IFACE_UP2), and to
 	 * LAN_CLIENT (through LR_CLIENT_IFACE_DOWN)
 	 */
-	public static final String	LR_CLIENT_ROUTER			= TEMPLATE_NS + "vcpe.lr.client";
+	public static final String	LR_CLIENT_ROUTER		= TEMPLATE_NS + "vcpe.lr.client";
 
 	// LR_1_ROUTER logical interfaces
 	/**
 	 * Logical interface in LR_1_ROUTER. Hosted by LR_1_PHY_IFACE_UP. It is linked to LINK_WAN1
 	 */
-	public static final String	LR_1_IFACE_UP				= TEMPLATE_NS + "vcpe.lr.1.iface.logical.up";
+	public static final String	LR_1_IFACE_UP			= TEMPLATE_NS + "vcpe.lr.1.iface.logical.up";
 	/**
 	 * Logical interface in LR_1_ROUTER. Hosted by LR_1_PHY_IFACE_DOWN. It is linked to LINK_LR_1_LR_CLIENT
 	 */
-	public static final String	LR_1_IFACE_DOWN				= TEMPLATE_NS + "vcpe.lr.1.iface.logical.down";
+	public static final String	LR_1_IFACE_DOWN			= TEMPLATE_NS + "vcpe.lr.1.iface.logical.down";
 	/**
 	 * Logical loopback interface in LR_1_ROUTER. Hosted by LR_1_PHY_IFACE_LO
 	 */
-	public static final String	LR_1_IFACE_LO				= TEMPLATE_NS + "vcpe.lr.1.iface.logical.lo";
+	public static final String	LR_1_IFACE_LO			= TEMPLATE_NS + "vcpe.lr.1.iface.logical.lo";
 
 	// LR_2_ROUTER logical interfaces
 	/**
 	 * Logical interface in LR_2_ROUTER. Hosted by LR_2_PHY_IFACE_UP. It is linked to LINK_WAN2
 	 */
-	public static final String	LR_2_IFACE_UP				= TEMPLATE_NS + "vcpe.lr.2.iface.logical.up";
+	public static final String	LR_2_IFACE_UP			= TEMPLATE_NS + "vcpe.lr.2.iface.logical.up";
 	/**
 	 * Logical interface in LR_2_ROUTER. Hosted by LR_2_PHY_IFACE_DOWN. It is linked to LINK_LR_2_LR_CLIENT
 	 */
-	public static final String	LR_2_IFACE_DOWN				= TEMPLATE_NS + "vcpe.lr.2.iface.logical.down";
+	public static final String	LR_2_IFACE_DOWN			= TEMPLATE_NS + "vcpe.lr.2.iface.logical.down";
 	/**
 	 * Logical loopback interface in LR_2_ROUTER. Hosted by LR_2_PHY_IFACE_LO
 	 */
-	public static final String	LR_2_IFACE_LO				= TEMPLATE_NS + "vcpe.lr.2.iface.logical.lo";
+	public static final String	LR_2_IFACE_LO			= TEMPLATE_NS + "vcpe.lr.2.iface.logical.lo";
 
 	// LR_CLIENT_ROUTER logical interfaces
 	/**
 	 * Logical interface in LR_CLIENT_ROUTER. Hosted by LR_CLIENT_PHY_IFACE_UP1. It is linked to LINK_LR_1_LR_CLIENT
 	 */
-	public static final String	LR_CLIENT_IFACE_UP1			= TEMPLATE_NS + "vcpe.lr.client.iface.logical.up1";
+	public static final String	LR_CLIENT_IFACE_UP1		= TEMPLATE_NS + "vcpe.lr.client.iface.logical.up1";
 	/**
 	 * Logical interface in LR_CLIENT_ROUTER. Hosted by LR_CLIENT_PHY_IFACE_UP2. It is linked to LINK_LR_2_LR_CLIENT
 	 */
-	public static final String	LR_CLIENT_IFACE_UP2			= TEMPLATE_NS + "vcpe.lr.client.iface.logical.up2";
+	public static final String	LR_CLIENT_IFACE_UP2		= TEMPLATE_NS + "vcpe.lr.client.iface.logical.up2";
 	/**
 	 * Logical interface in LR_CLIENT_ROUTER. Hosted by LR_CLIENT_PHY_IFACE_DOWN. It is linked to LINK_LAN_CLIENT
 	 */
-	public static final String	LR_CLIENT_IFACE_DOWN		= TEMPLATE_NS + "vcpe.lr.client.iface.logical.down";
+	public static final String	LR_CLIENT_IFACE_DOWN	= TEMPLATE_NS + "vcpe.lr.client.iface.logical.down";
 	/**
 	 * Logical loopback interface in LR_CLIENT_ROUTER. Hosted by LR_CLIENT_PHY_IFACE_LO
 	 */
-	public static final String	LR_CLIENT_IFACE_LO			= TEMPLATE_NS + "vcpe.lr.client.iface.logical.lo";
+	public static final String	LR_CLIENT_IFACE_LO		= TEMPLATE_NS + "vcpe.lr.client.iface.logical.lo";
 
 	// Links
+
+	// Tagged ethernet links (vlan tagged)
 	/**
 	 * Logical link connecting LR_1_IFACE_UP and WAN1_IFACE_DOWN. Implemented by LINK_WAN1_PHY
 	 */
-	public static final String	LINK_WAN1					= TEMPLATE_NS + "link.logical.wan.1";
+	public static final String	LINK_WAN1				= TEMPLATE_NS + "link.logical.wan.1";
 	/**
 	 * Logical link connecting LR_2_IFACE_UP and WAN2_IFACE_DOWN. Implemented by LINK_WAN2_PHY
 	 */
-	public static final String	LINK_WAN2					= TEMPLATE_NS + "link.logical.wan.2";
+	public static final String	LINK_WAN2				= TEMPLATE_NS + "link.logical.wan.2";
 	/**
 	 * Logical link connecting LR_CLIENT_IFACE_DOWN and LAN_CLIENT_IFACE_UP. Implemented by LINK_LAN_CLIENT_PHY
 	 */
-	public static final String	LINK_LAN_CLIENT				= TEMPLATE_NS + "link.logical.lan.client";
+	public static final String	LINK_LAN_CLIENT			= TEMPLATE_NS + "link.logical.lan.client";
 
-	// intern links of the vCPE (between LRs)
+	// intern links of the vCPE between LRs (logical tunnels)
 	/**
-	 * Logical link connecting LR_1_IFACE_DOWN and LR_CLIENT_IFACE_UP1. Implemented by LINK_LR_1_LR_CLIENT_PHY
+	 * Logical link connecting LR_1_IFACE_DOWN and LR_CLIENT_IFACE_UP1. Implemented by ROUTER_1_PHY_IFACE_LT
 	 */
-	public static final String	LINK_LR_1_LR_CLIENT			= TEMPLATE_NS + "link.logial.intern.1";
+	public static final String	LINK_LR_1_LR_CLIENT		= TEMPLATE_NS + "link.logial.intern.1";
 	/**
-	 * Logical link connecting LR_2_IFACE_DOWN and LR_CLIENT_IFACE_UP2. Implemented by LINK_LR_2_LR_CLIENT_PHY
+	 * Logical link connecting LR_2_IFACE_DOWN and LR_CLIENT_IFACE_UP2. Implemented by ROUTER_1_PHY_IFACE_LT
 	 */
-	public static final String	LINK_LR_2_LR_CLIENT			= TEMPLATE_NS + "link.logial.intern.2";
+	public static final String	LINK_LR_2_LR_CLIENT		= TEMPLATE_NS + "link.logial.intern.2";
 
 }


### PR DESCRIPTION
- Removed other physical routers
- Removed physical interfaces in networks
- Removed physical links creation.
- Moved creation of IPNetoworks to logicalInfrastructure.
