### PR TITLE
Avoid null poiter exception in isFreeVRRPGroup.

### DIFF
--- a/extensions/bundles/vcpe/src/main/java/org/opennaas/extensions/vcpe/manager/isfree/IsFreeChecker.java
+++ b/extensions/bundles/vcpe/src/main/java/org/opennaas/extensions/vcpe/manager/isfree/IsFreeChecker.java
@@ -294,8 +294,11 @@ public class IsFreeChecker {
 				vcpe = vcpes_it.next();
 				if (!vcpe.getResourceIdentifier().getId().equals(vcpeId)) {
 					if (((VCPENetworkModel) vcpe.getModel()).isCreated()) {
-						if (((VCPENetworkModel) vcpe.getModel()).getVrrp().getGroup().equals(Integer.parseInt(vrrpGroup))) {
-							isFree = false;
+						if (((VCPENetworkModel) vcpe.getModel()).getVrrp() != null &&
+								((VCPENetworkModel) vcpe.getModel()).getVrrp().getGroup() != null) {
+							if (((VCPENetworkModel) vcpe.getModel()).getVrrp().getGroup().equals(Integer.parseInt(vrrpGroup))) {
+								isFree = false;
+							}
 						}
 					}
 				}


### PR DESCRIPTION
MP-vcpes don't have VRRP configuration (it's set to null), so
calling isFreeVRRPGroup when there is a MP-vcpe already created
launches a nullpointer exception.

This patch fixes this by checking vrrp configuration and group is
not null before trying to compare it.
