### PR TITLE
Set exec permissions to opennaas bin folder content.

### DIFF
--- a/platform/src/main/assembly/opennaas.xml
+++ b/platform/src/main/assembly/opennaas.xml
@@ -45,6 +45,7 @@
 				<exclude>servicemix.bat</exclude>
 			</excludes>
 			<directoryMode>0755</directoryMode>
+			<fileMode>0755</fileMode>
 		</fileSet>
 	</fileSets>
 


### PR DESCRIPTION
Fixes issue
http://jira.i2cat.net/browse/OPENNAAS-1132

Permissions are set as follow
-rwxr-xr-x 1 i2cat i2cat  9121 oct 11 12:04 admin
-rwxr-xr-x 1 i2cat i2cat  8567 oct 11 12:04 client
-rwxr-xr-x 1 i2cat i2cat  1607 oct 11 12:04 create
-rwxr-xr-x 1 i2cat i2cat 10305 oct 11 12:04 karaf
-rw-r--r-- 1 i2cat i2cat  8447 oct 11 12:04 opennaas.bat
-rwxr-xr-x 1 i2cat i2cat  9633 oct 11 12:04 opennaas.sh
-rwxr-xr-x 1 i2cat i2cat  8451 oct 11 12:04 shell
-rwxr-xr-x 1 i2cat i2cat  3193 oct 11 12:04 start
-rwxr-xr-x 1 i2cat i2cat  3157 oct 11 12:04 stop
