### PR TITLE
Change PathFinderMockup route selection to be independent of ToS value in FlowRequest.

### DIFF
--- a/extensions/bundles/ofertie.ncl/src/main/java/org/opennaas/extensions/ofertie/ncl/helpers/FlowRequestHelper.java
+++ b/extensions/bundles/ofertie.ncl/src/main/java/org/opennaas/extensions/ofertie/ncl/helpers/FlowRequestHelper.java
@@ -20,6 +20,8 @@ public abstract class FlowRequestHelper {
 
 		FlowRequest req = new FlowRequest();
 
+		req.setRequestId("1001");
+
 		req.setSourceIPAddress("192.168.1.14");
 		req.setDestinationIPAddress("192.168.1.13");
 

--- a/extensions/bundles/ofertie.ncl/src/main/java/org/opennaas/extensions/ofertie/ncl/provisioner/api/model/FlowRequest.java
+++ b/extensions/bundles/ofertie.ncl/src/main/java/org/opennaas/extensions/ofertie/ncl/provisioner/api/model/FlowRequest.java
@@ -14,6 +14,11 @@ import javax.xml.bind.annotation.XmlRootElement;
 @XmlAccessorType(XmlAccessType.FIELD)
 public class FlowRequest {
 
+	// TODO to be removed.
+	// only required by PathFinderMockup.
+	// Not used in equals and hashCode.
+	private String			requestId;
+
 	private String			sourceIPAddress;
 	private String			destinationIPAddress;
 
@@ -35,6 +40,21 @@ public class FlowRequest {
 	private int				destinationVlanId;
 
 	private QoSRequirements	qoSRequirements;
+
+	/**
+	 * @return the requestId
+	 */
+	public String getRequestId() {
+		return requestId;
+	}
+
+	/**
+	 * @param requestId
+	 *            the requestId to set
+	 */
+	public void setRequestId(String requestId) {
+		this.requestId = requestId;
+	}
 
 	/**
 	 * @return the sourceIPAddress

--- a/extensions/bundles/ofertie.ncl/src/main/java/org/opennaas/extensions/ofertie/ncl/provisioner/components/mockup/PathFinderMockup.java
+++ b/extensions/bundles/ofertie.ncl/src/main/java/org/opennaas/extensions/ofertie/ncl/provisioner/components/mockup/PathFinderMockup.java
@@ -19,7 +19,7 @@ public class PathFinderMockup implements IPathFinder {
 
 	private static final String			DEFAULT_ROUTE	= "0";
 	/**
-	 * Key: ToS in request, Value: Route to apply
+	 * Key: RouteId, Value: Route to apply
 	 */
 	private static Map<String, Route>	routes;
 
@@ -33,13 +33,19 @@ public class PathFinderMockup implements IPathFinder {
 	@Override
 	public Route findPathForRequest(FlowRequest flowRequest, String networkId)
 			throws Exception {
-		return selectRouteFromToS(flowRequest.getTos());
+		return selectRouteFromRequestId(flowRequest.getRequestId());
 	}
 
-	private Route selectRouteFromToS(int tos) {
+	/**
+	 * Selects a route having RouteId equals to given requestId
+	 * 
+	 * @param requestId
+	 * @return
+	 */
+	private Route selectRouteFromRequestId(String requestId) {
 		Route route;
 
-		route = routes.get(String.valueOf(tos));
+		route = routes.get(String.valueOf(requestId));
 		if (route == null)
 			route = routes.get(DEFAULT_ROUTE);
 

--- a/extensions/bundles/ofertie.ncl/src/test/java/org/opennaas/extensions/ofertie/ncl/test/ProvisionerLogicTest.java
+++ b/extensions/bundles/ofertie.ncl/src/test/java/org/opennaas/extensions/ofertie/ncl/test/ProvisionerLogicTest.java
@@ -164,6 +164,7 @@ public class ProvisionerLogicTest {
 		qoSRequirements.setMaxPacketLoss(10);
 
 		FlowRequest request = new FlowRequest();
+		request.setRequestId("1");
 		request.setSourceIPAddress("192.168.0.1");
 		request.setDestinationIPAddress("192.168.0.2");
 		request.setSourcePort(8080);

--- a/extensions/bundles/ofertie.ncl/src/test/java/org/opennaas/extensions/ofertie/ncl/test/ProvisionerSerializationTest.java
+++ b/extensions/bundles/ofertie.ncl/src/test/java/org/opennaas/extensions/ofertie/ncl/test/ProvisionerSerializationTest.java
@@ -35,6 +35,7 @@ public class ProvisionerSerializationTest {
 	// <flow>
 	// <id>1</id>
 	// <flowRequest>
+	// <requestId>1</requestId>
 	// <sourceIPAddress>192.168.0.1</sourceIPAddress>
 	// <destinationIPAddress>192.168.0.2</destinationIPAddress>
 	// <sourcePort>8080</sourcePort>
@@ -67,6 +68,7 @@ public class ProvisionerSerializationTest {
 		qoSRequirements.setMaxPacketLoss(10);
 
 		FlowRequest request = new FlowRequest();
+		request.setRequestId("1");
 		request.setSourceIPAddress("192.168.0.1");
 		request.setDestinationIPAddress("192.168.0.2");
 		request.setSourcePort(8080);

--- a/itests/ofertie.ncl/src/test/java/org/opennaas/itests/ofertie/ncl/NCLProvisionerTest.java
+++ b/itests/ofertie.ncl/src/test/java/org/opennaas/itests/ofertie/ncl/NCLProvisionerTest.java
@@ -217,6 +217,7 @@ public class NCLProvisionerTest {
 		FlowRequest myRequest = new FlowRequest();
 		QoSRequirements myQoSRequirements = new QoSRequirements();
 
+		myRequest.setRequestId(String.valueOf(TOS));
 		myRequest.setSourceIPAddress(SRC_IP_ADDRESS);
 		myRequest.setDestinationIPAddress(DST_IP_ADDRESS);
 		myRequest.setSourcePort(SRC_PORT);


### PR DESCRIPTION
FlowRequest has now a new field, called requestId, that MUST be set by the user.
PathFinderMockup selects the route with an id equal to the requestId of given FlowRequest.

PathFinderMockup route selection is no longer related to FlowRequest ToS value.
This way an application may launch multiple requests with same ToS value, resulting in flows with different routes. (if different requestIds have been given!)
