### PR TITLE
Keep karaf features repo 2.2.2-fuse version.

### DIFF
--- a/core/features/src/main/resources/features.xml
+++ b/core/features/src/main/resources/features.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features>
 	<repository>mvn:org.apache.karaf.assemblies.features/standard/2.2.6/xml/features</repository>
-	<!--
-		<repository>mvn:org.apache.karaf.assemblies.features/standard/${karaf.version}/xml/features</repository>
-	-->
+	<repository>mvn:org.apache.karaf.assemblies.features/standard/${karaf.version}/xml/features</repository>
 	<repository>mvn:org.apache.servicemix.nmr/apache-servicemix-nmr/${nmr.version}/xml/features</repository>
 	<repository>mvn:org.apache.camel.karaf/apache-camel/${camel.version}/xml/features</repository>
 

--- a/platform/pom.xml
+++ b/platform/pom.xml
@@ -223,9 +223,7 @@
 							<karafVersion>${karaf.version}</karafVersion>
 							<descriptors>
 								<descriptor>mvn:org.apache.karaf.assemblies.features/standard/2.2.6/xml/features</descriptor>
-								<!--
-									<descriptor>mvn:org.apache.karaf.assemblies.features/standard/${karaf.version}/xml/features</descriptor>
-								-->
+								<descriptor>mvn:org.apache.karaf.assemblies.features/standard/${karaf.version}/xml/features</descriptor>
 								<descriptor>mvn:org.apache.servicemix.nmr/apache-servicemix-nmr/${nmr.version}/xml/features</descriptor>
 								<descriptor>mvn:org.apache.camel.karaf/apache-camel/${camel.version}/xml/features</descriptor>
 								<descriptor>mvn:org.opennaas/org.opennaas.core.features/${project.version}/xml/features</descriptor>


### PR DESCRIPTION
It coexists with newer karaf 2.2.6 features.
