### PR TITLE
Make Spring Security SecurityContext available to the application.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -10,7 +10,6 @@
 	<name>OpenNaaS :: Core</name>
 	<artifactId>org.opennaas.core</artifactId>
 	<modules>
-		<module>security</module>
 		<module>features</module>
 		<module>karafbranding</module>
 		<module>persistence</module>
@@ -18,6 +17,7 @@
 		<module>resources</module>
 		<!-- Bundles past this point do depend on the resources bundle -->
 		<!--<module>org.opennaas.core.resourcemanager-soapendpoint</module>-->
+		<module>security</module>
 		<module>tests-mockprofile</module>
 	</modules>
 	<build>

--- a/core/security/pom.xml
+++ b/core/security/pom.xml
@@ -12,10 +12,12 @@
 	<description>OpenNaaS Core Security </description>
 	<packaging>bundle</packaging>
 	<dependencies>
+		<!-- Servlet API -->
 		<dependency>
-			<groupId>org.opennaas</groupId>
-			<artifactId>org.opennaas.core.resources</artifactId>
+			<groupId>javax.servlet</groupId>
+			<artifactId>servlet-api</artifactId>
 		</dependency>
+		<!-- Spring security -->
 		<dependency>
 			<groupId>org.springframework.security</groupId>
 			<artifactId>spring-security-core</artifactId>
@@ -47,11 +49,11 @@
 			<groupId>org.osgi</groupId>
 			<artifactId>org.osgi.core</artifactId>
 		</dependency>
-		<!-- Servlet API -->
-		 <dependency>
-        	<groupId>javax.servlet</groupId>
-        	<artifactId>servlet-api</artifactId>
-    	</dependency>
+		<!-- OpenNaaS bundles -->
+		<dependency>
+			<groupId>org.opennaas</groupId>
+			<artifactId>org.opennaas.core.resources</artifactId>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/core/security/src/main/java/org/opennaas/core/security/filters/SecurityContextPersistenceFilterSkipClearContext.java
+++ b/core/security/src/main/java/org/opennaas/core/security/filters/SecurityContextPersistenceFilterSkipClearContext.java
@@ -1,0 +1,103 @@
+package org.opennaas.core.security.filters;
+
+import java.io.IOException;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.context.HttpRequestResponseHolder;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
+import org.springframework.security.web.context.SecurityContextRepository;
+import org.springframework.web.filter.GenericFilterBean;
+
+/**
+ * A modification of org.springframework.security.web.context.SecurityContextPersistenceFilter that allows for not clearing the SecurityContext once
+ * the request has completed.
+ * 
+ * This filter uses same identifier than SecurityContextPersistenceFilter to ensure only one of them is applied once per request.
+ * 
+ * This code is based on org.springframework.security.web.context.SecurityContextPersistenceFilter in spring-security-web-3.0.8.RELEASE.
+ * 
+ * @author Isart Canyameres Gimenez (i2cat Foundation)
+ * 
+ */
+public class SecurityContextPersistenceFilterSkipClearContext extends GenericFilterBean {
+
+	static final String					FILTER_APPLIED				= "__spring_security_scpf_applied";
+
+	private SecurityContextRepository	repo						= new HttpSessionSecurityContextRepository();
+
+	private boolean						forceEagerSessionCreation	= false;
+
+	private boolean						skipClearContext			= false;
+
+	public void doFilter(ServletRequest req, ServletResponse res, FilterChain chain)
+			throws IOException, ServletException {
+		HttpServletRequest request = (HttpServletRequest) req;
+		HttpServletResponse response = (HttpServletResponse) res;
+
+		if (request.getAttribute(FILTER_APPLIED) != null) {
+			// ensure that filter is only applied once per request
+			chain.doFilter(request, response);
+			return;
+		}
+
+		final boolean debug = logger.isDebugEnabled();
+
+		request.setAttribute(FILTER_APPLIED, Boolean.TRUE);
+
+		if (forceEagerSessionCreation) {
+			HttpSession session = request.getSession();
+
+			if (debug && session.isNew()) {
+				logger.debug("Eagerly created session: " + session.getId());
+			}
+		}
+
+		HttpRequestResponseHolder holder = new HttpRequestResponseHolder(request, response);
+		SecurityContext contextBeforeChainExecution = repo.loadContext(holder);
+
+		try {
+			SecurityContextHolder.setContext(contextBeforeChainExecution);
+
+			chain.doFilter(holder.getRequest(), holder.getResponse());
+
+		} finally {
+			SecurityContext contextAfterChainExecution = SecurityContextHolder.getContext();
+			if (!skipClearContext) {
+				// Crucial removal of SecurityContextHolder contents - do this before anything else.
+				SecurityContextHolder.clearContext();
+			}
+			repo.saveContext(contextAfterChainExecution, holder.getRequest(), holder.getResponse());
+			request.removeAttribute(FILTER_APPLIED);
+
+			if (debug) {
+				logger.debug("SecurityContextHolder now cleared, as request processing completed");
+			}
+		}
+	}
+
+	public void setSecurityContextRepository(SecurityContextRepository repo) {
+		this.repo = repo;
+	}
+
+	public void setForceEagerSessionCreation(boolean forceEagerSessionCreation) {
+		this.forceEagerSessionCreation = forceEagerSessionCreation;
+	}
+
+	/**
+	 * Tells whether clearing of SecurityContext after the request has completed should be skipped or not. Defaults to false.
+	 * 
+	 * @param skipClearContext
+	 */
+	public void setSkipClearContext(boolean skipClearContext) {
+		this.skipClearContext = skipClearContext;
+	}
+}

