### PR TITLE
Feature/action returns

### DIFF
--- a/core/resources/src/main/java/org/opennaas/core/resources/action/ActionResponse.java
+++ b/core/resources/src/main/java/org/opennaas/core/resources/action/ActionResponse.java
@@ -15,6 +15,7 @@ public class ActionResponse {
 	private String			actionID;
 	private String			information;
 	private List<Response>	responses	= new ArrayList<Response>();
+	private Object result;
 
 	public String getActionID() {
 		return actionID;
@@ -50,6 +51,18 @@ public class ActionResponse {
 
 	public void setStatus(STATUS status) {
 		this.status = status;
+	}
+
+	/**
+	 * 
+	 * @return the result of the action. It should be null when getStatus() is not OK. It may be null even when getStatus() is OK. 
+	 */
+	public Object getResult() {
+		return result;
+	}
+
+	public void setResult(Object result) {
+		this.result = result;
 	}
 
 	public static ActionResponse newPendingAction(String actionID) {


### PR DESCRIPTION
 Allow Actions to return results

Adds an Object result field to ActionResponse, so Actions can store
a result there.
The field is intended to hold the result of the execution
when execution has finished successfully, and should be null otherwise.
Even when an action has been executed successfully, its result may be null.
