### PR TITLE
Configure routing of MP template, using static routes.

### DIFF
--- a/extensions/bundles/vcpe/src/main/java/org/opennaas/extensions/vcpe/capability/builder/builders/helpers/StaticRouteHelper.java
+++ b/extensions/bundles/vcpe/src/main/java/org/opennaas/extensions/vcpe/capability/builder/builders/helpers/StaticRouteHelper.java
@@ -34,6 +34,11 @@ public class StaticRouteHelper extends GenericHelper {
 			throw new ResourceException("Invalid IP address range (missing mask): " + ipRange);
 		}
 
+		// nextHopIpAddress should have no mask
+		if (nextHopIpAddress != null && nextHopIpAddress.contains("/")) {
+			nextHopIpAddress = IPUtilsHelper.composedIPAddressToIPAddressAndMask(nextHopIpAddress)[0];
+		}
+
 		IStaticRouteCapability capability = (IStaticRouteCapability) routerResource.getCapabilityByInterface(IStaticRouteCapability.class);
 		capability.createStaticRoute(ipRangeAddressAndMask[0], ipRangeAddressAndMask[1], nextHopIpAddress, String.valueOf(isDiscard));
 	}

--- a/extensions/bundles/vcpe/src/main/java/org/opennaas/extensions/vcpe/capability/builder/builders/mp/VCPEMultipleProvider.java
+++ b/extensions/bundles/vcpe/src/main/java/org/opennaas/extensions/vcpe/capability/builder/builders/mp/VCPEMultipleProvider.java
@@ -16,12 +16,14 @@ import org.opennaas.extensions.vcpe.capability.builder.builders.helpers.GenericH
 import org.opennaas.extensions.vcpe.capability.builder.builders.helpers.IPHelper;
 import org.opennaas.extensions.vcpe.capability.builder.builders.helpers.InterfaceHelper;
 import org.opennaas.extensions.vcpe.capability.builder.builders.helpers.LogicalRouterHelper;
+import org.opennaas.extensions.vcpe.capability.builder.builders.helpers.StaticRouteHelper;
 import org.opennaas.extensions.vcpe.model.Interface;
 import org.opennaas.extensions.vcpe.model.LogicalRouter;
 import org.opennaas.extensions.vcpe.model.PhysicalRouter;
 import org.opennaas.extensions.vcpe.model.Router;
 import org.opennaas.extensions.vcpe.model.VCPENetworkModel;
 import org.opennaas.extensions.vcpe.model.helper.VCPENetworkModelHelper;
+import org.opennaas.extensions.vcpe.model.routing.StaticRouteConfiguration;
 
 import com.google.common.collect.Iterables;
 
