### PR TITLE
Transform Globals singleton into VNTMapperConfiguration.

### DIFF
--- a/extensions/bundles/vnmapper/src/main/java/org/opennaas/extensions/vnmapper/VNTMapper.java
+++ b/extensions/bundles/vnmapper/src/main/java/org/opennaas/extensions/vnmapper/VNTMapper.java
@@ -19,7 +19,9 @@ import org.apache.commons.logging.LogFactory;
 // /// the next class is resposible for matching and mapping///
 public class VNTMapper {
 
-	Log	log	= LogFactory.getLog(VNTMapper.class);
+	Log								log	= LogFactory.getLog(VNTMapper.class);
+
+	private VNTMapperConfiguration	configuration;
 
 	// // the next method sorts the virtual nodes based on nodes degrees
 	public ArrayList<Integer> vNodesSorting(VNTRequest v)
@@ -121,11 +123,11 @@ public class VNTMapper {
 
 		}
 
-		if (Global.getInstance().getPathChoice() == 1) // // shortest path
-			p = net.findPathBetweemTwoNodes(v1RealNode, v2RealNode, requiredB, requiredD, Global.getInstance().getMaxPathLinksNum());
+		if (getConfiguration().getPathChoice() == 1) // // shortest path
+			p = net.findPathBetweemTwoNodes(v1RealNode, v2RealNode, requiredB, requiredD, getConfiguration().getMaxPathLinksNum());
 		else
 			// / load balancing
-			p = net.findPathBetweemTwoNodes2(v1RealNode, v2RealNode, requiredB, requiredD, Global.getInstance().getMaxPathLinksNum());
+			p = net.findPathBetweemTwoNodes2(v1RealNode, v2RealNode, requiredB, requiredD, getConfiguration().getMaxPathLinksNum());
 		return p;
 	}
 
