### PR TITLE
Update IP in model after changing VRRP IP address.

### DIFF
--- a/extensions/bundles/vcpe/src/main/java/org/opennaas/extensions/vcpe/capability/vrrp/VCPEVRRPCapability.java
+++ b/extensions/bundles/vcpe/src/main/java/org/opennaas/extensions/vcpe/capability/vrrp/VCPEVRRPCapability.java
@@ -125,6 +125,15 @@ public class VCPEVRRPCapability extends AbstractCapability implements IVCPEVRRPC
 			GenericHelper.executeQueue(router1);
 			GenericHelper.executeQueue(router2);
 
+			// Update the IP address in the model
+			IResource vcpeResource = GenericHelper.getResourceManager().getResourceById(resourceId);
+			VCPENetworkModel vcpeNetworkModel = (VCPENetworkModel) vcpeResource.getModel();
+			if (vcpeNetworkModel != null) {
+				if (vcpeNetworkModel.getVrrp() != null) {
+					vcpeNetworkModel.getVrrp().setVirtualIPAddress(vcpeModel.getVrrp().getVirtualIPAddress());
+				}
+			}
+
 		} catch (Exception e) {
 			throw new CapabilityException(e);
 		}


### PR DESCRIPTION
Model is now updated after changing VRRP IP address (if changed correctly)
This way, model and router configuration are sync, and the GUI shows currently configured IP address.

Fixes issue:
http://jira.i2cat.net:8080/browse/OPENNAAS-908
