### PR TITLE
Fix/port identifiers

### DIFF
--- a/extensions/bundles/ofertie.ncl/src/main/java/org/opennaas/extensions/ofertie/ncl/controller/NCLController.java
+++ b/extensions/bundles/ofertie.ncl/src/main/java/org/opennaas/extensions/ofertie/ncl/controller/NCLController.java
@@ -28,6 +28,13 @@ public class NCLController implements INCLController {
 		try {
 
 			SDNNetworkOFFlow flowWithRoute = FlowRequestParser.parseFlowRequestIntoSDNFlow(flowRequest, route);
+			flowWithRoute.setActive(true);
+			flowWithRoute.setPriority("32768");
+			// FIXME requesting a flow that won't filter by IP, by now
+			flowWithRoute.getMatch().setSrcIp(null);
+			flowWithRoute.getMatch().setDstIp(null);
+			// FIXME requesting a flow that won't filter by ToS, by now
+			flowWithRoute.getMatch().setTosBits(null);
 
 			IResource networkResource = getResource(networkId);
 			IOFProvisioningNetworkCapability provisionCapab = (IOFProvisioningNetworkCapability) networkResource

--- a/extensions/bundles/ofertie.ncl/src/main/java/org/opennaas/extensions/ofertie/ncl/helpers/FlowRequestParser.java
+++ b/extensions/bundles/ofertie.ncl/src/main/java/org/opennaas/extensions/ofertie/ncl/helpers/FlowRequestParser.java
@@ -52,8 +52,18 @@ public abstract class FlowRequestParser {
 		match.setSrcPort(String.valueOf(flowRequest.getSourcePort()));
 		match.setDstPort(String.valueOf(flowRequest.getDestinationPort()));
 		match.setTosBits(String.valueOf(flowRequest.getTos()));
-		match.setSrcIp(flowRequest.getSourceIPAddress());
-		match.setDstIp(flowRequest.getDestinationIPAddress());
+		if (flowRequest.getSourceIPAddress() == null || flowRequest.getSourceIPAddress().isEmpty()) {
+			// remove empty strings, use null instead
+			match.setSrcIp(null);
+		} else {
+			match.setSrcIp(flowRequest.getSourceIPAddress());
+		}
+		if (flowRequest.getDestinationIPAddress() == null || flowRequest.getDestinationIPAddress().isEmpty()) {
+			// remove empty strings, use null instead
+			match.setDstIp(null);
+		} else {
+			match.setDstIp(flowRequest.getDestinationIPAddress());
+		}
 
 		String ingressPort = route.getNetworkConnections().get(0).getSource().getId();
 		match.setIngressPort(ingressPort);

--- a/extensions/bundles/openflowswitch.driver.floodlight/src/main/java/org/opennaas/extensions/openflowswitch/driver/floodlight/actionssets/FloodlightConstants.java
+++ b/extensions/bundles/openflowswitch.driver.floodlight/src/main/java/org/opennaas/extensions/openflowswitch/driver/floodlight/actionssets/FloodlightConstants.java
@@ -1,0 +1,7 @@
+package org.opennaas.extensions.openflowswitch.driver.floodlight.actionssets;
+
+public class FloodlightConstants {
+
+	public static final String	DEFAULT_PRIORITY	= "32767";
+
+}

--- a/extensions/bundles/sdnnetwork/src/main/java/org/opennaas/extensions/sdnnetwork/driver/internal/actionsets/actions/AllocateFlowAction.java
+++ b/extensions/bundles/sdnnetwork/src/main/java/org/opennaas/extensions/sdnnetwork/driver/internal/actionsets/actions/AllocateFlowAction.java
@@ -36,23 +36,7 @@ public class AllocateFlowAction extends Action {
 		for (int i = 0; i < connections.size(); i++) {
 			NetworkConnection networkConnection = connections.get(i);
 			try {
-
-				SDNNetworkOFFlow copy = new SDNNetworkOFFlow(flow);
-				// FIXME following changes should be introduced in the NCLcontroller, not here!
-				copy.setActive(true);
-				copy.setPriority("32768");
-				copy.getMatch().setSrcIp(null);
-				copy.getMatch().setDstIp(null);
-
-				// FIXME Following logic should go in floodlight controller driver implementation.
-				if (copy.getMatch().getSrcIp() != null || copy.getMatch().getDstIp() != null) {
-					// To avoid following message in floodlight controller:
-					// Warning! Pushing a static flow entry that matches IP fields without matching for IP payload (ether-type 2048)
-					// will cause the switch to wildcard higher level fields.
-					copy.getMatch().setEtherType("2048");
-				}
-
-				provisionLink(networkConnection.getSource(), networkConnection.getDestination(), copy,
+				provisionLink(networkConnection.getSource(), networkConnection.getDestination(), new SDNNetworkOFFlow(flow),
 						i == connections.size() - 1);
 			} catch (Exception e) {
 				throw new ActionException("Error provisioning link : ", e);


### PR DESCRIPTION
Move out flow request logic from network into NCL controller.
Move out floodlight logic from network into openflowswitch driver floodlight actions.
