### PR TITLE
Add BGPProperties validator as a JUnit test.

### DIFF
--- a/extensions/bundles/router.capability.bgp/src/test/java/org/opennaas/extensions/router/capability/bgp/tests/BGPPropertiesLoaderTest.java
+++ b/extensions/bundles/router.capability.bgp/src/test/java/org/opennaas/extensions/router/capability/bgp/tests/BGPPropertiesLoaderTest.java
@@ -12,7 +12,8 @@ public class BGPPropertiesLoaderTest {
 	private static final String	BGP_PROPERTIES_PATH	= "/absolute/path/to/bgp.properties";
 
 	public static void main(String args[]) throws Exception {
-		checkPropertiesAreCorrect(BGP_PROPERTIES_PATH);
+		checkPropertiesAreCorrect(args[0]);
+		System.out.println("Properties loaded without error");
 	}
 
 	private static void checkPropertiesAreCorrect(String path) throws IOException {


### PR DESCRIPTION
To use it, set BGP_PROPERTIES_PATH to your properties file,
remove @Ignore annotation in the test,
and run the test.

If the test fails, a surefire-report will be generated with information of the error.
Debugging may also help to finding where the error is.

The validator can also be run as an application, passing it the path of the file to validate.
