### PR TITLE
Fix bug causing sdnnetwork internal driver not allocating nor deallocating flows.

### DIFF
--- a/extensions/bundles/sdnnetwork/src/main/java/org/opennaas/extensions/sdnnetwork/driver/internal/actionsets/actions/AllocateFlowAction.java
+++ b/extensions/bundles/sdnnetwork/src/main/java/org/opennaas/extensions/sdnnetwork/driver/internal/actionsets/actions/AllocateFlowAction.java
@@ -90,9 +90,7 @@ public class AllocateFlowAction extends Action {
 	private void provisionLink(NetworkConnection connection, SDNNetworkOFFlow sdnNetworkOFFlow, boolean isLastLinkInRoute) throws ResourceException,
 			ActivatorException {
 
-		if (connection.getSource().getDeviceId() != connection.getDestination().getDeviceId()) {
-			/* link between different devices, assume it exists or it is provisioned */
-		} else {
+		if (connection.getSource().getDeviceId().equals(connection.getDestination().getDeviceId())) {
 			/* link inside same device, use device internal capability to provision it */
 
 			// Last link should include all actions of the original flow and the forwarding one.
@@ -106,6 +104,8 @@ public class AllocateFlowAction extends Action {
 					.getCapabilityByInterface(IOpenflowForwardingCapability.class);
 
 			forwardingCapability.createOpenflowForwardingRule(flow);
+		} else {
+			/* link between different devices, assume it exists or it is provisioned */
 		}
 	}
 

--- a/extensions/bundles/sdnnetwork/src/main/java/org/opennaas/extensions/sdnnetwork/driver/internal/actionsets/actions/DeallocateFlowAction.java
+++ b/extensions/bundles/sdnnetwork/src/main/java/org/opennaas/extensions/sdnnetwork/driver/internal/actionsets/actions/DeallocateFlowAction.java
@@ -67,11 +67,12 @@ public class DeallocateFlowAction extends Action {
 	}
 
 	private void deallocateNetworkConnection(NetworkConnection networkConnection) throws ActionException {
-		if (networkConnection.getSource().getDeviceId() != networkConnection.getDestination().getDeviceId()) {
-			/* link between different devices, assume it is statically allocated/deallocated */
-		} else {
+
+		if (networkConnection.getSource().getDeviceId().equals(networkConnection.getDestination().getDeviceId())) {
 			/* link inside same device, use device internal capability to deallocate it */
 			deallocateConnectionInsideDevice(networkConnection);
+		} else {
+			/* link between different devices, assume it is statically allocated/deallocated */
 		}
 	}
 


### PR DESCRIPTION
The bug was causing switches not being called to allocate or deallocate flows, resulting in no change for the real network.

The bug is fixed by using equals to compare strings (was using == operator).
