### PR TITLE
Solve OPENNAAS-1108.

### DIFF
--- a/extensions/bundles/router.capability.vrrp/src/main/java/org/opennaas/extensions/router/capability/vrrp/VRRPCapability.java
+++ b/extensions/bundles/router.capability.vrrp/src/main/java/org/opennaas/extensions/router/capability/vrrp/VRRPCapability.java
@@ -129,7 +129,7 @@ public class VRRPCapability extends AbstractCapability implements IVRRPCapabilit
 		VRRPProtocolEndpoint param = (VRRPProtocolEndpoint) vrrpCopy.getProtocolEndpoint().get(0);
 		param.setPriority(vrrpProtocolEndpoint.getPriority());
 
-		IAction action = createActionAndCheckParams(VRRPActionSet.VRRP_UPDATE_VIRTUAL_IP_ADDRESS, vrrpProtocolEndpoint);
+		IAction action = createActionAndCheckParams(VRRPActionSet.VRRP_UPDATE_VIRTUAL_IP_ADDRESS, param);
 		queueAction(action);
 		log.info("End of updateVRRPVirtualIPAddress call");
 	}


### PR DESCRIPTION
The error was in org.opennaas.extensions.router.capability.vrrp.VRRPCapability.java

updateVRRPVirtualIPAddress method crafted a VRRPProtocolEndpoint param object (not used) but used the original VRRPProtocolEndpoint vrrpProtocolEndpoint to call the action.
Using param to call the action solves the issue by avoiding the error.

http://jira.i2cat.net:8080/browse/OPENNAAS-1108
