### PR TITLE
Use injected EntityManagerFactory.

### DIFF
--- a/core/persistence/src/main/java/org/opennaas/core/persistence/GenericOSGiJpaRepository.java
+++ b/core/persistence/src/main/java/org/opennaas/core/persistence/GenericOSGiJpaRepository.java
@@ -1,147 +1,75 @@
 package org.opennaas.core.persistence;
 
 import java.io.Serializable;
-import java.util.Properties;
 
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.osgi.framework.BundleContext;
-import org.osgi.framework.Constants;
-import org.osgi.framework.Filter;
-import org.osgi.framework.FrameworkUtil;
-import org.osgi.framework.InvalidSyntaxException;
-import org.osgi.util.tracker.ServiceTracker;
 
 /**
  * GenericJPARepository that gets the EntityManagerFactory from the OSGi registry
  * 
  * @author eduardgrasa
+ * @author Isart Canyameres Gimenez (i2cat)
  * 
  * @param <T>
  * @param <ID>
  */
 public class GenericOSGiJpaRepository<T, ID extends Serializable> extends GenericJpaRepository<T, ID> {
 
-	private EntityManagerFactory	entityManagerFactory	= null;
-	private String					persistenceUnit			= null;
-	private static Log				logger					= LogFactory.getLog(GenericOSGiJpaRepository.class);
+	private static Log				logger	= LogFactory.getLog(GenericOSGiJpaRepository.class);
+
+	private EntityManagerFactory	entityManagerFactory;
 
 	public GenericOSGiJpaRepository() {
 		super();
 	}
 
-	public void setPersistenceUnit(String persistenceUnit) {
-		this.persistenceUnit = persistenceUnit;
+	/**
+	 * @return the entityManagerFactory
+	 */
+	public EntityManagerFactory getEntityManagerFactory() {
+		return entityManagerFactory;
+	}
+
+	/**
+	 * @param entityManagerFactory
+	 *            the entityManagerFactory to set
+	 */
+	public void setEntityManagerFactory(EntityManagerFactory entityManagerFactory) {
+		this.entityManagerFactory = entityManagerFactory;
 	}
 
 	public void initializeEntityManager() throws Exception {
 
-		try {
-			/*
-			 * FIXME We have to find a better method to do this to get the entityManager. It tries 10 times to try to get the persistence. The
-			 * persistence bundle spends more time because it is to need the config file persistence.xml which it needs more time to finish it.
-			 */
-			entityManagerFactory = waitForEntityManager(persistenceUnit);
-			if (entityManagerFactory == null)
-				throw new PersistenceException();
-
-			logger.debug("DESCRIPTION. Entity manager: " + entityManagerFactory);
-		} catch (PersistenceException e) {
-			logger.debug("PersistenceException: " + e.getMessage());
-			throw new Exception(e);
+		if (getEntityManager() == null) {
+			initializeEntityManagerFromFactory();
 		}
-		setEntityManager(entityManagerFactory.createEntityManager());
+
+		if (getEntityManager() == null)
+			throw new PersistenceException("Required EntityManager is null");
+	}
+
+	/**
+	 * Workaround for https://issues.apache.org/jira/browse/ARIES-796
+	 * 
+	 * This method supports loading the entityManager from an injected entityManagerFactory. entityManagerFactory can easily be injected using
+	 * blueprint normal injection, which is not affected by ARIES-796 issue, even when a property-placeholder is being used.
+	 */
+	private void initializeEntityManagerFromFactory() {
+		if (entityManagerFactory != null) {
+			setEntityManager(entityManagerFactory.createEntityManager());
+		}
 	}
 
 	public void close() {
 		EntityManager entityManager = getEntityManager();
-		if (entityManager != null) {
-			logger.debug("Closing entity manager: " + entityManager);
+		if (getEntityManager() != null) {
+			logger.debug("Closing entity manager: " + getEntityManager());
 			entityManager.close();
 			setEntityManager(null);
 		}
-	}
-
-	private EntityManagerFactory getEntityManagerFactoryFromOSGiRegistry(String persistenceUnit) {
-		EntityManagerFactory entityManagerFactory = null;
-		Filter filter = null;
-
-		try {
-			filter = createServiceFilter(EntityManagerFactory.class
-					.getName(), createFilterProperties(persistenceUnit));
-		} catch (InvalidSyntaxException e) {
-			e.printStackTrace();
-			logger.error("InvalidSyntaxException:" + e.getMessage());
-
-			return null;
-		}
-
-		try {
-			entityManagerFactory = (EntityManagerFactory) getServiceFromRegistry(
-					Activator.getBundleContext(), filter);
-		} catch (InterruptedException e) {
-			e.printStackTrace();
-			logger.error("InterruptedException:" + e.getMessage());
-		}
-
-		return entityManagerFactory;
-	}
-
-	public EntityManagerFactory waitForEntityManager(String persistenceUnit) {
-		int MAX_RETRIES = 10;
-		boolean active = false;
-
-		for (int i = 0; i < MAX_RETRIES; i++) {
-			EntityManagerFactory entityManagerFactory = getEntityManagerFactoryFromOSGiRegistry(persistenceUnit);
-			active = (null != entityManagerFactory);
-			if (active == true) {
-				return entityManagerFactory;
-			}
-			logger.info("Waiting for the activation of Entity Manager");
-			try {
-				Thread.sleep(1000);
-			} catch (InterruptedException ex) {
-				ex.printStackTrace();
-			}
-		}
-		return null;
-	}
-
-	private Properties createFilterProperties(String persistenceUnit) {
-		Properties properties = new Properties();
-		properties.setProperty("osgi.unit.name", persistenceUnit);
-		properties.setProperty("org.apache.aries.jpa.container.managed", "true");
-		return properties;
-	}
-
-	private Filter createServiceFilter(String clazz, Properties properties) throws InvalidSyntaxException {
-		StringBuilder query = new StringBuilder();
-		query.append("(&");
-		query.append("(").append(Constants.OBJECTCLASS).append("=").append(clazz).append(")");
-		for (String key : properties.stringPropertyNames()) {
-			String value = properties.getProperty(key);
-			query.append("(").append(key).append("=").append(value).append(")");
-		}
-		query.append(")");
-		return FrameworkUtil.createFilter(query.toString());
-	}
-
-	private Object getServiceFromRegistry(BundleContext bundleContext, Filter filter) throws InterruptedException {
-		ServiceTracker tracker = new ServiceTracker(bundleContext, filter, null);
-
-		tracker.open();
-		Object service = null;
-		logger.debug("Looking up Service from registry with properties: " + filter);
-		service = tracker.waitForService(10000);
-		tracker.close();
-
-		if (service != null) {
-			return service;
-		}
-
-		return null;
 	}
 }

--- a/core/security/pom.xml
+++ b/core/security/pom.xml
@@ -68,6 +68,7 @@
 					<instructions>
 						<Bundle-Activator>org.opennaas.core.security.Activator</Bundle-Activator>
 						<Import-Package>
+							javax.persistence,
 							javax.servlet,
 							javax.servlet.http,
 							net.sf.ehcache.exceptionhandler;version="${ehcache.version}",

--- a/core/security/src/main/java/org/opennaas/core/security/persistence/SecurityRepository.java
+++ b/core/security/src/main/java/org/opennaas/core/security/persistence/SecurityRepository.java
@@ -1,7 +1,5 @@
 package org.opennaas.core.security.persistence;
 
-import java.util.Properties;
-
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.PersistenceContext;
@@ -9,55 +7,43 @@ import javax.persistence.PersistenceContext;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.opennaas.core.persistence.PersistenceException;
-import org.opennaas.core.security.Activator;
-import org.osgi.framework.BundleContext;
-import org.osgi.framework.Constants;
-import org.osgi.framework.Filter;
-import org.osgi.framework.FrameworkUtil;
-import org.osgi.framework.InvalidSyntaxException;
-import org.osgi.util.tracker.ServiceTracker;
 import org.springframework.beans.factory.annotation.Required;
 
 /**
  * 
  * @author Julio Carlos Barrera
+ * @author Isart Canyameres Gimenez (i2cat)
  * 
  */
 public class SecurityRepository {
 
-	private static Log				log						= LogFactory.getLog(SecurityRepository.class);
+	private static Log				log	= LogFactory.getLog(SecurityRepository.class);
 
-	private EntityManagerFactory	entityManagerFactory	= null;
-	private String					persistenceUnit			= null;
+	private EntityManagerFactory	entityManagerFactory;
 	private EntityManager			entityManager;
 
 	public SecurityRepository() {
 	}
 
-	public void init() {
+	public void init() throws Exception {
 		try {
 			initializeEntityManager();
 		} catch (Exception e) {
 			log.error("Error initializing Security Persistence!", e);
+			throw e;
 		}
 	}
 
 	private void initializeEntityManager() throws Exception {
-		try {
-			/*
-			 * FIXME We have to find a better method to do this to get the entityManager. It tries 10 times to try to get the persistence. The
-			 * persistence bundle spends more time because it is to need the config file persistence.xml which it needs more time to finish it.
-			 */
-			entityManagerFactory = waitForEntityManager(persistenceUnit);
-			if (entityManagerFactory == null)
-				throw new PersistenceException();
 
-			log.debug("DESCRIPTION. Entity manager: " + entityManagerFactory);
-		} catch (PersistenceException e) {
-			log.debug("PersistenceException: " + e.getMessage());
-			throw new Exception(e);
+		if (getEntityManager() == null) {
+			if (getEntityManagerFactory() != null) {
+				setEntityManager(getEntityManagerFactory().createEntityManager());
+			}
 		}
-		setEntityManager(entityManagerFactory.createEntityManager());
+
+		if (getEntityManager() == null)
+			throw new PersistenceException("Required EntityManager is null");
 	}
 
 	public void close() {
@@ -70,86 +56,6 @@ public class SecurityRepository {
 		}
 	}
 
-	private EntityManagerFactory getEntityManagerFactoryFromOSGiRegistry(String persistenceUnit) {
-		EntityManagerFactory entityManagerFactory = null;
-		Filter filter = null;
-
-		try {
-			filter = createServiceFilter(EntityManagerFactory.class
-					.getName(), createFilterProperties(persistenceUnit));
-		} catch (InvalidSyntaxException e) {
-			e.printStackTrace();
-			log.error("InvalidSyntaxException:" + e.getMessage());
-
-			return null;
-		}
-
-		try {
-			entityManagerFactory = (EntityManagerFactory) getServiceFromRegistry(
-					Activator.getBundleContext(), filter);
-		} catch (InterruptedException e) {
-			e.printStackTrace();
-			log.error("InterruptedException:" + e.getMessage());
-		}
-
-		return entityManagerFactory;
-	}
-
-	public EntityManagerFactory waitForEntityManager(String persistenceUnit) {
-		int MAX_RETRIES = 10;
-		boolean active = false;
-
-		for (int i = 0; i < MAX_RETRIES; i++) {
-			EntityManagerFactory entityManagerFactory = getEntityManagerFactoryFromOSGiRegistry(persistenceUnit);
-			active = (null != entityManagerFactory);
-			if (active == true) {
-				return entityManagerFactory;
-			}
-			log.info("Waiting for the activation of Entity Manager");
-			try {
-				Thread.sleep(1000);
-			} catch (InterruptedException ex) {
-				ex.printStackTrace();
-			}
-		}
-		return null;
-	}
-
-	private Properties createFilterProperties(String persistenceUnit) {
-		Properties properties = new Properties();
-		properties.setProperty("osgi.unit.name", persistenceUnit);
-		properties.setProperty("org.apache.aries.jpa.container.managed", "true");
-		return properties;
-	}
-
-	private Filter createServiceFilter(String clazz, Properties properties) throws InvalidSyntaxException {
-		StringBuilder query = new StringBuilder();
-		query.append("(&");
-		query.append("(").append(Constants.OBJECTCLASS).append("=").append(clazz).append(")");
-		for (String key : properties.stringPropertyNames()) {
-			String value = properties.getProperty(key);
-			query.append("(").append(key).append("=").append(value).append(")");
-		}
-		query.append(")");
-		return FrameworkUtil.createFilter(query.toString());
-	}
-
-	private Object getServiceFromRegistry(BundleContext bundleContext, Filter filter) throws InterruptedException {
-		ServiceTracker tracker = new ServiceTracker(bundleContext, filter, null);
-
-		tracker.open();
-		Object service = null;
-		log.debug("Looking up Service from registry with properties: " + filter);
-		service = tracker.waitForService(10000);
-		tracker.close();
-
-		if (service != null) {
-			return service;
-		}
-
-		return null;
-	}
-
 	@Required
 	@PersistenceContext
 	public void setEntityManager(final EntityManager entityManager) {
@@ -160,8 +66,12 @@ public class SecurityRepository {
 		return entityManager;
 	}
 
-	public void setPersistenceUnit(String persistenceUnit) {
-		this.persistenceUnit = persistenceUnit;
+	public EntityManagerFactory getEntityManagerFactory() {
+		return entityManagerFactory;
+	}
+
+	public void setEntityManagerFactory(EntityManagerFactory entityManagerFactory) {
+		this.entityManagerFactory = entityManagerFactory;
 	}
 
 }

--- a/core/security/src/main/resources/META-INF/spring/security-context.xml
+++ b/core/security/src/main/resources/META-INF/spring/security-context.xml
@@ -194,36 +194,16 @@
 			value="org.springframework.security.acls.domain.BasePermission.READ" />
 	</bean>
 
-	<!-- Register OpenNaaS OSGi Services & Beans for Security -->
-
-	<!-- DataSourceSecurity bean -->
-	<bean id="dataSourceSecurity" class="org.apache.commons.dbcp.BasicDataSource"
-		destroy-method="close">
-		<property name="driverClassName" value="org.hsqldb.jdbcDriver" />
-		<property name="url"
-			value="jdbc:hsqldb:file:databases/security/security_db;hsqldb.default_table_type=cached;shutdown=true" />
-		<property name="username" value="sa" />
-		<property name="password" value="" />
-	</bean>
-
-	<!-- DataSourceSecurity exported as OSGi service -->
-	<osgi:service ref="dataSourceSecurity" interface="javax.sql.DataSource">
-		<osgi:service-properties>
-			<entry key="osgi.jndi.service.name" value="jdbc/opennaas-security" />
-		</osgi:service-properties>
-	</osgi:service>
-
-	<!-- SecurityRepository bean -->
-	<bean id="securityRepository"
-		class="org.opennaas.core.security.persistence.SecurityRepository"
-		init-method="init" destroy-method="close">
-		<property name="persistenceUnit" value="opennaas-security" />
-	</bean>
+	<!-- Get a dataSourceSecurity reference, used in aclService -->
+	<osgi:reference id="dataSourceSecurity" interface="javax.sql.DataSource" filter="(osgi.jndi.service.name=jdbc/opennaas-security)"/>
+	
+	<!-- Get a SecurityRepository reference, used in aclManager -->
+	<osgi:reference id="securityRepositoryService" interface="org.opennaas.core.security.persistence.SecurityRepository" />
 
 	<!-- ACLManager bean -->
 	<bean id="aclManager" class="org.opennaas.core.security.acl.ACLManager"
 		init-method="init">
-		<property name="securityRepository" ref="securityRepository" />
+		<property name="securityRepository" ref="securityRepositoryService" />
 		<property name="aclService" ref="aclService" />
 		<property name="permissionEvaluator" ref="permissionEvaluator" />
 		<property name="usersPropertiesFile" value="users" />

--- a/core/security/src/main/resources/OSGI-INF/blueprint/core.xml
+++ b/core/security/src/main/resources/OSGI-INF/blueprint/core.xml
@@ -2,10 +2,8 @@
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0"
-	xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0
-						http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd 
- 						http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0 
-						http://aries.apache.org/schemas/blueprint-cm/blueprint-cm-1.1.0.xsd">
+	xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0	http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd 
+						http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0 	http://aries.apache.org/schemas/blueprint-cm/blueprint-cm-1.1.0.xsd">
 
 	<cm:property-placeholder persistent-id="org.opennaas"
 		update-strategy="reload" />
@@ -27,10 +25,16 @@
 		</service-properties>
 	</service>
 
+	<!-- Workaround for  https://issues.apache.org/jira/browse/ARIES-796:
+	Resolve and inject entityManagerFactory and get the entityManager using code in securityEntityManagerFactory. 
+	Obtained entityManager is not container managed, then. 
+	Given unit MUST already be registered as an OSGi service for this to work. -->
+	<reference id="securityEntityManagerFactory" interface="javax.persistence.EntityManagerFactory" filter="(osgi.unit.name=opennaas-security)"/>
 	<bean id="securityRepository"
 		class="org.opennaas.core.security.persistence.SecurityRepository"
 		init-method="init" destroy-method="close">
-		<property name="persistenceUnit" value="opennaas-security" />
+		<property name="entityManagerFactory" ref="securityEntityManagerFactory" />
 	</bean>
+	<service ref="securityRepository" interface="org.opennaas.core.security.persistence.SecurityRepository" />
 
 </blueprint>

--- a/extensions/bundles/bod.repository/pom.xml
+++ b/extensions/bundles/bod.repository/pom.xml
@@ -43,7 +43,7 @@
 				-->
 				<configuration>
 					<instructions>
-						<Import-Package>org.slf4j,*</Import-Package>
+						<Import-Package>org.slf4j,javax.persistence,*</Import-Package>
 						<!--<Export-Package>org.opennaas.extensions.router.repository.*;version="${project.version}"</Export-Package>-->
 					</instructions>
 				</configuration>

--- a/extensions/bundles/bod.repository/src/main/resources/OSGI-INF/blueprint/core.xml
+++ b/extensions/bundles/bod.repository/src/main/resources/OSGI-INF/blueprint/core.xml
@@ -1,12 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
+
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
 	<!-- Build the bootstrapper -->
 	<bean id="bodBootstrapperFactory" class="org.opennaas.extensions.bod.repository.BoDBootstrapperFactory"/>
-    <bean id="resourceDescriptorRepository"
-          class="org.opennaas.core.resources.descriptor.ResourceDescriptorRepository"
-          init-method="initializeEntityManager" destroy-method="close">
-         <property name="persistenceUnit" value="ResourceCore"/>
-    </bean>
+	<!-- Workaround for  https://issues.apache.org/jira/browse/ARIES-796:
+	Resolve and inject entityManagerFactory and get the entityManager using code in ResourceDescriptorRepository. 
+	Obtained entityManager is not container managed, then. 
+	Given unit MUST already be registered as an OSGi service for this to work. -->
+	<reference id="entityManagerFactory" interface="javax.persistence.EntityManagerFactory" filter="(osgi.unit.name=ResourceCore)"/>
+	<bean id="resourceDescriptorRepository"
+	class="org.opennaas.core.resources.descriptor.ResourceDescriptorRepository"
+	init-method="initializeEntityManager" destroy-method="close">
+		<property name="entityManagerFactory" ref="entityManagerFactory" />
+	</bean>
 	<bean id="bodRepository" class="org.opennaas.extensions.bod.repository.BoDRepository" init-method="init">
 		<argument value="bod"/>
 		<property name="resourceDescriptorRepository" ref="resourceDescriptorRepository"/>
@@ -22,7 +28,4 @@
 			<entry key="version" value="1.0.0"/>
 		</service-properties>
 	</service>
-	
-	<!-- Forces this bundle to wait for dataSourceResources being published -->
-	<reference id="dataSourceResources" interface="javax.sql.DataSource" filter="(osgi.jndi.service.name=jdbc/opennaas-resources)"/>	
 </blueprint>

--- a/extensions/bundles/macbridge.ios.resource/pom.xml
+++ b/extensions/bundles/macbridge.ios.resource/pom.xml
@@ -62,6 +62,10 @@
 				<configuration>
 					<instructions>
 						<!--  TODO Is it necessary to check the org.opennaas.extensions.router.junos.actionssets.actions -->
+						<Import-Package>
+							javax.persistence,
+							*
+						</Import-Package>
 						<Export-Package>
 							   org.opennaas.extensions.macbridge.ios.resource.commandsets.*;version="${project.version}",
              				   org.opennaas.extensions.macbridge.ios.resource.actionssets.*;version="${project.version}",

--- a/extensions/bundles/macbridge.ios.resource/src/main/resources/OSGI-INF/blueprint/core.xml
+++ b/extensions/bundles/macbridge.ios.resource/src/main/resources/OSGI-INF/blueprint/core.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
 	<!--  	publish action set services  -->
 	<bean id="VLANAwareBridgeActionSet" class="org.opennaas.extensions.macbridge.ios.resource.actionssets.VLANAwareBridgeActionSet"/>
@@ -27,11 +28,16 @@
 	<bean id="macBridgeIOSBootstrapperFactory" class="org.opennaas.extensions.macbridge.ios.resource.repository.MACBridgeIOSBootstrapperFactory"/>
 	<reference id="queueCapabilityFactory" interface="org.opennaas.core.resources.capability.ICapabilityFactory" filter="(&amp;(capability=queue)(capability.model=junos))"/>
 	<reference id="vlanAwareBridgeCapabilityFactory" interface="org.opennaas.core.resources.capability.ICapabilityFactory" filter="(&amp;(capability=VLANAwareBridge))"/>
-    <bean id="resourceDescriptorRepository"
-          class="org.opennaas.core.resources.descriptor.ResourceDescriptorRepository"
-          init-method="initializeEntityManager" destroy-method="close">
-         <property name="persistenceUnit" value="ResourceCore"/>
-    </bean>
+	<!-- Workaround for  https://issues.apache.org/jira/browse/ARIES-796:
+	Resolve and inject entityManagerFactory and get the entityManager using code in ResourceDescriptorRepository. 
+	Obtained entityManager is not container managed, then. 
+	Given unit MUST already be registered as an OSGi service for this to work. -->
+	<reference id="entityManagerFactory" interface="javax.persistence.EntityManagerFactory" filter="(osgi.unit.name=ResourceCore)"/>
+	<bean id="resourceDescriptorRepository"
+	class="org.opennaas.core.resources.descriptor.ResourceDescriptorRepository"
+	init-method="initializeEntityManager" destroy-method="close">
+		<property name="entityManagerFactory" ref="entityManagerFactory" />
+	</bean>
 	<bean id="MACBridgeIOSRepository" class="org.opennaas.extensions.macbridge.ios.resource.repository.MACBridgeIOSRepository" init-method="init">
 		<argument value="MACBridgeIOS"/>
 		<!-- resourceType -->
@@ -50,7 +56,4 @@
 			<entry key="version" value="1.0"/>
 		</service-properties>
 	</service>
-	<!-- Forces this bundle to wait for dataSourceResources being published -->
-	<reference id="dataSourceResources" interface="javax.sql.DataSource" filter="(osgi.jndi.service.name=jdbc/opennaas-resources)"/>
-	
 </blueprint>

--- a/extensions/bundles/network.repository/pom.xml
+++ b/extensions/bundles/network.repository/pom.xml
@@ -44,7 +44,7 @@
 				<configuration>
 					<instructions>
 						<Bundle-Activator>org.opennaas.extensions.network.repository.Activator</Bundle-Activator>
-						<Import-Package>org.slf4j,*</Import-Package>
+						<Import-Package>org.slf4j,javax.persistence,*</Import-Package>
 						<!--<Export-Package>
 						org.opennaas.extensions.router.repository.*;version="${project.version}"
 						</Export-Package>-->

--- a/extensions/bundles/network.repository/src/main/resources/OSGI-INF/blueprint/core.xml
+++ b/extensions/bundles/network.repository/src/main/resources/OSGI-INF/blueprint/core.xml
@@ -2,11 +2,16 @@
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
 	<!-- Build the bootstrapper -->
 	<bean id="networkBootstrapperFactory" class="org.opennaas.extensions.network.repository.NetworkBootstrapperFactory"/>
-    <bean id="resourceDescriptorRepository"
-          class="org.opennaas.core.resources.descriptor.ResourceDescriptorRepository"
-          init-method="initializeEntityManager" destroy-method="close">
-         <property name="persistenceUnit" value="ResourceCore"/>
-    </bean>
+	<!-- Workaround for  https://issues.apache.org/jira/browse/ARIES-796:
+	Resolve and inject entityManagerFactory and get the entityManager using code in ResourceDescriptorRepository. 
+	Obtained entityManager is not container managed, then. 
+	Given unit MUST already be registered as an OSGi service for this to work. -->
+	<reference id="entityManagerFactory" interface="javax.persistence.EntityManagerFactory" filter="(osgi.unit.name=ResourceCore)"/>
+	<bean id="resourceDescriptorRepository"
+	class="org.opennaas.core.resources.descriptor.ResourceDescriptorRepository"
+	init-method="initializeEntityManager" destroy-method="close">
+		<property name="entityManagerFactory" ref="entityManagerFactory" />
+	</bean>
 	<bean id="networkRepository" class="org.opennaas.extensions.network.repository.NetworkRepository" init-method="init">
 		<argument value="network"/>
 		<property name="resourceDescriptorRepository" ref="resourceDescriptorRepository"/>
@@ -22,6 +27,4 @@
 			<entry key="version" value="1.0.0"/>
 		</service-properties>
 	</service>
-	<!-- Forces this bundle to wait for dataSourceResources being published -->
-	<reference id="dataSourceResources" interface="javax.sql.DataSource" filter="(osgi.jndi.service.name=jdbc/opennaas-resources)"/>
 </blueprint>

--- a/extensions/bundles/openflowswitch/pom.xml
+++ b/extensions/bundles/openflowswitch/pom.xml
@@ -1,25 +1,23 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <parent>
-    <groupId>org.opennaas</groupId>
-    <artifactId>org.opennaas.extensions.bundles</artifactId>
-    <version>0.25-SNAPSHOT</version>
-  </parent>
-  <artifactId>org.opennaas.extensions.openflowswitch</artifactId>
-  	<!--  Maven configuration -->
-  	<packaging>bundle</packaging>
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.opennaas</groupId>
+		<artifactId>org.opennaas.extensions.bundles</artifactId>
+		<version>0.25-SNAPSHOT</version>
+	</parent>
+	
+	<artifactId>org.opennaas.extensions.openflowswitch</artifactId>
+	<!--  Maven configuration -->
+	<packaging>bundle</packaging>
 	<name>OpenNaaS :: OpenFlow Switch </name>
 	<description>OpenFLow Switch Resource Implementation</description>
 
- 	<dependencies>
+	<dependencies>
 		<dependency>
 			<groupId>org.opennaas</groupId>
 			<artifactId>org.opennaas.core.resources</artifactId>
 		</dependency>
-
-
-				
- 	</dependencies>
+	</dependencies>
 
 	<build>
 		<plugins>
@@ -37,12 +35,11 @@
 				-->
 				<configuration>
 					<instructions>
-						<Bundle-Activator>org.opennaas.extensions.openflowswitch.repository.Activator</Bundle-Activator>	
+						<Bundle-Activator>org.opennaas.extensions.openflowswitch.repository.Activator</Bundle-Activator>
+						<Import-Package>javax.persistence,*</Import-Package>
 					</instructions>
 				</configuration>
 			</plugin>
 		</plugins>
 	</build>
-
-
 </project>

--- a/extensions/bundles/openflowswitch/src/main/resources/OSGI-INF/blueprint/core.xml
+++ b/extensions/bundles/openflowswitch/src/main/resources/OSGI-INF/blueprint/core.xml
@@ -3,12 +3,16 @@
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
 	<!-- Build the bootstrapper -->
 	<bean id="openflowSwitchBootstrapperFactory" class="org.opennaas.extensions.openflowswitch.repository.OpenflowSwitchBootstrapperFactory"/>
-    <bean id="resourceDescriptorRepository"
-          class="org.opennaas.core.resources.descriptor.ResourceDescriptorRepository"
-          init-method="initializeEntityManager" destroy-method="close">
-         <property name="persistenceUnit" value="ResourceCore"/>
-    </bean>	
- 
+	<!-- Workaround for  https://issues.apache.org/jira/browse/ARIES-796:
+	Resolve and inject entityManagerFactory and get the entityManager using code in ResourceDescriptorRepository. 
+	Obtained entityManager is not container managed, then. 
+	Given unit MUST already be registered as an OSGi service for this to work. -->
+	<reference id="entityManagerFactory" interface="javax.persistence.EntityManagerFactory" filter="(osgi.unit.name=ResourceCore)"/>
+	<bean id="resourceDescriptorRepository"
+	class="org.opennaas.core.resources.descriptor.ResourceDescriptorRepository"
+	init-method="initializeEntityManager" destroy-method="close">
+		<property name="entityManagerFactory" ref="entityManagerFactory" />
+	</bean>
  	<bean id="openflowSwitchRepository" class="org.opennaas.extensions.openflowswitch.repository.OpenflowSwitchRepository"
           init-method="init">
 		<argument value="openflowswitch"/>
@@ -39,9 +43,5 @@
 			<entry key="capability.model" value="openflowswitch"/>
 			<entry key="capability.version" value="1.0.0"/>
 		</service-properties>
-	</service>	
-	
-	<!-- Forces this bundle to wait for dataSourceResources being published -->
-	<reference id="dataSourceResources" interface="javax.sql.DataSource" filter="(osgi.jndi.service.name=jdbc/opennaas-resources)"/>	
-	
+	</service>
 </blueprint>

--- a/extensions/bundles/pdu/pom.xml
+++ b/extensions/bundles/pdu/pom.xml
@@ -46,6 +46,7 @@
 					<instructions>
 						<Bundle-Activator>org.opennaas.extensions.pdu.Activator</Bundle-Activator>
 						<Import-Package>
+							javax.persistence,
 							org.slf4j,
 							org.opennaas.extensions.gim.controller.capabilities;version="${opennaas.gim.version}",
 							org.opennaas.extensions.gim.controller.snmp;version="${opennaas.gim.version}",

--- a/extensions/bundles/pdu/src/main/resources/OSGI-INF/blueprint/core.xml
+++ b/extensions/bundles/pdu/src/main/resources/OSGI-INF/blueprint/core.xml
@@ -17,11 +17,16 @@
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
 	<!-- Build the bootstrapper -->
 	<bean id="pduBootstrapperFactory" class="org.opennaas.extensions.pdu.repository.PDUResourceBootstrapperFactory"/>
-    <bean id="resourceDescriptorRepository"
-          class="org.opennaas.core.resources.descriptor.ResourceDescriptorRepository"
-          init-method="initializeEntityManager" destroy-method="close">
-         <property name="persistenceUnit" value="ResourceCore"/>
-    </bean>
+	<!-- Workaround for  https://issues.apache.org/jira/browse/ARIES-796:
+	Resolve and inject entityManagerFactory and get the entityManager using code in ResourceDescriptorRepository. 
+	Obtained entityManager is not container managed, then. 
+	Given unit MUST already be registered as an OSGi service for this to work. -->
+	<reference id="entityManagerFactory" interface="javax.persistence.EntityManagerFactory" filter="(osgi.unit.name=ResourceCore)"/>
+	<bean id="resourceDescriptorRepository"
+	class="org.opennaas.core.resources.descriptor.ResourceDescriptorRepository"
+	init-method="initializeEntityManager" destroy-method="close">
+		<property name="entityManagerFactory" ref="entityManagerFactory" />
+	</bean>
 	<bean id="pduRepository" class="org.opennaas.extensions.pdu.repository.PDUResourceRepository" init-method="init">
 		<argument value="pdu"/>
 		<property name="resourceDescriptorRepository" ref="resourceDescriptorRepository"/>
@@ -76,10 +81,6 @@
 		</service-properties>
 	</service>
 	
-	
-	<!-- Forces this bundle to wait for dataSourceResources being published -->
-	<reference id="dataSourceResources" interface="javax.sql.DataSource" filter="(osgi.jndi.service.name=jdbc/opennaas-resources)"/>	
-
 	<!-- Command completers -->
 	<reference id="resourceNameCompleter" interface="org.apache.karaf.shell.console.Completer" filter="(completer.name=resourceNameCompleter)"/>
 	<!-- Provide commands to the Karaf shell -->

--- a/extensions/bundles/powernet/pom.xml
+++ b/extensions/bundles/powernet/pom.xml
@@ -41,7 +41,7 @@
 				<configuration>
 					<instructions>
 						<Bundle-Activator>org.opennaas.extensions.powernet.Activator</Bundle-Activator>
-						<Import-Package>org.slf4j,*</Import-Package>
+						<Import-Package>org.slf4j,javax.persistence,*</Import-Package>
 						<Export-Package>
 							org.opennaas.extensions.powernet.capability.mgt;version="${project.version}",
 							org.opennaas.extensions.powernet.model;version="${project.version}"

--- a/extensions/bundles/powernet/src/main/resources/OSGI-INF/blueprint/core.xml
+++ b/extensions/bundles/powernet/src/main/resources/OSGI-INF/blueprint/core.xml
@@ -17,11 +17,16 @@
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
 	<!-- Build the bootstrapper -->
 	<bean id="powernetBootstrapperFactory" class="org.opennaas.extensions.powernet.repository.PowerNetResourceBootstrapperFactory"/>
-    <bean id="resourceDescriptorRepository"
-          class="org.opennaas.core.resources.descriptor.ResourceDescriptorRepository"
-          init-method="initializeEntityManager" destroy-method="close">
-         <property name="persistenceUnit" value="ResourceCore"/>
-    </bean>
+	<!-- Workaround for  https://issues.apache.org/jira/browse/ARIES-796:
+	Resolve and inject entityManagerFactory and get the entityManager using code in ResourceDescriptorRepository. 
+	Obtained entityManager is not container managed, then. 
+	Given unit MUST already be registered as an OSGi service for this to work. -->
+	<reference id="entityManagerFactory" interface="javax.persistence.EntityManagerFactory" filter="(osgi.unit.name=ResourceCore)"/>
+	<bean id="resourceDescriptorRepository"
+	class="org.opennaas.core.resources.descriptor.ResourceDescriptorRepository"
+	init-method="initializeEntityManager" destroy-method="close">
+		<property name="entityManagerFactory" ref="entityManagerFactory" />
+	</bean>
 	<bean id="powernetRepository" class="org.opennaas.extensions.powernet.repository.PowerNetResourceRepository" init-method="init">
 		<argument value="powernet"/>
 		<property name="resourceDescriptorRepository" ref="resourceDescriptorRepository"/>
@@ -37,9 +42,6 @@
 			<entry key="version" value="1.0.0"/>
 		</service-properties>
 	</service>
-	
-	<!-- Forces this bundle to wait for dataSourceResources being published -->
-	<reference id="dataSourceResources" interface="javax.sql.DataSource" filter="(osgi.jndi.service.name=jdbc/opennaas-resources)"/>	
 
 	<!-- Factory that creates protocol capabilities -->
 	<bean id="exampleCapabilityFactory" class="org.opennaas.extensions.powernet.capability.mgt.PowerNetManagementCapabilityFactory">

--- a/extensions/bundles/quantum/pom.xml
+++ b/extensions/bundles/quantum/pom.xml
@@ -72,6 +72,7 @@
 					<instructions>
 						<Bundle-Activator>org.opennaas.extensions.quantum.Activator</Bundle-Activator>
 						<Import-Package>
+							javax.persistence,
 							org.slf4j,
 							*
 						</Import-Package>

--- a/extensions/bundles/quantum/src/main/resources/OSGI-INF/blueprint/core.xml
+++ b/extensions/bundles/quantum/src/main/resources/OSGI-INF/blueprint/core.xml
@@ -18,12 +18,17 @@
 	<!-- Build the bootstrapper -->
 	<bean id="quantumresourceBootstrapperFactory" class="org.opennaas.extensions.quantum.repository.QuantumResourceBootstrapperFactory"/>
 	
-    <bean id="resourceDescriptorRepository"
-          class="org.opennaas.core.resources.descriptor.ResourceDescriptorRepository"
-          init-method="initializeEntityManager" destroy-method="close">
-         <property name="persistenceUnit" value="ResourceCore"/>
-    </bean>
-    
+	<!-- Workaround for  https://issues.apache.org/jira/browse/ARIES-796:
+	Resolve and inject entityManagerFactory and get the entityManager using code in ResourceDescriptorRepository. 
+	Obtained entityManager is not container managed, then. 
+	Given unit MUST already be registered as an OSGi service for this to work. -->
+	<reference id="entityManagerFactory" interface="javax.persistence.EntityManagerFactory" filter="(osgi.unit.name=ResourceCore)"/>
+	<bean id="resourceDescriptorRepository"
+	class="org.opennaas.core.resources.descriptor.ResourceDescriptorRepository"
+	init-method="initializeEntityManager" destroy-method="close">
+		<property name="entityManagerFactory" ref="entityManagerFactory" />
+	</bean>
+
 	<bean id="quantumresourceRepository" class="org.opennaas.extensions.quantum.repository.QuantumResourceRepository" init-method="init">
 		<argument value="quantumresource"/>
 		<property name="resourceDescriptorRepository" ref="resourceDescriptorRepository"/>
@@ -42,9 +47,6 @@
 		</service-properties>
 	</service>
 	
-	<!-- Forces this bundle to wait for dataSourceResources being published -->
-	<reference id="dataSourceResources" interface="javax.sql.DataSource" filter="(osgi.jndi.service.name=jdbc/opennaas-resources)"/>	
-
 	<!-- Factory that creates protocol capabilities -->
 	<bean id="quantumAPIV2CapabilityFactory" class="org.opennaas.extensions.quantum.capability.apiv2.QuantumAPIV2CapabilityFactory">
 		<property name="type" value="quantum-apiv2"/>

--- a/extensions/bundles/roadm.repository/pom.xml
+++ b/extensions/bundles/roadm.repository/pom.xml
@@ -43,7 +43,7 @@
 				-->
 				<configuration>
 					<instructions>
-						<Import-Package>org.slf4j,*</Import-Package>
+						<Import-Package>javax.persistence,org.slf4j,*</Import-Package>
 						<!--<Export-Package>org.opennaas.extensions.router.repository.*;version="${project.version}"</Export-Package>-->
 					</instructions>
 				</configuration>

--- a/extensions/bundles/roadm.repository/src/main/resources/OSGI-INF/blueprint/core.xml
+++ b/extensions/bundles/roadm.repository/src/main/resources/OSGI-INF/blueprint/core.xml
@@ -13,11 +13,16 @@
 	<reference id="queueCapabilityFactory" interface="org.opennaas.core.resources.capability.ICapabilityFactory" filter="(&amp;(capability=queue)(capability.model=junos))"/>
 	<reference id="connectionsCapabilityFactory" interface="org.opennaas.core.resources.capability.ICapabilityFactory" filter="(&amp;(capability=connections)(capability.model=proteus))"/>
 	<reference id="monitoringCapabilityFactory" interface="org.opennaas.core.resources.capability.ICapabilityFactory" filter="(&amp;(capability=monitoring)(capability.model=proteus))"/>
-    <bean id="resourceDescriptorRepository"
-          class="org.opennaas.core.resources.descriptor.ResourceDescriptorRepository"
-          init-method="initializeEntityManager" destroy-method="close">
-         <property name="persistenceUnit" value="ResourceCore"/>
-    </bean>
+	<!-- Workaround for  https://issues.apache.org/jira/browse/ARIES-796:
+	Resolve and inject entityManagerFactory and get the entityManager using code in ResourceDescriptorRepository. 
+	Obtained entityManager is not container managed, then. 
+	Given unit MUST already be registered as an OSGi service for this to work. -->
+	<reference id="entityManagerFactory" interface="javax.persistence.EntityManagerFactory" filter="(osgi.unit.name=ResourceCore)"/>
+	<bean id="resourceDescriptorRepository"
+	class="org.opennaas.core.resources.descriptor.ResourceDescriptorRepository"
+	init-method="initializeEntityManager" destroy-method="close">
+		<property name="entityManagerFactory" ref="entityManagerFactory" />
+	</bean>
 	<bean id="ROADMRepository" class="org.opennaas.extensions.roadm.repository.ROADMRepository" init-method="init">
 		<argument value="roadm"/>
 		<!-- resourceType -->
@@ -37,6 +42,4 @@
 			<entry key="version" value="1.0"/>
 		</service-properties>
 	</service>
-	<!-- Forces this bundle to wait for dataSourceResources being published -->
-	<reference id="dataSourceResources" interface="javax.sql.DataSource" filter="(osgi.jndi.service.name=jdbc/opennaas-resources)"/>
 </blueprint>

--- a/extensions/bundles/router.repository/pom.xml
+++ b/extensions/bundles/router.repository/pom.xml
@@ -48,7 +48,7 @@
 				<configuration>
 					<instructions>
 						<Bundle-Activator>org.opennaas.extensions.router.repository.Activator</Bundle-Activator>
-						<Import-Package>org.slf4j,*</Import-Package>
+						<Import-Package>org.slf4j,javax.persistence,*</Import-Package>
 						<!--<Export-Package>
 						org.opennaas.extensions.router.repository.*;version="${project.version}"
 						</Export-Package>-->

--- a/extensions/bundles/router.repository/src/main/resources/OSGI-INF/blueprint/core.xml
+++ b/extensions/bundles/router.repository/src/main/resources/OSGI-INF/blueprint/core.xml
@@ -1,14 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
 	<!-- Build the bootstrapper -->
 	<bean id="mantychoreBootstrapperFactory" class="org.opennaas.extensions.router.repository.MantychoreBootstrapperFactory"/>
-    <bean id="resourceDescriptorRepository"
-          class="org.opennaas.core.resources.descriptor.ResourceDescriptorRepository"
-          init-method="initializeEntityManager" destroy-method="close">
-         <property name="persistenceUnit" value="ResourceCore"/>
-    </bean>
-	<bean id="mantychoreRepository" class="org.opennaas.extensions.router.repository.MantychoreRepository"
-          init-method="init">
+	<!-- Workaround for  https://issues.apache.org/jira/browse/ARIES-796:
+	Resolve and inject entityManagerFactory and get the entityManager using code in ResourceDescriptorRepository. 
+	Obtained entityManager is not container managed, then. 
+	Given unit MUST already be registered as an OSGi service for this to work. -->
+	<reference id="entityManagerFactory" interface="javax.persistence.EntityManagerFactory" filter="(osgi.unit.name=ResourceCore)"/>
+	<bean id="resourceDescriptorRepository"
+	class="org.opennaas.core.resources.descriptor.ResourceDescriptorRepository"
+	init-method="initializeEntityManager" destroy-method="close">
+		<property name="entityManagerFactory" ref="entityManagerFactory" />
+	</bean>
+	<bean id="mantychoreRepository" class="org.opennaas.extensions.router.repository.MantychoreRepository" init-method="init">
 		<argument value="router"/>
 		<property name="resourceDescriptorRepository" ref="resourceDescriptorRepository"/>
 		<property name="resourceBootstrapperFactory" ref="mantychoreBootstrapperFactory"/>
@@ -23,6 +28,4 @@
 			<entry key="version" value="1.0.0"/>
 		</service-properties>
 	</service>
-	<!-- Forces this bundle to wait for dataSourceResources being published -->
-	<reference id="dataSourceResources" interface="javax.sql.DataSource" filter="(osgi.jndi.service.name=jdbc/opennaas-resources)"/>
 </blueprint>

--- a/extensions/bundles/sampleresource/pom.xml
+++ b/extensions/bundles/sampleresource/pom.xml
@@ -42,7 +42,7 @@
 				<configuration>
 					<instructions>
 						<Bundle-Activator>org.opennaas.extensions.sampleresource.capability.example.Activator</Bundle-Activator>
-						<Import-Package>org.slf4j,*</Import-Package>
+						<Import-Package>javax.persistence,org.slf4j,*</Import-Package>
 						<Export-Package>
 							org.opennaas.extensions.sampleresource.capability.example;version="${project.version}"
 						</Export-Package>

--- a/extensions/bundles/sampleresource/src/main/resources/OSGI-INF/blueprint/core.xml
+++ b/extensions/bundles/sampleresource/src/main/resources/OSGI-INF/blueprint/core.xml
@@ -17,11 +17,16 @@
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
 	<!-- Build the bootstrapper -->
 	<bean id="sampleresourceBootstrapperFactory" class="org.opennaas.extensions.sampleresource.repository.SampleResourceBootstrapperFactory"/>
-    <bean id="resourceDescriptorRepository"
-          class="org.opennaas.core.resources.descriptor.ResourceDescriptorRepository"
-          init-method="initializeEntityManager" destroy-method="close">
-         <property name="persistenceUnit" value="ResourceCore"/>
-    </bean>
+	<!-- Workaround for  https://issues.apache.org/jira/browse/ARIES-796:
+	Resolve and inject entityManagerFactory and get the entityManager using code in ResourceDescriptorRepository. 
+	Obtained entityManager is not container managed, then. 
+	Given unit MUST already be registered as an OSGi service for this to work. -->
+	<reference id="entityManagerFactory" interface="javax.persistence.EntityManagerFactory" filter="(osgi.unit.name=ResourceCore)"/>
+	<bean id="resourceDescriptorRepository"
+	class="org.opennaas.core.resources.descriptor.ResourceDescriptorRepository"
+	init-method="initializeEntityManager" destroy-method="close">
+		<property name="entityManagerFactory" ref="entityManagerFactory" />
+	</bean>
 	<bean id="sampleresourceRepository" class="org.opennaas.extensions.sampleresource.repository.SampleResourceRepository" init-method="init">
 		<argument value="sampleresource"/>
 		<property name="resourceDescriptorRepository" ref="resourceDescriptorRepository"/>
@@ -38,9 +43,6 @@
 		</service-properties>
 	</service>
 	
-	<!-- Forces this bundle to wait for dataSourceResources being published -->
-	<reference id="dataSourceResources" interface="javax.sql.DataSource" filter="(osgi.jndi.service.name=jdbc/opennaas-resources)"/>	
-
 	<!-- Factory that creates protocol capabilities -->
 	<bean id="exampleCapabilityFactory" class="org.opennaas.extensions.sampleresource.capability.example.ExampleCapabilityFactory">
 		<property name="type" value="example"/>

--- a/extensions/bundles/sdnnetwork/pom.xml
+++ b/extensions/bundles/sdnnetwork/pom.xml
@@ -39,6 +39,7 @@
 						<Bundle-Activator>org.opennaas.extensions.sdnnetwork.Activator</Bundle-Activator>
 						<Import-Package>
 							!org.opennaas.extensions.sdnnetwork.*,
+							javax.persistence,
 							*
 						</Import-Package>
 					</instructions>

--- a/extensions/bundles/sdnnetwork/src/main/resources/OSGI-INF/blueprint/core.xml
+++ b/extensions/bundles/sdnnetwork/src/main/resources/OSGI-INF/blueprint/core.xml
@@ -3,18 +3,23 @@
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
 	<!-- Build the bootstrapper -->
 	<bean id="bootstrapperFactory" class="org.opennaas.extensions.sdnnetwork.repository.SdnNetworkBootstrapperFactory"/>
-    <bean id="resourceDescriptorRepository"
-          class="org.opennaas.core.resources.descriptor.ResourceDescriptorRepository"
-          init-method="initializeEntityManager" destroy-method="close">
-         <property name="persistenceUnit" value="ResourceCore"/>
-    </bean>	
- 
- 	<bean id="sdnNetworkRepository" class="org.opennaas.extensions.sdnnetwork.repository.SdnNetworkRepository"
+	<!-- Workaround for  https://issues.apache.org/jira/browse/ARIES-796:
+	Resolve and inject entityManagerFactory and get the entityManager using code in ResourceDescriptorRepository. 
+	Obtained entityManager is not container managed, then. 
+	Given unit MUST already be registered as an OSGi service for this to work. -->
+	<reference id="entityManagerFactory" interface="javax.persistence.EntityManagerFactory" filter="(osgi.unit.name=ResourceCore)"/>
+	<bean id="resourceDescriptorRepository"
+	class="org.opennaas.core.resources.descriptor.ResourceDescriptorRepository"
+	init-method="initializeEntityManager" destroy-method="close">
+		<property name="entityManagerFactory" ref="entityManagerFactory" />
+	</bean>
+	
+	<bean id="sdnNetworkRepository" class="org.opennaas.extensions.sdnnetwork.repository.SdnNetworkRepository"
           init-method="init">
 		<argument value="sdnnetwork"/>
 		<property name="resourceDescriptorRepository" ref="resourceDescriptorRepository"/>
 		<property name="resourceBootstrapperFactory" ref="bootstrapperFactory"/>
-	</bean>   
+	</bean>
 	
 	<!-- Get capability factories from the OSGi registry -->
 	<reference-list id="capabilityFactory" interface="org.opennaas.core.resources.capability.ICapabilityFactory" availability="optional">
@@ -50,9 +55,5 @@
 			<entry key="actionset.capability" value="ofprovisionnet"/>
 			<entry key="actionset.version" value="1.0.0"/>
 		</service-properties>
-	</service>	
-	
-	<!-- Forces this bundle to wait for dataSourceResources being published -->
-	<reference id="dataSourceResources" interface="javax.sql.DataSource" filter="(osgi.jndi.service.name=jdbc/opennaas-resources)"/>	
-	
+	</service>
 </blueprint>

--- a/extensions/bundles/vcpe/pom.xml
+++ b/extensions/bundles/vcpe/pom.xml
@@ -88,6 +88,7 @@
 				<configuration>
 					<instructions>
 						<Bundle-Activator>org.opennaas.extensions.vcpe.Activator</Bundle-Activator>
+						<Import-Package>javax.persistence,*</Import-Package>
 						<Export-Package>
 							org.opennaas.extensions.vcpe.*;version="${project.version}"
 						</Export-Package>

--- a/extensions/bundles/vcpe/src/main/resources/OSGI-INF/blueprint/core.xml
+++ b/extensions/bundles/vcpe/src/main/resources/OSGI-INF/blueprint/core.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <blueprint 
-	xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0" 
+	xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0" 
     xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd 
@@ -39,13 +39,19 @@
 	
 	<!-- Build the bootstrapper -->
 	<bean id="vCPENetBootstrapperFactory" class="org.opennaas.extensions.vcpe.repository.VCPENetBootstrapperFactory"/>
-    <bean id="resourceDescriptorRepository"
-          class="org.opennaas.core.resources.descriptor.ResourceDescriptorRepository"
-          init-method="initializeEntityManager" destroy-method="close">
-         <property name="persistenceUnit" value="ResourceCore"/>
-    </bean>
-   
-    <!-- Build the repository -->
+	
+	<!-- Workaround for  https://issues.apache.org/jira/browse/ARIES-796:
+	Resolve and inject entityManagerFactory and get the entityManager using code in ResourceDescriptorRepository. 
+	Obtained entityManager is not container managed, then. 
+	Given unit MUST already be registered as an OSGi service for this to work. -->
+	<reference id="entityManagerFactory" interface="javax.persistence.EntityManagerFactory" filter="(osgi.unit.name=ResourceCore)"/>
+	<bean id="resourceDescriptorRepository"
+	class="org.opennaas.core.resources.descriptor.ResourceDescriptorRepository"
+	init-method="initializeEntityManager" destroy-method="close">
+		<property name="entityManagerFactory" ref="entityManagerFactory" />
+	</bean>
+	
+	<!-- Build the repository -->
 	<bean id="vCPENetRepository" class="org.opennaas.extensions.vcpe.repository.VCPENetRepository"
           init-method="init">
 		<argument value="vcpenet"/>
@@ -106,8 +112,4 @@
 			</completers>
 		</command>
 	</command-bundle>
-
-	
-	<!-- Forces this bundle to wait for dataSourceResources being published -->
-	<reference id="dataSourceResources" interface="javax.sql.DataSource" filter="(osgi.jndi.service.name=jdbc/opennaas-resources)"/>
 </blueprint>

--- a/extensions/bundles/vnmapper/pom.xml
+++ b/extensions/bundles/vnmapper/pom.xml
@@ -47,7 +47,7 @@
 				<configuration>
 					<instructions>
 						<Bundle-Activator>org.opennaas.extensions.vnmapper.capability.vnmapping.Activator</Bundle-Activator>
-						<Import-Package>org.slf4j,*</Import-Package>
+						<Import-Package>javax.persistence,org.slf4j,*</Import-Package>
 						<Export-Package>
 							org.opennaas.extensions.vnmapper.capability.vnmapping;version="${project.version}",
 							org.opennaas.extensions.vnmapper;version="${project.version}"

--- a/extensions/bundles/vnmapper/src/main/resources/OSGI-INF/blueprint/core.xml
+++ b/extensions/bundles/vnmapper/src/main/resources/OSGI-INF/blueprint/core.xml
@@ -17,11 +17,16 @@
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
 	<!-- Build the bootstrapper -->
 	<bean id="vnmapperResourceBootstrapperFactory" class="org.opennaas.extensions.vnmapper.repository.VNMapperResourceBootstrapperFactory"/>
-    <bean id="resourceDescriptorRepository"
-          class="org.opennaas.core.resources.descriptor.ResourceDescriptorRepository"
-          init-method="initializeEntityManager" destroy-method="close">
-         <property name="persistenceUnit" value="ResourceCore"/>
-    </bean>
+	<!-- Workaround for  https://issues.apache.org/jira/browse/ARIES-796:
+	Resolve and inject entityManagerFactory and get the entityManager using code in ResourceDescriptorRepository. 
+	Obtained entityManager is not container managed, then. 
+	Given unit MUST already be registered as an OSGi service for this to work. -->
+	<reference id="entityManagerFactory" interface="javax.persistence.EntityManagerFactory" filter="(osgi.unit.name=ResourceCore)"/>
+	<bean id="resourceDescriptorRepository"
+	class="org.opennaas.core.resources.descriptor.ResourceDescriptorRepository"
+	init-method="initializeEntityManager" destroy-method="close">
+		<property name="entityManagerFactory" ref="entityManagerFactory" />
+	</bean>
 	<bean id="vnmapperResourceRepository" class="org.opennaas.extensions.vnmapper.repository.VNMapperResourceRepository" init-method="init">
 		<argument value="vnmapper"/>
 		<property name="resourceDescriptorRepository" ref="resourceDescriptorRepository"/>
@@ -37,9 +42,6 @@
 			<entry key="version" value="1.0.0"/>
 		</service-properties>
 	</service>
-	
-	<!-- Forces this bundle to wait for dataSourceResources being published -->
-	<reference id="dataSourceResources" interface="javax.sql.DataSource" filter="(osgi.jndi.service.name=jdbc/opennaas-resources)"/>	
 
 	<!-- Factory that creates protocol capabilities -->
 	<bean id="vnmappingCapabilityFactory" class="org.opennaas.extensions.vnmapper.capability.vnmapping.VNMappingCapabilityFactory">


### PR DESCRIPTION
This patch changes the way GenericOSGiJpaRepository and SecurityRepository get an EntityManager.
Instead of looking up in the service registry for an EntityManagerFactory, this object is now injected at instantiation time.

Injection is specified in blueprint configuration files, by first resolving a reference to the EntityManagerFactory service,
and second injecting it as a property when instantiating each ResourceDescriptorReposiroty bean. The same is true for the SecurityRepository.

All bundles resolving a reference to the EntityManagerFactory must import javax.persistence package.
If the reference is in blueprint files, this import must be explicitely set in maven-bundle-plugin instructions in the bundle pom.xml, because the plugin does not inspect blueprint files.
All required poms have been updated with the new required import.

This patch also fixes a duplication of persistence related beans in org.opennaaas.core.security (same beans were instantiated in blueprint and spring-context.xml)
Persistence related beans and services are now instantiated and published by blueprint.
The spring-context.xml file resolves references to required persistence services using the osgi registry.

EntityManagerFactory creation and injection works as follows:
- A data source is specified in a persistence file.
- The data source is published as an OSGi service using javax.sql.DataSource interface and with osgi.jndi.service.name property set to the jdbc identifier of the DB.
- Apache Aries JPA (that listens to data sources being published as explained above) creates the EntityManagerFactory and publishes it as an OSGi service, with following properties:
  osgi.unit.name - this is the name of the persistence unit
  osgi.unit.provider - this is the class name of the JPA PersistenceProvider that was used to create the EntityManagerFactory
  org.apache.aries.jpa.container.managed - this property will be set to true, indicating this is a managed EntityManagerFactory.
- A reference to the EntityManagerFactory is obtained from the OSgi service registry using javax.persistence.EntityManagerFactory interface and properties above.
- The reference is injected in desired bean by blueprint.
  More information at https://aries.apache.org/modules/jpaproject.html
