### PR TITLE
Fix/sdn selector mockup

### DIFF
--- a/extensions/bundles/ofertie.ncl/pom.xml
+++ b/extensions/bundles/ofertie.ncl/pom.xml
@@ -52,6 +52,7 @@
 						<Bundle-Activator>org.opennaas.extensions.ofertie.ncl.Activator</Bundle-Activator>
 						<Import-Package>
 							org.slf4j,
+							org.opennaas.extensions.sdnnetwork.repository,
 							*
 						</Import-Package>
 						<Export-Package>

--- a/extensions/bundles/ofertie.ncl/src/main/java/org/opennaas/extensions/ofertie/ncl/provisioner/components/mockup/NetworkSelectorMockup.java
+++ b/extensions/bundles/ofertie.ncl/src/main/java/org/opennaas/extensions/ofertie/ncl/provisioner/components/mockup/NetworkSelectorMockup.java
@@ -3,12 +3,12 @@ package org.opennaas.extensions.ofertie.ncl.provisioner.components.mockup;
 import org.opennaas.core.resources.IResourceManager;
 import org.opennaas.extensions.ofertie.ncl.provisioner.api.model.FlowRequest;
 import org.opennaas.extensions.ofertie.ncl.provisioner.components.INetworkSelector;
+import org.opennaas.extensions.sdnnetwork.repository.SdnNetworkRepository;
 
 public class NetworkSelectorMockup implements INetworkSelector {
-	
-	private static final String SDN_NETWORK_RESOURCE_TYPE= "sdnnet";
-	private IResourceManager resourceManager;
-	
+
+	private IResourceManager	resourceManager;
+
 	/**
 	 * @return the resourceManager
 	 */
@@ -17,7 +17,8 @@ public class NetworkSelectorMockup implements INetworkSelector {
 	}
 
 	/**
-	 * @param resourceManager the resourceManager to set
+	 * @param resourceManager
+	 *            the resourceManager to set
 	 */
 	public void setResourceManager(IResourceManager resourceManager) {
 		this.resourceManager = resourceManager;
@@ -28,13 +29,14 @@ public class NetworkSelectorMockup implements INetworkSelector {
 			throws Exception {
 		return getFirstSDNNetworkInOpenNaaS();
 	}
-	
+
 	/**
 	 * It assumes OpenNaaS supports SDN networks and there is at least one of them active.
+	 * 
 	 * @return
 	 */
 	private String getFirstSDNNetworkInOpenNaaS() {
-		return resourceManager.listResourcesByType(SDN_NETWORK_RESOURCE_TYPE).get(0)
+		return resourceManager.listResourcesByType(SdnNetworkRepository.SDN_NETWORK_RESOURCE_TYPE).get(0)
 				.getResourceIdentifier().getId();
 	}
 

--- a/extensions/bundles/sdnnetwork/src/main/java/org/opennaas/extensions/sdnnetwork/repository/SdnNetworkRepository.java
+++ b/extensions/bundles/sdnnetwork/src/main/java/org/opennaas/extensions/sdnnetwork/repository/SdnNetworkRepository.java
@@ -8,11 +8,13 @@ import org.opennaas.core.resources.capability.ICapabilityFactory;
 /**
  * 
  * @author Isart Canyameres Gimenez (i2cat)
- *
+ * 
  */
-public class SdnNetworkRepository  extends ResourceRepository {
-	
-	Log	log	= LogFactory.getLog(SdnNetworkRepository.class);
+public class SdnNetworkRepository extends ResourceRepository {
+
+	public static final String	SDN_NETWORK_RESOURCE_TYPE	= "sdnnetwork";
+
+	Log							log							= LogFactory.getLog(SdnNetworkRepository.class);
 
 	public SdnNetworkRepository(String resourceType) {
 		super(resourceType);


### PR DESCRIPTION
Use correct sdn network resource type to retieve sdn networks from the ResourceManager.

Was using "sdnnet" and correct one is "sdnnetwork".