--- a/core/security/src/main/resources/META-INF/spring/security-context.xml
+++ b/core/security/src/main/resources/META-INF/spring/security-context.xml
@@ -16,7 +16,7 @@
 	<bean id="mySecurityFilterChain" class="org.springframework.security.web.FilterChainProxy">
 		<security:filter-chain-map path-type="ant">
 			<security:filter-chain pattern="/**"
-				filters="securityContextPersistenceFilterWithASCFalse,
+				filters="securityContextPersistenceFilterWithASCFalseSkippingClearContext,
 				basicAuthenticationFilter,
 				exceptionTranslationFilter,
 				filterSecurityInterceptor" />
@@ -36,14 +36,15 @@
 	</osgi:service>
 
 	<!-- Define filter beans -->
-	<bean id="securityContextPersistenceFilterWithASCFalse"
-		class="org.springframework.security.web.context.SecurityContextPersistenceFilter">
-		<property name='securityContextRepository'>
-			<bean
-				class='org.springframework.security.web.context.HttpSessionSecurityContextRepository'>
-				<property name='allowSessionCreation' value='false' />
-			</bean>
-		</property>
+	<bean id="securityContextPersistenceFilterWithASCFalseSkippingClearContext"
+		class="org.opennaas.core.security.filters.SecurityContextPersistenceFilterSkipClearContext">
+		<property name="securityContextRepository" ref="httpSessionSecurityContextRepositoryWithASCFalse"/>
+		<property name="skipClearContext" value="true" />
+	</bean>
+	
+	<bean id="httpSessionSecurityContextRepositoryWithASCFalse"
+		class='org.springframework.security.web.context.HttpSessionSecurityContextRepository'>
+		<property name="allowSessionCreation" value="false" />
 	</bean>
 
 	<bean id="basicAuthenticationFilter"
@@ -70,7 +71,7 @@
 				<!-- Require ROLE_USER in all other methods -->
 				<!-- TODO secure WS endpoints dinamically, with roles!! -->
 				<security:intercept-url pattern="/**"
-					access="ROLE_ADMIN, ROLE_NOC, ROLE_USER" />
+					access="ROLE_USER" />
 			</security:filter-security-metadata-source>
 		</property>
 	</bean>


### PR DESCRIPTION
The filter chain now registered doesn't clear SecurityContext to make it available to CXF and to the following service invocation.

The problem we faced comes from DOSGi not linking registered filter chain with CXF request processing, as explained here:
https://issues.apache.org/jira/browse/DOSGI-183
Instead, filter chain is executed before CXF request processing, which normally cleares the context, thus preventing it being accessible when method invocation is triggered.

To solve this issue, a customised version of org.springframework.security.web.context.SecurityContextPersistenceFilter is used (SecurityContextPersistenceFilterSkipClearContext) which lets the user specify if context clearing should be skipped.
Using it with "skipClearContext" property set to true ensures that SecurityContext will be available in our environment, while DOSGI-183 is not fixed. 
Security issues may rise due to not removing the context (i.e. credentials disclosure to other callers of same thread).

Dependencies order has been changed to force Servlet API version 2.5 is resolved in compilation.

This patch also changes required roles in url filters.
The only role required to call all web services is now ROLE_USER.
