### PR TITLE
Bug solved: ResourceManager throws a ResourceException in

### DIFF
--- a/core/resources/src/main/java/org/opennaas/core/resources/ResourceManager.java
+++ b/core/resources/src/main/java/org/opennaas/core/resources/ResourceManager.java
@@ -302,9 +302,10 @@ public class ResourceManager implements IResourceManager {
 			try {
 				return (Resource) repo.getResource(resourceId);
 			} catch (ResourceException e) {
+				// ignore, try next repository
 			}
 		}
-		return null;
+		throw new ResourceException("No resource with ID " + resourceId + " was found.");
 	}
 
 	@Override


### PR DESCRIPTION
getResourceById() method when a resource is not found (instead of
returning null)
