### PR TITLE
Feature/of switch driver floodlight

### DIFF
--- a/extensions/bundles/openflowswitch.driver.floodlight/pom.xml
+++ b/extensions/bundles/openflowswitch.driver.floodlight/pom.xml
@@ -10,6 +10,12 @@
   	<packaging>bundle</packaging>
 	<name>OpenNaaS :: OpenFlow Switch :: Floodlight driver v0.90 </name>
 	<description>OpenFlow Switch driver using Floodlight v0.90</description>
+	<properties>
+	<!-- Jackson (old version of Jackson, instead of 2.x, due to bug integrating with CXF DOSGi
+			http://cxf.547215.n5.nabble.com/Using-Jackson-as-JSON-body-reader-writer-with-DOSGi-td5729257.html)-->
+		<jackson.version>1.9.12</jackson.version>
+		<jsonassert.version>1.2.0</jsonassert.version>
+	</properties>
 
  	<dependencies>
 		<dependency>
@@ -33,6 +39,29 @@
 		<dependency>
 			<groupId>org.apache.servicemix.specs</groupId>
 			<artifactId>org.apache.servicemix.specs.jsr311-api-1.1</artifactId>
+		</dependency>
+		<!-- Jackson (old version of Jackson, instead of 2.x, due to bug integrating with CXF DOSGi
+			http://cxf.547215.n5.nabble.com/Using-Jackson-as-JSON-body-reader-writer-with-DOSGi-td5729257.html)-->
+		<dependency>
+			<groupId>org.codehaus.jackson</groupId>
+			<artifactId>jackson-mapper-asl</artifactId>
+			<version>${jackson.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.codehaus.jackson</groupId>
+			<artifactId>jackson-xc</artifactId>
+			<version>${jackson.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.codehaus.jackson</groupId>
+			<artifactId>jackson-jaxrs</artifactId>
+			<version>${jackson.version}</version>
+		</dependency>
+		<!-- JSON Assert (https://github.com/skyscreamer/JSONassert) -->
+		<dependency>
+			<groupId>org.skyscreamer</groupId>
+			<artifactId>jsonassert</artifactId>
+			<version>${jsonassert.version}</version>
 		</dependency>
  	</dependencies>
 

--- a/extensions/bundles/openflowswitch.driver.floodlight/src/main/java/org/opennaas/extensions/openflowswitch/driver/floodlight/protocol/FloodlightProtocolSession.java
+++ b/extensions/bundles/openflowswitch.driver.floodlight/src/main/java/org/opennaas/extensions/openflowswitch/driver/floodlight/protocol/FloodlightProtocolSession.java
@@ -5,7 +5,7 @@ import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.cxf.jaxrs.client.JAXRSClientFactory;
+import org.apache.cxf.jaxrs.client.JAXRSClientFactoryBean;
 import org.opennaas.core.resources.protocol.IProtocolMessageFilter;
 import org.opennaas.core.resources.protocol.IProtocolSession;
 import org.opennaas.core.resources.protocol.IProtocolSessionListener;
@@ -14,6 +14,7 @@ import org.opennaas.core.resources.protocol.ProtocolSessionContext;
 import org.opennaas.core.resources.protocol.IProtocolSession.Status;
 
 import org.opennaas.extensions.openflowswitch.driver.floodlight.protocol.client.IFloodlightStaticFlowPusherClient;
+import org.opennaas.extensions.openflowswitch.driver.floodlight.protocol.client.serializers.json.CustomJSONProvider;
 
 public class FloodlightProtocolSession implements IProtocolSession {
 
@@ -157,7 +158,12 @@ public class FloodlightProtocolSession implements IProtocolSession {
 		String switchId = (String) sessionContext.getSessionParameters().get(SWITCHID_CONTEXT_PARAM_NAME);
 		//TODO use switch id to instantiate the client
 		
-		return JAXRSClientFactory.create(uri, IFloodlightStaticFlowPusherClient.class);
+		
+		JAXRSClientFactoryBean bean = new JAXRSClientFactoryBean();
+		bean.setAddress(uri);
+		bean.setProvider(new CustomJSONProvider());
+		bean.setResourceClass(IFloodlightStaticFlowPusherClient.class);
+		return (IFloodlightStaticFlowPusherClient) bean.create();
 	}
 	
 	private void checkProtocolSessionContext(ProtocolSessionContext protocolSessionContext) throws ProtocolException {

--- a/extensions/bundles/openflowswitch.driver.floodlight/src/main/java/org/opennaas/extensions/openflowswitch/driver/floodlight/protocol/client/IFloodlightStaticFlowPusherClient.java
+++ b/extensions/bundles/openflowswitch.driver.floodlight/src/main/java/org/opennaas/extensions/openflowswitch/driver/floodlight/protocol/client/IFloodlightStaticFlowPusherClient.java
@@ -3,8 +3,18 @@ package org.opennaas.extensions.openflowswitch.driver.floodlight.protocol.client
 import java.util.List;
 import java.util.Map;
 
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
 import org.opennaas.extensions.openflowswitch.driver.floodlight.protocol.client.model.FloodlightOFFlow;
 
+
+@Path("/wm/staticflowentrypusher")
 public interface IFloodlightStaticFlowPusherClient {
 
 	/**
@@ -13,6 +23,9 @@ public interface IFloodlightStaticFlowPusherClient {
 	 * @param flow
 	 *            The flow to push.
 	 */
+	@Path("/json")
+	@POST
+	@Consumes(MediaType.APPLICATION_JSON)
 	public void addFlow(FloodlightOFFlow flow);
 
 	/**
@@ -21,6 +34,9 @@ public interface IFloodlightStaticFlowPusherClient {
 	 * @param name
 	 *            The name of the static flow to delete.
 	 */
+	@Path("/json")
+	@DELETE
+	@Consumes(MediaType.APPLICATION_JSON)
 	public void deleteFlow(String name);
 
 	/**
@@ -29,21 +45,27 @@ public interface IFloodlightStaticFlowPusherClient {
 	 * @param dpid
 	 *            The DPID of the switch to delete flows for.
 	 */
-	public void deleteFlowsForSwitch(long dpid);
+	@Path("clear/{switchId}/json")
+	public void deleteFlowsForSwitch(@PathParam("switchId") long dpid);
 
 	/**
 	 * Deletes all flows.
 	 */
+	@Path("clear/all/json")
 	public void deleteAllFlows();
 
 	/**
 	 * Gets all list of all flows
 	 */
+	@Path("list/all/json")
+	@Produces(MediaType.APPLICATION_JSON)
 	public Map<String, List<FloodlightOFFlow>> getFlows();
 
 	/**
 	 * Gets a list of flows by switch
 	 */
-	public List<FloodlightOFFlow> getFlows(String dpid);
+	@Path("list/{switchId}/json")
+	@Produces(MediaType.APPLICATION_JSON)
+	public List<FloodlightOFFlow> getFlows(@PathParam("switchId") String dpid);
 
 }

--- a/extensions/bundles/openflowswitch.driver.floodlight/src/main/java/org/opennaas/extensions/openflowswitch/driver/floodlight/protocol/client/serializers/json/CustomJSONProvider.java
+++ b/extensions/bundles/openflowswitch.driver.floodlight/src/main/java/org/opennaas/extensions/openflowswitch/driver/floodlight/protocol/client/serializers/json/CustomJSONProvider.java
@@ -1,0 +1,28 @@
+package org.opennaas.extensions.openflowswitch.driver.floodlight.protocol.client.serializers.json;
+
+import org.codehaus.jackson.jaxrs.JacksonJsonProvider;
+import org.codehaus.jackson.Version;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.codehaus.jackson.map.module.SimpleModule;
+import org.opennaas.extensions.openflowswitch.driver.floodlight.protocol.client.model.FloodlightOFFlow;
+
+public class CustomJSONProvider extends JacksonJsonProvider {
+	
+	public CustomJSONProvider() {
+		super();
+
+		ObjectMapper mapper = new ObjectMapper();
+		
+		SimpleModule myModule = new SimpleModule("MyFloodlightOFFlowJSONSerializerDeserializerModule", new Version(1, 0, 0, null));
+		myModule.addSerializer(new FloodlightOFFlowJSONSerializer()); // assuming FloodlightOFFlowJSONSerializer declares correct class to bind to
+		myModule.addDeserializer(FloodlightOFFlow.class, new FloodlightOFFlowJSONDeserializer());
+		mapper.registerModule(myModule);
+		
+		mapper.configure(org.codehaus.jackson.map.SerializationConfig.Feature.WRAP_ROOT_VALUE, false);
+		mapper.configure(org.codehaus.jackson.map.SerializationConfig.Feature.INDENT_OUTPUT, true);
+//		mapper.configure(org.codehaus.jackson.map.DeserializationConfig.Feature.UNWRAP_ROOT_VALUE, true);
+		mapper.configure(org.codehaus.jackson.map.DeserializationConfig.Feature.FAIL_ON_UNKNOWN_PROPERTIES, true);
+
+		super.setMapper(mapper);
+	}
+}

--- a/extensions/bundles/openflowswitch.driver.floodlight/src/main/java/org/opennaas/extensions/openflowswitch/driver/floodlight/protocol/client/serializers/json/FloodlightOFFlowJSONDeserializer.java
+++ b/extensions/bundles/openflowswitch.driver.floodlight/src/main/java/org/opennaas/extensions/openflowswitch/driver/floodlight/protocol/client/serializers/json/FloodlightOFFlowJSONDeserializer.java
@@ -1,0 +1,115 @@
+package org.opennaas.extensions.openflowswitch.driver.floodlight.protocol.client.serializers.json;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.codehaus.jackson.JsonParser;
+import org.codehaus.jackson.JsonProcessingException;
+import org.codehaus.jackson.JsonToken;
+import org.codehaus.jackson.map.DeserializationContext;
+import org.codehaus.jackson.map.JsonDeserializer;
+
+import org.opennaas.extensions.openflowswitch.driver.floodlight.protocol.client.model.FloodlightOFAction;
+import org.opennaas.extensions.openflowswitch.driver.floodlight.protocol.client.model.FloodlightOFFlow;
+import org.opennaas.extensions.openflowswitch.driver.floodlight.protocol.client.model.FloodlightOFMatch;
+
+public class FloodlightOFFlowJSONDeserializer extends
+		JsonDeserializer<FloodlightOFFlow> {
+
+	@Override
+	public FloodlightOFFlow deserialize(JsonParser jp,
+			DeserializationContext ctx) throws IOException,
+			JsonProcessingException {
+
+		FloodlightOFFlow flow = new FloodlightOFFlow();
+		FloodlightOFMatch match = new FloodlightOFMatch();
+		List<FloodlightOFAction> actions = new ArrayList<FloodlightOFAction>(0);
+
+		JsonToken token;
+		
+//		token = jp.nextToken();
+//		if ((token = jp.getCurrentToken()) != JsonToken.START_OBJECT) {
+//			throw new IOException("Expected START_OBJECT");
+//		}
+
+		while ((token = jp.nextToken()) != JsonToken.END_OBJECT) {
+			if ((token = jp.getCurrentToken()) != JsonToken.FIELD_NAME) {
+				throw new IOException("Expected FIELD_NAME");
+			}
+
+			String n = jp.getCurrentName();
+			token = jp.nextToken();
+			if (jp.getText().equals(""))
+				continue;
+
+			if (n == "name")
+				flow.setName(jp.getText());
+			else if (n == "switch")
+				flow.setSwitchId(jp.getText());
+			else if (n == "actions") {
+				actions = parseActions(jp.getText());
+			} else if (n == "priority")
+				flow.setPriority(jp.getText());
+			else if (n == "active")
+				flow.setActive(Boolean.parseBoolean(jp.getText()));
+			else if (n == "wildcards")
+				match.setWildcards(jp.getText());
+			else if (n == "ingress-port")
+				match.setIngressPort(jp.getText());
+			else if (n == "src-mac")
+				match.setSrcMac(jp.getText());
+			else if (n == "dst-mac")
+				match.setDstMac(jp.getText());
+			else if (n == "vlan-id")
+				match.setVlanId(jp.getText());
+			else if (n == "vlan-priority")
+				match.setVlanPriority(jp.getText());
+			else if (n == "ether-type")
+				match.setEtherType(jp.getText());
+			else if (n == "tos-bits")
+				match.setTosBits(jp.getText());
+			else if (n == "protocol")
+				match.setProtocol(jp.getText());
+			else if (n == "src-ip")
+				match.setSrcIp(jp.getText());
+			else if (n == "dst-ip")
+				match.setDstIp(jp.getText());
+			else if (n == "src-port")
+				match.setSrcPort(jp.getText());
+			else if (n == "dst-port")
+				match.setDstPort(jp.getText());
+		}
+		
+		flow.setMatch(match);
+		flow.setActions(actions);
+		return flow;
+	}
+
+	private List<FloodlightOFAction> parseActions(String actionstr) {
+		List<FloodlightOFAction> actions = new ArrayList<FloodlightOFAction>();
+		FloodlightOFAction currentAction;
+		String type;
+		String value;
+
+		if (actionstr != null) {
+			actionstr = actionstr.toLowerCase();
+			for (String subaction : actionstr.split(",")) {
+
+				type = subaction.split("[=:]")[0];
+				if (subaction.split("[=:]").length > 1) {
+					value = subaction.split("[=:]")[1];
+				} else {
+					value = null;
+				}
+
+				currentAction = new FloodlightOFAction();
+				currentAction.setType(type);
+				currentAction.setValue(value);
+				
+				actions.add(currentAction);
+			}
+		}
+		return actions;
+	}
+}

--- a/extensions/bundles/openflowswitch.driver.floodlight/src/main/java/org/opennaas/extensions/openflowswitch/driver/floodlight/protocol/client/serializers/json/FloodlightOFFlowJSONSerializer.java
+++ b/extensions/bundles/openflowswitch.driver.floodlight/src/main/java/org/opennaas/extensions/openflowswitch/driver/floodlight/protocol/client/serializers/json/FloodlightOFFlowJSONSerializer.java
@@ -1,0 +1,134 @@
+package org.opennaas.extensions.openflowswitch.driver.floodlight.protocol.client.serializers.json;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.codehaus.jackson.JsonGenerator;
+import org.codehaus.jackson.JsonProcessingException;
+import org.codehaus.jackson.map.JsonSerializer;
+import org.codehaus.jackson.map.SerializerProvider;
+import org.opennaas.extensions.openflowswitch.driver.floodlight.protocol.client.model.FloodlightOFAction;
+import org.opennaas.extensions.openflowswitch.driver.floodlight.protocol.client.model.FloodlightOFFlow;
+import org.opennaas.extensions.openflowswitch.driver.floodlight.protocol.client.model.FloodlightOFMatch;
+
+public class FloodlightOFFlowJSONSerializer extends
+		JsonSerializer<FloodlightOFFlow> {
+
+	@Override
+	public void serialize(FloodlightOFFlow flow, JsonGenerator jGen,
+			SerializerProvider serializer) throws IOException,
+			JsonProcessingException {
+
+		jGen.writeStartObject();
+		if (flow.getSwitchId() != null)
+			jGen.writeStringField("switch", flow.getSwitchId());
+		if (flow.getName() != null)
+			jGen.writeStringField("name", flow.getName());
+		if (flow.getPriority() != null)
+			jGen.writeStringField("priority", flow.getPriority());
+		
+		jGen.writeStringField("active", String.valueOf(flow.isActive()));
+		
+		if (flow.getMatch() != null)
+			serializeMatch(flow.getMatch(), jGen, serializer);
+		
+		if (flow.getActions() != null)
+			serializeActions(flow.getActions(), jGen, serializer);
+		
+		jGen.writeEndObject();
+
+	}
+	
+	/**
+	 * Fields in a Match are serialized as fields in the flow (no Match object separators)
+	 * @param match
+	 * @param jGen
+	 * @param serializer
+	 * @throws IOException
+	 * @throws JsonProcessingException
+	 */
+	private void serializeMatch(FloodlightOFMatch match, JsonGenerator jGen,
+			SerializerProvider serializer) throws IOException,
+			JsonProcessingException {
+		
+		if  (match == null)
+			return;
+		
+		if (match.getWildcards() != null && !match.getWildcards().isEmpty())
+			jGen.writeStringField("wildcards", match.getWildcards());
+		
+		if (match.getIngressPort() != null && !match.getIngressPort().isEmpty())
+			jGen.writeStringField("ingress-port", match.getIngressPort());
+		
+		if (match.getSrcMac() != null && !match.getSrcMac().isEmpty())
+			jGen.writeStringField("src-mac", match.getSrcMac());
+		
+		if (match.getDstMac() != null && !match.getDstMac().isEmpty())
+			jGen.writeStringField("dst-mac", match.getDstMac());
+		
+		if (match.getVlanId() != null && !match.getVlanId().isEmpty())
+			jGen.writeStringField("vlan-id", match.getVlanId());
+		
+		if (match.getVlanPriority() != null && !match.getVlanPriority().isEmpty())
+			jGen.writeStringField("vlan-priority", match.getVlanPriority());
+		
+		if (match.getEtherType() != null && !match.getEtherType().isEmpty())
+			jGen.writeStringField("ether-type", match.getEtherType());
+		
+		if (match.getTosBits() != null && !match.getTosBits().isEmpty())
+			jGen.writeStringField("tos-bits", match.getTosBits());
+		
+		if (match.getProtocol() != null && !match.getProtocol().isEmpty())
+			jGen.writeStringField("protocol", match.getProtocol());
+		
+		if (match.getSrcIp() != null && !match.getSrcIp().isEmpty())
+			jGen.writeStringField("src-ip", match.getSrcIp());
+		
+		if (match.getDstIp() != null && !match.getDstIp().isEmpty())
+			jGen.writeStringField("dst-ip", match.getDstIp());
+		
+		if (match.getSrcPort() != null && !match.getSrcPort().isEmpty())
+			jGen.writeStringField("src-port", match.getSrcPort());
+		
+		if (match.getDstPort() != null && !match.getDstPort().isEmpty())
+			jGen.writeStringField("dst-port", match.getDstPort());
+	}
+	
+	/**
+	 * The list of actions is serialized as a comma separated list of type=value elements:
+	 * "actions":"output=2,set-vlan-id=1" 
+	 * 
+	 * @param actions
+	 * @param jGen
+	 * @param serializer
+	 * @throws IOException
+	 * @throws JsonProcessingException
+	 */
+	private void serializeActions(List<FloodlightOFAction> actions, JsonGenerator jGen,
+			SerializerProvider serializer) throws IOException,
+			JsonProcessingException {
+		
+		if (actions == null || actions.isEmpty())
+			return;
+		
+		StringBuilder sb = new StringBuilder();
+		for (FloodlightOFAction action : actions) {
+			sb.append(",");
+			sb.append(action.getType());
+			if (action.getValue() != null) {
+				sb.append("=");
+				sb.append(action.getValue());
+			}
+		}
+		sb.deleteCharAt(0);	// delete first comma
+		
+		jGen.writeStringField("actions", sb.toString());
+		
+	}
+
+	@Override
+	public Class<FloodlightOFFlow> handledType() {
+		return FloodlightOFFlow.class;
+	}
+
+}

--- a/extensions/bundles/openflowswitch.driver.floodlight/src/test/java/org/opennaas/extensions/openflowswitch/driver/floodlight/test/FloodlightMsgSerializationTest.java
+++ b/extensions/bundles/openflowswitch.driver.floodlight/src/test/java/org/opennaas/extensions/openflowswitch/driver/floodlight/test/FloodlightMsgSerializationTest.java
@@ -1,0 +1,66 @@
+package org.opennaas.extensions.openflowswitch.driver.floodlight.test;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import javax.ws.rs.core.MediaType;
+
+import junit.framework.Assert;
+
+import org.codehaus.jackson.JsonParseException;
+import org.codehaus.jackson.map.JsonMappingException;
+
+
+import org.json.JSONException;
+import org.junit.Before;
+import org.junit.Test;
+import org.opennaas.extensions.openflowswitch.driver.floodlight.protocol.client.model.FloodlightOFAction;
+import org.opennaas.extensions.openflowswitch.driver.floodlight.protocol.client.model.FloodlightOFFlow;
+import org.opennaas.extensions.openflowswitch.driver.floodlight.protocol.client.model.FloodlightOFMatch;
+import org.opennaas.extensions.openflowswitch.driver.floodlight.protocol.client.serializers.json.CustomJSONProvider;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+public class FloodlightMsgSerializationTest {
+	
+	String flowJSON;
+	FloodlightOFFlow flow;
+
+	CustomJSONProvider provider;
+	
+	@Before
+	public void initFlow() {
+		flowJSON = "{\"switch\": \"00:00:00:00:00:00:00:01\", \"name\":\"flow-mod-1\", \"priority\":\"32768\", \"ingress-port\":\"1\",\"active\":\"true\", \"actions\":\"output=2\"}";
+		
+		flow = new FloodlightOFFlow();
+		flow.setSwitchId("00:00:00:00:00:00:00:01");
+		flow.setName("flow-mod-1");
+		flow.setPriority("32768");
+		flow.setActive(true);
+		
+		FloodlightOFMatch match = new FloodlightOFMatch();
+		match.setIngressPort("1");
+		flow.setMatch(match);
+		
+		FloodlightOFAction action = new FloodlightOFAction();
+		action.setType("output");
+		action.setValue("2");
+		
+		flow.setActions(Arrays.asList(action));
+	}
+	
+	@Before
+	public void initProvider(){
+		provider = new CustomJSONProvider();
+	}
+	
+	@Test
+	public void flowSerializationDeserializationTest() throws JsonParseException, JsonMappingException, IOException, JSONException {
+		
+		String generatedJSON = provider.locateMapper(FloodlightOFFlow.class, MediaType.APPLICATION_JSON_TYPE).writeValueAsString(flow);
+		JSONAssert.assertEquals(flowJSON, generatedJSON, false);
+		
+		FloodlightOFFlow generatedFlow = provider.locateMapper(FloodlightOFFlow.class, MediaType.APPLICATION_JSON_TYPE).readValue(flowJSON, FloodlightOFFlow.class);
+		Assert.assertEquals(flow, generatedFlow);
+	}
+
+}


### PR DESCRIPTION
FloodlightProtocolSession instantiates a client with anotated IFloodlightStaticFlowPusherClient interface.
The client uses CustomJSONProvider to serialize/deserialize FloodlightOFFlow data structures.

CustomJSONProvider contains a serializer and a deserializer for FloodlightOFFlow and application/json MediaType.
The mapping between model classes and serializers is configured in CustomJSONProvider.
This way, model classes are not linked to serializers.

A tests checks CustomJSONProvider serializes and deserializes as expected by floodlight.