@@ -183,7 +185,7 @@ public class VNTMapper {
 			IntSet mappedVNTNodes = new IntSet();
 
 			// // call the method that is resposible for the recursive backtracking job of composing the VNT
-			Global.getInstance().setStepsNum(0);
+			getConfiguration().setStepsNum(0);
 			res = VNTMappingFunc(v, net, selectedRealNodes, VNTNodeMappingArray, VNTLinkMappingArray, sortedVNodesSet, mappedVNTNodes);
 
 			// // calculating the mapping result and cost of it //
@@ -314,18 +316,18 @@ public class VNTMapper {
 			Path resultedPath = new Path();
 
 			// // sort the possible candidate physical nodes
-			if (Global.getInstance().getpNodeChoice() == 1) { // / cost reduction
+			if (getConfiguration().getpNodeChoice() == 1) { // / cost reduction
 				ArrayList<Integer> node = sortRealNode1(v, net, currentVNodeId,
 						VNTNodeMappingArray.get(currentVNodeId).getPossibleRealNodes(), selectedRealNodes);
 				VNTNodeMappingArray.get(currentVNodeId).setPossibleRealNodes(node);
 			}
-			if (Global.getInstance().getpNodeChoice() == 2) { // / load balancing
+			if (getConfiguration().getpNodeChoice() == 2) { // / load balancing
 				ArrayList<Integer> node = sortRealNode2(v, net, currentVNodeId,
 						VNTNodeMappingArray.get(currentVNodeId).getPossibleRealNodes(), selectedRealNodes);
 				VNTNodeMappingArray.get(currentVNodeId).setPossibleRealNodes(node);
 			}
-			for (int i = 0; i < VNTNodeMappingArray.get(currentVNodeId).getPossibleRealNodes().size() && (mappingFinish == 0) && (Global
-					.getInstance().getStepsNum() <= Global.getInstance().getStepsMax()); i++)
+			for (int i = 0; i < VNTNodeMappingArray.get(currentVNodeId).getPossibleRealNodes().size() && (mappingFinish == 0) &&
+					(getConfiguration().getStepsNum() <= getConfiguration().getStepsMax()); i++)
 			{
 				// / get next candidate pnode
 				currentRealNode = Integer.valueOf(VNTNodeMappingArray.get(currentVNodeId).getPossibleRealNodes().get(i).toString());
@@ -427,8 +429,9 @@ public class VNTMapper {
 							}
 						}
 
-						if ((mappingFinish == 0) && (Global.getInstance().getStepsNum() < Global.getInstance().getStepsMax())) // / need to continue
-																																	// mapping
+						if ((mappingFinish == 0) && (getConfiguration().getStepsNum() < getConfiguration()
+								.getStepsMax())) // / need to continue
+						// mapping
 						{
 							// / recursive call
 							mappingFinish = VNTMappingFunc(v, net, selectedRealNodes, VNTNodeMappingArray, VNTLinkMappingArray, sortedVNodesSet,
@@ -437,8 +440,8 @@ public class VNTMapper {
 								// / remove the selected pnode
 								VNTNodeMappingArray.get(currentVNodeId).setChosenRealNode(-1);
 								selectedRealNodes.remove(currentRealNode);
-								Global.getInstance().increaseStepsNum(1);
-								// System.out.println("steps = "+Global.stepsNum);
+								getConfiguration().increaseStepsNum(1);
+								// System.out.println("steps = "+VNTMapperConfiguration.stepsNum);
 								for (int u = 0; u < v.getVnodeNum(); u++)
 								{
 									if ((u < currentVNodeId) && (v.getConnections().get(u).get(currentVNodeId).getId() != -1))
@@ -737,6 +740,14 @@ public class VNTMapper {
 		}
 
 		return nets;
+	}
+
+	public VNTMapperConfiguration getConfiguration() {
+		return configuration;
+	}
+
+	public void setConfiguration(VNTMapperConfiguration config) {
+		this.configuration = config;
 	}
 
 }

--- a/extensions/bundles/vnmapper/src/main/java/org/opennaas/extensions/vnmapper/VNTMapperConfiguration.java
+++ b/extensions/bundles/vnmapper/src/main/java/org/opennaas/extensions/vnmapper/VNTMapperConfiguration.java
@@ -1,39 +1,30 @@
 package org.opennaas.extensions.vnmapper;
 
-public class Global {
+public class VNTMapperConfiguration {
 
-	private static Global	instance;
-
-	private int				rowNum;
-	private int				cellNum;
-	private int				servNumMin;
-	private int				servNumMax;
-	private int				vEnvMax;
-	private int				vTypeMax;
-	private int				minDay;
-	private int				maxDay;
-	private int				pNodeChoice;
-	private int				pathChoice;		// // SPF: pathChoice=1 / LB: pathChoice=2
-	private int				maxPathLinksNum;
-	private int				staticNet;
-	private int				staticVNT;
+	private int	rowNum;
+	private int	cellNum;
+	private int	servNumMin;
+	private int	servNumMax;
+	private int	vEnvMax;
+	private int	vTypeMax;
+	private int	minDay;
+	private int	maxDay;
+	private int	pNodeChoice;
+	private int	pathChoice;		// // SPF: pathChoice=1 / LB: pathChoice=2
+	private int	maxPathLinksNum;
+	private int	staticNet;
+	private int	staticVNT;
 
 	// /
-	private int				stepsNum;
-	private int				stepsMax;
+	private int	stepsNum;
+	private int	stepsMax;
 
-	private Global() {
+	public VNTMapperConfiguration() {
 		stepsNum = 0;
 		stepsMax = 500;
 		staticVNT = 0;
 		staticNet = 0;
-	}
-
-	public static Global getInstance() {
-		if (instance == null)
-			instance = new Global();
-
-		return instance;
 	}
 
 	public int getRowNum() {

--- a/extensions/bundles/vnmapper/src/main/java/org/opennaas/extensions/vnmapper/capability/vnmapping/VNMappingCapability.java
+++ b/extensions/bundles/vnmapper/src/main/java/org/opennaas/extensions/vnmapper/capability/vnmapping/VNMappingCapability.java
@@ -21,7 +21,6 @@ import org.opennaas.extensions.network.model.NetworkModelHelper;
 import org.opennaas.extensions.network.model.topology.Device;
 import org.opennaas.extensions.network.model.topology.Link;
 import org.opennaas.extensions.queuemanager.IQueueManagerCapability;
-import org.opennaas.extensions.vnmapper.Global;
 import org.opennaas.extensions.vnmapper.InPNetwork;
 import org.opennaas.extensions.vnmapper.MappingResult;
 import org.opennaas.extensions.vnmapper.ObjectCopier;
@@ -29,6 +28,7 @@ import org.opennaas.extensions.vnmapper.PLink;
 import org.opennaas.extensions.vnmapper.PNode;
 import org.opennaas.extensions.vnmapper.VNState;
 import org.opennaas.extensions.vnmapper.VNTMapper;
+import org.opennaas.extensions.vnmapper.VNTMapperConfiguration;
 import org.opennaas.extensions.vnmapper.VNTRequest;
 
 /**
@@ -92,14 +92,8 @@ public class VNMappingCapability extends AbstractCapability implements IVNMappin
 
 		try {
 			// //// run the matching and mapping/////
-			// Global.rowNum=8;
-			// Global.cellNum=8;
-			Global.getInstance().setpNodeChoice(1);
-			Global.getInstance().setPathChoice(1);
-			Global.getInstance().setMaxPathLinksNum(5);
-			// Global.staticNet=1;
-			// Global.staticVNT=1;
-			Global.getInstance().setStepsMax(100);
+			VNTMapperConfiguration vNTMapperConfiguration = prepareVNTMapperConfiguration();
+
 			// //
 			// InPNetwork net=new InPNetwork();
 			// net=net.readPNetworkFromXMLFile("src\\marketplace\\network.xml");
@@ -108,7 +102,7 @@ public class VNMappingCapability extends AbstractCapability implements IVNMappin
 			InPNetwork net = getInPNetwork();
 			VNMapperInput input = new VNMapperInput(net, request);
 
-			MappingResult result = executeAlgorithm(request, net);
+			MappingResult result = executeAlgorithm(vNTMapperConfiguration, request, net);
 
 			return new VNMapperOutput(result, input);
 		} catch (IOException io) {
@@ -116,6 +110,20 @@ public class VNMappingCapability extends AbstractCapability implements IVNMappin
 			throw new CapabilityException(io);
 		}
 
+	}
+
+	private VNTMapperConfiguration prepareVNTMapperConfiguration() {
+		VNTMapperConfiguration vNTMapperConfiguration = new VNTMapperConfiguration();
+		// VNTMapperConfiguration.rowNum=8;
+		// VNTMapperConfiguration.cellNum=8;
+		vNTMapperConfiguration.setpNodeChoice(1);
+		vNTMapperConfiguration.setPathChoice(1);
+		vNTMapperConfiguration.setMaxPathLinksNum(5);
+		// VNTMapperConfiguration.staticNet=1;
+		// VNTMapperConfiguration.staticVNT=1;
+		vNTMapperConfiguration.setStepsMax(100);
+
+		return vNTMapperConfiguration;
 	}
 
 	public InPNetwork getInPNetwork() throws CapabilityException {
@@ -212,9 +220,16 @@ public class VNMappingCapability extends AbstractCapability implements IVNMappin
 		return net;
 	}
 
-	public MappingResult executeAlgorithm(VNTRequest request, InPNetwork net) throws IOException {
+	public MappingResult executeAlgorithm(VNTMapperConfiguration config, VNTRequest request, InPNetwork net) throws IOException {
 
 		VNTMapper mapper = new VNTMapper();
+		if (config != null) {
+			mapper.setConfiguration(config);
+		} else {
+			// set configuration with default values
+			mapper.setConfiguration(new VNTMapperConfiguration());
+		}
+
 		MappingResult mres = new MappingResult();
 		ArrayList<ArrayList<Integer>> matchingResult = new ArrayList<ArrayList<Integer>>();
 		int matchingRes = mapper.matchVirtualNetwork(request, net, matchingResult);
@@ -242,4 +257,5 @@ public class VNMappingCapability extends AbstractCapability implements IVNMappin
 		return mres;
 
 	}
+
 }

--- a/extensions/bundles/vnmapper/src/test/java/org/opennaas/extensions/vnmapper/test/VNMapperTest.java
+++ b/extensions/bundles/vnmapper/src/test/java/org/opennaas/extensions/vnmapper/test/VNMapperTest.java
@@ -21,13 +21,13 @@ import org.opennaas.core.resources.descriptor.Information;
 import org.opennaas.core.resources.descriptor.ResourceDescriptor;
 import org.opennaas.core.resources.descriptor.network.NetworkTopology;
 import org.opennaas.extensions.network.repository.NetworkMapperDescriptorToModel;
-import org.opennaas.extensions.vnmapper.Global;
 import org.opennaas.extensions.vnmapper.InPNetwork;
 import org.opennaas.extensions.vnmapper.MappingResult;
 import org.opennaas.extensions.vnmapper.PLink;
 import org.opennaas.extensions.vnmapper.PNode;
 import org.opennaas.extensions.vnmapper.VLink;
 import org.opennaas.extensions.vnmapper.VNState;
+import org.opennaas.extensions.vnmapper.VNTMapperConfiguration;
 import org.opennaas.extensions.vnmapper.VNTRequest;
 import org.opennaas.extensions.vnmapper.VNode;
 import org.opennaas.extensions.vnmapper.capability.vnmapping.VNMapperInput;
@@ -37,20 +37,21 @@ import org.xml.sax.SAXException;
 
 public class VNMapperTest {
 
-	private final static String	TOPOLOGY_FILE	= "topology.xml";
-	private final static String	REQUEST_FILE	= "request.xml";
-	private final static String	RESULT_FILE		= "output.karaf";
+	private final static String		TOPOLOGY_FILE	= "topology.xml";
+	private final static String		REQUEST_FILE	= "request.xml";
+	private final static String		RESULT_FILE		= "output.karaf";
 
-	private final static String	SAMPLE_1_URL	= "/samples/sample1/";
-	private final static String	SAMPLE_2_URL	= "/samples/sample2/";
-	private final static String	SAMPLE_3_URL	= "/samples/sample3/";
-	private final static String	SAMPLE_4_URL	= "/samples/sample4/";
-	private final static String	SAMPLE_5_URL	= "/samples/sample5/";
-	private final static String	SAMPLE_6_URL	= "/samples/sample6/";
-	private final static String	SAMPLE_7_URL	= "/samples/sample7/";
-	private final static String	SAMPLE_8_URL	= "/samples/sample8/";
+	private final static String		SAMPLE_1_URL	= "/samples/sample1/";
+	private final static String		SAMPLE_2_URL	= "/samples/sample2/";
+	private final static String		SAMPLE_3_URL	= "/samples/sample3/";
+	private final static String		SAMPLE_4_URL	= "/samples/sample4/";
+	private final static String		SAMPLE_5_URL	= "/samples/sample5/";
+	private final static String		SAMPLE_6_URL	= "/samples/sample6/";
+	private final static String		SAMPLE_7_URL	= "/samples/sample7/";
+	private final static String		SAMPLE_8_URL	= "/samples/sample8/";
 
-	private VNMappingCapability	capab;
+	private VNMappingCapability		capab;
+	private VNTMapperConfiguration	vNTMapperConfiguration;
 
 	class TestInput {
 		InPNetwork	net;
@@ -70,10 +71,11 @@ public class VNMapperTest {
 		descriptor.setCapabilityInformation(capabilityInformation);
 		capab = new VNMappingCapability(descriptor, resourceId);
 
-		Global.getInstance().setpNodeChoice(1);
-		Global.getInstance().setPathChoice(1);
-		Global.getInstance().setMaxPathLinksNum(5);
-		Global.getInstance().setStepsMax(100);
+		vNTMapperConfiguration = new VNTMapperConfiguration();
+		vNTMapperConfiguration.setpNodeChoice(1);
+		vNTMapperConfiguration.setPathChoice(1);
+		vNTMapperConfiguration.setMaxPathLinksNum(5);
+		vNTMapperConfiguration.setStepsMax(100);
 	}
 
 	@Test
@@ -81,7 +83,7 @@ public class VNMapperTest {
 
 		TestInput testInput = loadTestInput(SAMPLE_1_URL);
 
-		MappingResult result = capab.executeAlgorithm(testInput.vnt, testInput.net);
+		MappingResult result = capab.executeAlgorithm(vNTMapperConfiguration, testInput.vnt, testInput.net);
 
 		VNMapperInput input = new VNMapperInput(testInput.net, testInput.vnt);
 		VNMapperOutput output = new VNMapperOutput(result, input);
@@ -95,7 +97,7 @@ public class VNMapperTest {
 
 		TestInput testInput = loadTestInput(SAMPLE_2_URL);
 
-		MappingResult result = capab.executeAlgorithm(testInput.vnt, testInput.net);
+		MappingResult result = capab.executeAlgorithm(vNTMapperConfiguration, testInput.vnt, testInput.net);
 
 		VNMapperInput input = new VNMapperInput(testInput.net, testInput.vnt);
 		VNMapperOutput output = new VNMapperOutput(result, input);
@@ -109,7 +111,7 @@ public class VNMapperTest {
 
 		TestInput testInput = loadTestInput(SAMPLE_3_URL);
 
-		MappingResult result = capab.executeAlgorithm(testInput.vnt, testInput.net);
+		MappingResult result = capab.executeAlgorithm(vNTMapperConfiguration, testInput.vnt, testInput.net);
 
 		VNMapperInput input = new VNMapperInput(testInput.net, testInput.vnt);
 		VNMapperOutput output = new VNMapperOutput(result, input);
@@ -123,7 +125,7 @@ public class VNMapperTest {
 
 		TestInput testInput = loadTestInput(SAMPLE_4_URL);
 
-		MappingResult result = capab.executeAlgorithm(testInput.vnt, testInput.net);
+		MappingResult result = capab.executeAlgorithm(vNTMapperConfiguration, testInput.vnt, testInput.net);
 
 		VNMapperInput input = new VNMapperInput(testInput.net, testInput.vnt);
 		VNMapperOutput output = new VNMapperOutput(result, input);
@@ -137,7 +139,7 @@ public class VNMapperTest {
 
 		TestInput testInput = loadTestInput(SAMPLE_5_URL);
 
-		MappingResult result = capab.executeAlgorithm(testInput.vnt, testInput.net);
+		MappingResult result = capab.executeAlgorithm(vNTMapperConfiguration, testInput.vnt, testInput.net);
 
 		VNMapperInput input = new VNMapperInput(testInput.net, testInput.vnt);
 		VNMapperOutput output = new VNMapperOutput(result, input);
@@ -151,7 +153,7 @@ public class VNMapperTest {
 
 		TestInput testInput = loadTestInput(SAMPLE_6_URL);
 
-		MappingResult result = capab.executeAlgorithm(testInput.vnt, testInput.net);
+		MappingResult result = capab.executeAlgorithm(vNTMapperConfiguration, testInput.vnt, testInput.net);
 
 		VNMapperInput input = new VNMapperInput(testInput.net, testInput.vnt);
 		VNMapperOutput output = new VNMapperOutput(result, input);
@@ -194,7 +196,7 @@ public class VNMapperTest {
 		testInput.net.getConnections().get(2).get(4).setCapacity(500);
 		testInput.net.getConnections().get(3).get(4).setCapacity(600);
 
-		MappingResult result = capab.executeAlgorithm(testInput.vnt, testInput.net);
+		MappingResult result = capab.executeAlgorithm(vNTMapperConfiguration, testInput.vnt, testInput.net);
 
 		VNMapperInput input = new VNMapperInput(testInput.net, testInput.vnt);
 		VNMapperOutput output = new VNMapperOutput(result, input);
@@ -235,7 +237,7 @@ public class VNMapperTest {
 			link.setCapacity(600);
 		}
 
-		MappingResult result = capab.executeAlgorithm(testInput.vnt, testInput.net);
+		MappingResult result = capab.executeAlgorithm(vNTMapperConfiguration, testInput.vnt, testInput.net);
 
 		VNMapperInput input = new VNMapperInput(testInput.net, testInput.vnt);
 		VNMapperOutput output = new VNMapperOutput(result, input);
@@ -277,7 +279,7 @@ public class VNMapperTest {
 			}
 		}
 
-		MappingResult result = capab.executeAlgorithm(request1, net);
+		MappingResult result = capab.executeAlgorithm(vNTMapperConfiguration, request1, net);
 
 		Assert.assertEquals(VNState.SUCCESSFUL, result.getMatchingState());
 		Assert.assertEquals(VNState.ERROR, result.getMappingState());
@@ -299,7 +301,7 @@ public class VNMapperTest {
 
 		testInput.vnt.getVnodes().get(randomIndex).setCapacity(maxPNodeCapacity + 1);
 
-		MappingResult result = capab.executeAlgorithm(testInput.vnt, testInput.net);
+		MappingResult result = capab.executeAlgorithm(vNTMapperConfiguration, testInput.vnt, testInput.net);
 
 		Assert.assertEquals(VNState.ERROR, result.getMatchingState());
 		Assert.assertEquals(VNState.SKIPPED, result.getMappingState());
@@ -321,7 +323,7 @@ public class VNMapperTest {
 
 		testInput.vnt.getVlinks().get(randomIndex).setCapacity(maxPLinkCapacity + 10);
 
-		MappingResult result = capab.executeAlgorithm(testInput.vnt, testInput.net);
+		MappingResult result = capab.executeAlgorithm(vNTMapperConfiguration, testInput.vnt, testInput.net);
 
 		Assert.assertEquals(VNState.SUCCESSFUL, result.getMatchingState());
 		Assert.assertEquals(VNState.ERROR, result.getMappingState());


### PR DESCRIPTION
A new VNTMapperConfiguration is created each time mapVN method is called in the VNMappingCapability.
executeAlgorithm method in VNMappingCapability now requires an exra param of type VNTMapperConfiguration.
During this method, this configuration is set into VNTMapper before executing the algorithm itself.
The algorithm now takes the parameters by calling getConfiguration() method in VNTMapper.

This way, different instances of VNTMappingCapability do no longer share same configuration instance,
and each VNTMapper instance is customizable by passing a different configuration.

Related with task OPENNAAS-899
