### PR TITLE
Remove unnecesary features from platform.

### DIFF
--- a/platform/pom.xml
+++ b/platform/pom.xml
@@ -113,8 +113,6 @@
 							<features>
 								<feature version="${project.version}">opennaas-core</feature>
 								<feature version="${project.version}">opennaas-extensions-all</feature> 
-								<feature version="${project.version}">itests-helpers</feature> 
-								<feature version="${project.version}">nexus-testprofile</feature> 
 							</features>
 							<repository>target/system</repository>
 						</configuration>


### PR DESCRIPTION
This commit removes test related features from the platform.

This commit causes platform to build successfully.
It was failing because itest.helpers feature is build after the platform, but platform was requiring it.
With itest.helpers feature already being loaded in itests requiring it, it is no longer required for the platform to build.
The same happens with testprofile feature, although it was not causing platform to fail, as it is installed before platform is build.
