### PR TITLE
Change default addressing in mp-vcpe.

### DIFF
--- a/platform/src/main/filtered-resources/etc/org.opennaas.extensions.vcpe.manager.templates.mp.suggestor.defaults.cfg
+++ b/platform/src/main/filtered-resources/etc/org.opennaas.extensions.vcpe.manager.templates.mp.suggestor.defaults.cfg
@@ -81,11 +81,11 @@ vcpe.lr.1.iface.logical.up.ipaddress = 192.168.1.3/24
 
 vcpe.lr.1.iface.logical.down.name = lt-1/0/10
 vcpe.lr.1.iface.logical.down.port = 1
-vcpe.lr.1.iface.logical.down.ipaddress = 192.168.1.253/30
+vcpe.lr.1.iface.logical.down.ipaddress = 192.168.254.253/30
 
 vcpe.lr.1.iface.logical.lo.name = lo0
 vcpe.lr.1.iface.logical.lo.port = 1
-vcpe.lr.1.iface.logical.lo.ipaddress = 192.168.1.1/24
+vcpe.lr.1.iface.logical.lo.ipaddress = 192.168.254.128/32
 
 ###################################### Logical Router 2 ###################################
 
@@ -98,11 +98,11 @@ vcpe.lr.2.iface.logical.up.ipaddress = 192.168.4.3/24
 
 vcpe.lr.2.iface.logical.down.name = lt-1/0/10
 vcpe.lr.2.iface.logical.down.port = 2
-vcpe.lr.2.iface.logical.down.ipaddress = 192.168.4.253/30
+vcpe.lr.2.iface.logical.down.ipaddress = 192.168.255.253/30
 
 vcpe.lr.2.iface.logical.lo.name = lo0
 vcpe.lr.2.iface.logical.lo.port = 2
-vcpe.lr.2.iface.logical.lo.ipaddress = 192.168.4.1/24
+vcpe.lr.2.iface.logical.lo.ipaddress = 192.168.255.128/32
 
 #################################### Logical Router client ################################
 
@@ -110,18 +110,18 @@ vcpe.lr.client.name = LRclient
 
 vcpe.lr.client.iface.logical.up1.name = lt-1/0/10
 vcpe.lr.client.iface.logical.up1.port = 3
-vcpe.lr.client.iface.logical.up1.ipaddress = 192.168.1.254/30
+vcpe.lr.client.iface.logical.up1.ipaddress = 192.168.254.254/30
 
 vcpe.lr.client.iface.logical.up2.name = lt-1/0/10
 vcpe.lr.client.iface.logical.up2.port = 4
-vcpe.lr.client.iface.logical.up2.ipaddress = 192.168.4.254/30
+vcpe.lr.client.iface.logical.up2.ipaddress = 192.168.255.254/30
 
 vcpe.lr.client.iface.logical.down.name = ge-1/1/4
 vcpe.lr.client.iface.logical.down.port = 907
 vcpe.lr.client.iface.logical.down.vlan = 907
-vcpe.lr.client.iface.logical.down.ipaddress = 192.168.7.3/24
+vcpe.lr.client.iface.logical.down.ipaddress = 192.168.7.1/24
 
 vcpe.lr.client.iface.logical.lo.name = lo0
 vcpe.lr.client.iface.logical.lo.port = 3
-vcpe.lr.client.iface.logical.lo.ipaddress = 192.168.7.1/24
+vcpe.lr.client.iface.logical.lo.ipaddress = 192.168.7.128/32
 


### PR DESCRIPTION
Interfaces connecting LRs between each others should have a different network than the rest. Each lt link should have its own network.
