### PR TITLE
DOSGi version upgraded to 1.5.0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
 		<commons.net.version>1.4.1_3</commons.net.version>
 		<commons.pool.version>1.5.4</commons.pool.version>
 		<cxf.version>2.4.3-fuse-01-02</cxf.version>
-		<cxf.dosgi.version>1.4.0</cxf.dosgi.version>
+		<cxf.dosgi.version>1.5.0</cxf.dosgi.version>
 		<easymock.version>3.1</easymock.version>
 		<felix.gogo.version>0.10.0</felix.gogo.version>
 		<geronimo.jaxws.version>1.0</geronimo.jaxws.version>


### PR DESCRIPTION
 It solves ConcurrentModificationException's issue (http://jira.i2cat.net/browse/OPENNAAS-1004) executing OpenNaaS.