@@ -59,9 +61,9 @@ public class VCPEMultipleProvider implements IVCPENetworkBuilder {
 			assignIPAddresses(vcpe, desiredScenario);
 			executeLogicalRouters(desiredScenario);
 
-			// TODO Configure routing protocols
-			// configureStaticRoutes(vcpe, desiredScenario);
-			// executeLogicalRouters(desiredScenario);
+			// Configure routing protocols
+			configureStaticRoutes(vcpe, desiredScenario);
+			executeLogicalRouters(desiredScenario);
 
 			// TODO return created model, not the desired one
 			vcpe.setModel(desiredScenario);
@@ -123,8 +125,13 @@ public class VCPEMultipleProvider implements IVCPENetworkBuilder {
 	}
 
 	private void configureStaticRoutes(IResource vcpe, VCPENetworkModel model) throws ResourceException {
-		// TODO Auto-generated method stub
-		throw new ResourceException("Not implemented operation");
+		for (LogicalRouter lr : getLogicalRouters(model)) {
+			if (lr.getRoutingConfiguration() != null) {
+				for (StaticRouteConfiguration staticRoute : lr.getRoutingConfiguration().getStaticRoutes()) {
+					StaticRouteHelper.setStaticRoute(lr, model, staticRoute.getDestination(), staticRoute.getNextHop(), staticRoute.isDiscard());
+				}
+			}
+		}
 	}
 
 	private void createLogicalRouters(IResource vcpe, VCPENetworkModel model) throws ResourceException {

--- a/extensions/bundles/vcpe/src/main/java/org/opennaas/extensions/vcpe/manager/templates/mp/MPTemplateModelBuilder.java
+++ b/extensions/bundles/vcpe/src/main/java/org/opennaas/extensions/vcpe/manager/templates/mp/MPTemplateModelBuilder.java
@@ -13,6 +13,7 @@ import org.opennaas.extensions.vcpe.model.Router;
 import org.opennaas.extensions.vcpe.model.VCPENetworkElement;
 import org.opennaas.extensions.vcpe.model.VCPENetworkModel;
 import org.opennaas.extensions.vcpe.model.helper.VCPENetworkModelHelper;
+import org.opennaas.extensions.vcpe.model.routing.RoutingConfiguration;
 
 public class MPTemplateModelBuilder {
 
@@ -89,6 +90,7 @@ public class MPTemplateModelBuilder {
 		// LogicalRouter 1
 		Router lr1 = new LogicalRouter();
 		lr1.setTemplateName(TemplateConstants.LR_1_ROUTER);
+		lr1.setRoutingConfiguration(new RoutingConfiguration());
 
 		List<Interface> interfaces = new ArrayList<Interface>();
 		lr1.setInterfaces(interfaces);
@@ -103,6 +105,7 @@ public class MPTemplateModelBuilder {
 		// LogicalRouter 2
 		Router lr2 = new LogicalRouter();
 		lr2.setTemplateName(TemplateConstants.LR_2_ROUTER);
+		lr2.setRoutingConfiguration(new RoutingConfiguration());
 
 		interfaces = new ArrayList<Interface>();
 		lr2.setInterfaces(interfaces);
@@ -117,6 +120,7 @@ public class MPTemplateModelBuilder {
 		// Client Logical Router
 		Router lrclient = new LogicalRouter();
 		lrclient.setTemplateName(TemplateConstants.LR_CLIENT_ROUTER);
+		lrclient.setRoutingConfiguration(new RoutingConfiguration());
 
 		interfaces = new ArrayList<Interface>();
 		lrclient.setInterfaces(interfaces);

--- a/extensions/bundles/vcpe/src/main/java/org/opennaas/extensions/vcpe/model/Router.java
+++ b/extensions/bundles/vcpe/src/main/java/org/opennaas/extensions/vcpe/model/Router.java
@@ -7,12 +7,16 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlIDREF;
 import javax.xml.bind.annotation.XmlSeeAlso;
 
+import org.opennaas.extensions.vcpe.model.routing.RoutingConfiguration;
+
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlSeeAlso({ LogicalRouter.class, PhysicalRouter.class })
 public class Router extends VCPENetworkElement {
 
 	@XmlIDREF
-	protected List<Interface>	interfaces;
+	protected List<Interface>		interfaces;
+
+	protected RoutingConfiguration	routingConfiguration;
 
 	public List<Interface> getInterfaces() {
 		return interfaces;
@@ -20,6 +24,14 @@ public class Router extends VCPENetworkElement {
 
 	public void setInterfaces(List<Interface> interfaces) {
 		this.interfaces = interfaces;
+	}
+
+	public RoutingConfiguration getRoutingConfiguration() {
+		return routingConfiguration;
+	}
+
+	public void setRoutingConfiguration(RoutingConfiguration routingConfiguration) {
+		this.routingConfiguration = routingConfiguration;
 	}
 
 	/*
@@ -64,6 +76,12 @@ public class Router extends VCPENetworkElement {
 				return false;
 		} else if (!interfaces.equals(other.interfaces))
 			return false;
+		if (routingConfiguration == null) {
+			if (other.routingConfiguration != null)
+				return false;
+		} else if (!routingConfiguration.equals(other.routingConfiguration))
+			return false;
+
 		return true;
 	}
 

--- a/extensions/bundles/vcpe/src/main/java/org/opennaas/extensions/vcpe/model/routing/RoutingConfiguration.java
+++ b/extensions/bundles/vcpe/src/main/java/org/opennaas/extensions/vcpe/model/routing/RoutingConfiguration.java
@@ -1,0 +1,41 @@
+package org.opennaas.extensions.vcpe.model.routing;
+
+import java.util.List;
+
+public class RoutingConfiguration {
+
+	private List<StaticRouteConfiguration>	staticRoutes;
+
+	public List<StaticRouteConfiguration> getStaticRoutes() {
+		return staticRoutes;
+	}
+
+	public void setStaticRoutes(List<StaticRouteConfiguration> staticRoutes) {
+		this.staticRoutes = staticRoutes;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((staticRoutes == null) ? 0 : staticRoutes.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		RoutingConfiguration other = (RoutingConfiguration) obj;
+		if (staticRoutes == null) {
+			if (other.staticRoutes != null)
+				return false;
+		} else if (!staticRoutes.equals(other.staticRoutes))
+			return false;
+		return true;
+	}
+}

--- a/extensions/bundles/vcpe/src/main/java/org/opennaas/extensions/vcpe/model/routing/StaticRouteConfiguration.java
+++ b/extensions/bundles/vcpe/src/main/java/org/opennaas/extensions/vcpe/model/routing/StaticRouteConfiguration.java
@@ -1,0 +1,75 @@
+package org.opennaas.extensions.vcpe.model.routing;
+
+public class StaticRouteConfiguration {
+
+	private String	destination	= null;
+	private String	nextHop		= null;
+	private boolean	discard		= false;
+
+	public StaticRouteConfiguration() {
+	}
+
+	public StaticRouteConfiguration(String destination, String nextHop, boolean isDiscard) {
+		this.destination = destination;
+		this.nextHop = nextHop;
+		this.discard = isDiscard;
+	}
+
+	public String getDestination() {
+		return destination;
+	}
+
+	public void setDestination(String destination) {
+		this.destination = destination;
+	}
+
+	public String getNextHop() {
+		return nextHop;
+	}
+
+	public void setNextHop(String nextHop) {
+		this.nextHop = nextHop;
+	}
+
+	public boolean isDiscard() {
+		return discard;
+	}
+
+	public void setDiscard(boolean discard) {
+		this.discard = discard;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((destination == null) ? 0 : destination.hashCode());
+		result = prime * result + (discard ? 1231 : 1237);
+		result = prime * result + ((nextHop == null) ? 0 : nextHop.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		StaticRouteConfiguration other = (StaticRouteConfiguration) obj;
+		if (destination == null) {
+			if (other.destination != null)
+				return false;
+		} else if (!destination.equals(other.destination))
+			return false;
+		if (discard != other.discard)
+			return false;
+		if (nextHop == null) {
+			if (other.nextHop != null)
+				return false;
+		} else if (!nextHop.equals(other.nextHop))
+			return false;
+		return true;
+	}
+}

--- a/platform/src/main/filtered-resources/etc/org.opennaas.extensions.vcpe.manager.templates.mp.suggestor.defaults.cfg
+++ b/platform/src/main/filtered-resources/etc/org.opennaas.extensions.vcpe.manager.templates.mp.suggestor.defaults.cfg
@@ -42,7 +42,7 @@ net.wan.2.name = Provider 2 Network
 net.wan.2.asnum = 65534
 
 net.wan.2.ipranges.num = 1
-net.wan.2.ipranges.0 = 192.168.4.2/24
+net.wan.2.ipranges.0 = 192.168.4.0/24
 
 net.wan.2.iface.logical.down.name = eth0
 net.wan.2.iface.logical.down.port = 0
@@ -59,7 +59,7 @@ net.lan.client.name = Client Network
 net.lan.client.asnum = 65533
 
 net.lan.client.ipranges.num = 1
-net.lan.client.ipranges.0 = 192.168.7.2/24
+net.lan.client.ipranges.0 = 192.168.7.0/24
 
 net.lan.client.iface.logical.up.name = eth0
 net.lan.client.iface.logical.up.port = 0
@@ -81,7 +81,7 @@ vcpe.lr.1.iface.logical.up.ipaddress = 192.168.1.3/24
 
 vcpe.lr.1.iface.logical.down.name = lt-1/0/10
 vcpe.lr.1.iface.logical.down.port = 1
-vcpe.lr.1.iface.logical.down.ipaddress = 192.168.1.4/24
+vcpe.lr.1.iface.logical.down.ipaddress = 192.168.1.253/30
 
 vcpe.lr.1.iface.logical.lo.name = lo0
 vcpe.lr.1.iface.logical.lo.port = 1
@@ -98,7 +98,7 @@ vcpe.lr.2.iface.logical.up.ipaddress = 192.168.4.3/24
 
 vcpe.lr.2.iface.logical.down.name = lt-1/0/10
 vcpe.lr.2.iface.logical.down.port = 2
-vcpe.lr.2.iface.logical.down.ipaddress = 192.168.4.4/24
+vcpe.lr.2.iface.logical.down.ipaddress = 192.168.4.253/30
 
 vcpe.lr.2.iface.logical.lo.name = lo0
 vcpe.lr.2.iface.logical.lo.port = 2
@@ -110,11 +110,11 @@ vcpe.lr.client.name = LRclient
 
 vcpe.lr.client.iface.logical.up1.name = lt-1/0/10
 vcpe.lr.client.iface.logical.up1.port = 3
-vcpe.lr.client.iface.logical.up1.ipaddress = 192.168.7.4/24
+vcpe.lr.client.iface.logical.up1.ipaddress = 192.168.1.254/30
 
 vcpe.lr.client.iface.logical.up2.name = lt-1/0/10
 vcpe.lr.client.iface.logical.up2.port = 4
-vcpe.lr.client.iface.logical.up2.ipaddress = 192.168.7.5/24
+vcpe.lr.client.iface.logical.up2.ipaddress = 192.168.4.254/30
 
 vcpe.lr.client.iface.logical.down.name = ge-1/1/4
 vcpe.lr.client.iface.logical.down.port = 907


### PR DESCRIPTION
Created RoutingConfiguration in VCPEmodel, which should hold routing configuration in Routers.

MProviderTemplate populates RoutingConfiguration with required static routes, as discussed in http://jira.i2cat.net:8080/browse/OPENNAAS-869.

MP Template builder configures desired static routes calling routers static route capability.

Default IP addresses have been changed, so lt links have a /30 subnet each one, and NetworkDomain IPRanges are correctly specified.

This pull request fixes following issues:
http://jira.i2cat.net:8080/browse/OPENNAAS-867
http://jira.i2cat.net:8080/browse/OPENNAAS-869
