### PR TITLE
NCLController accepts SDNNetworkFlow as parameter in allocateFlow().

### DIFF
--- a/extensions/bundles/ofertie.ncl/src/main/java/org/opennaas/extensions/ofertie/ncl/controller/NCLController.java
+++ b/extensions/bundles/ofertie.ncl/src/main/java/org/opennaas/extensions/ofertie/ncl/controller/NCLController.java
@@ -1,8 +1,6 @@
 package org.opennaas.extensions.ofertie.ncl.controller;
 
 import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
 
 import org.opennaas.core.resources.ActivatorException;
 import org.opennaas.core.resources.IResource;
@@ -10,12 +8,9 @@ import org.opennaas.core.resources.IResourceManager;
 import org.opennaas.core.resources.ResourceException;
 import org.opennaas.extensions.ofertie.ncl.Activator;
 import org.opennaas.extensions.ofertie.ncl.controller.api.INCLController;
-import org.opennaas.extensions.ofertie.ncl.helpers.FlowRequestParser;
 import org.opennaas.extensions.ofertie.ncl.provisioner.api.exceptions.FlowAllocationException;
-import org.opennaas.extensions.ofertie.ncl.provisioner.api.model.Flow;
-import org.opennaas.extensions.ofertie.ncl.provisioner.api.model.FlowRequest;
+import org.opennaas.extensions.ofertie.ncl.provisioner.api.exceptions.FlowRetrievalException;
 import org.opennaas.extensions.sdnnetwork.capability.ofprovision.IOFProvisioningNetworkCapability;
-import org.opennaas.extensions.sdnnetwork.model.Route;
 import org.opennaas.extensions.sdnnetwork.model.SDNNetworkOFFlow;
 
 /**
@@ -26,41 +21,15 @@ import org.opennaas.extensions.sdnnetwork.model.SDNNetworkOFFlow;
  */
 public class NCLController implements INCLController {
 
-	public static final String	DEFAULT_FLOW_PRIORITY	= "32000";
-
-	private Map<String, Flow>	allocatedFlows;
-
-	public NCLController() {
-		allocatedFlows = new HashMap<String, Flow>();
-	}
-
 	@Override
-	public String allocateFlow(FlowRequest flowRequest, Route route,
-			String networkId) throws FlowAllocationException {
-
+	public String allocateFlow(SDNNetworkOFFlow flowWithRoute, String networkId) throws FlowAllocationException {
 		try {
-
-			SDNNetworkOFFlow flowWithRoute = FlowRequestParser.parseFlowRequestIntoSDNFlow(flowRequest, route);
-			flowWithRoute.setActive(true);
-			flowWithRoute.setPriority(DEFAULT_FLOW_PRIORITY);
-			// FIXME requesting a flow that won't filter by IP, by now
-			flowWithRoute.getMatch().setSrcIp(null);
-			flowWithRoute.getMatch().setDstIp(null);
-			// FIXME requesting a flow that won't filter by ToS, by now
-			flowWithRoute.getMatch().setTosBits(null);
 
 			IResource networkResource = getResource(networkId);
 			IOFProvisioningNetworkCapability provisionCapab = (IOFProvisioningNetworkCapability) networkResource
 					.getCapabilityByInterface(IOFProvisioningNetworkCapability.class);
 
-			String flowId = provisionCapab.allocateOFFlow(flowWithRoute);
-
-			Flow flow = new Flow();
-			flow.setFlowRequest(flowRequest);
-			flow.setId(flowId);
-			allocatedFlows.put(flowId, flow);
-
-			return flowId;
+			return provisionCapab.allocateOFFlow(flowWithRoute);
 
 		} catch (ActivatorException e) {
 			throw new FlowAllocationException(e);
@@ -78,7 +47,6 @@ public class NCLController implements INCLController {
 					.getCapabilityByInterface(IOFProvisioningNetworkCapability.class);
 
 			provisionCapab.deallocateOFFlow(flowId);
-			allocatedFlows.remove(flowId);
 			return flowId;
 
 		} catch (ActivatorException e) {
@@ -89,8 +57,20 @@ public class NCLController implements INCLController {
 	}
 
 	@Override
-	public Collection<Flow> getFlows() {
-		return allocatedFlows.values();
+	public Collection<SDNNetworkOFFlow> getFlows(String networkId) throws FlowRetrievalException {
+
+		try {
+			IResource networkResource = getResource(networkId);
+			IOFProvisioningNetworkCapability provisionCapab = (IOFProvisioningNetworkCapability) networkResource
+					.getCapabilityByInterface(IOFProvisioningNetworkCapability.class);
+
+			return provisionCapab.getAllocatedFlows();
+
+		} catch (ActivatorException e) {
+			throw new FlowRetrievalException(e);
+		} catch (ResourceException e) {
+			throw new FlowRetrievalException(e);
+		}
 	}
 
 	private IResource getResource(String networkId) throws ActivatorException, ResourceException {

--- a/extensions/bundles/ofertie.ncl/src/main/java/org/opennaas/extensions/ofertie/ncl/controller/api/INCLController.java
+++ b/extensions/bundles/ofertie.ncl/src/main/java/org/opennaas/extensions/ofertie/ncl/controller/api/INCLController.java
@@ -3,9 +3,8 @@ package org.opennaas.extensions.ofertie.ncl.controller.api;
 import java.util.Collection;
 
 import org.opennaas.extensions.ofertie.ncl.provisioner.api.exceptions.FlowAllocationException;
-import org.opennaas.extensions.ofertie.ncl.provisioner.api.model.Flow;
-import org.opennaas.extensions.ofertie.ncl.provisioner.api.model.FlowRequest;
-import org.opennaas.extensions.sdnnetwork.model.Route;
+import org.opennaas.extensions.ofertie.ncl.provisioner.api.exceptions.FlowRetrievalException;
+import org.opennaas.extensions.sdnnetwork.model.SDNNetworkOFFlow;
 
 /**
  * 
@@ -16,13 +15,12 @@ public interface INCLController {
 
 	/**
 	 * 
-	 * @param flowRequest
-	 * @param route
+	 * @param flowWithRoute
 	 * @param networkId
 	 * @return flowId of allocated flow
 	 * @throws FlowAllocationException
 	 */
-	public String allocateFlow(FlowRequest flowRequest, Route route, String networkId) throws FlowAllocationException;
+	public String allocateFlow(SDNNetworkOFFlow flowWithRoute, String networkId) throws FlowAllocationException;
 
 	/**
 	 * 
@@ -37,6 +35,5 @@ public interface INCLController {
 	 * 
 	 * @return
 	 */
-	public Collection<Flow> getFlows();
-
+	public Collection<SDNNetworkOFFlow> getFlows(String networkId) throws FlowRetrievalException;
 }

--- a/extensions/bundles/ofertie.ncl/src/main/java/org/opennaas/extensions/ofertie/ncl/provisioner/api/exceptions/FlowRetrievalException.java
+++ b/extensions/bundles/ofertie.ncl/src/main/java/org/opennaas/extensions/ofertie/ncl/provisioner/api/exceptions/FlowRetrievalException.java
@@ -1,0 +1,26 @@
+package org.opennaas.extensions.ofertie.ncl.provisioner.api.exceptions;
+
+public class FlowRetrievalException extends Exception {
+
+	/**
+	 * Auto-generated serial number.
+	 */
+	private static final long	serialVersionUID	= 5625007589933220784L;
+
+	public FlowRetrievalException() {
+		super();
+	}
+
+	public FlowRetrievalException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public FlowRetrievalException(String message) {
+		super(message);
+	}
+
+	public FlowRetrievalException(Throwable cause) {
+		super(cause);
+	}
+
+}

--- a/extensions/bundles/ofertie.ncl/src/main/java/org/opennaas/extensions/ofertie/ncl/provisioner/components/IRequestToFlowsLogic.java
+++ b/extensions/bundles/ofertie.ncl/src/main/java/org/opennaas/extensions/ofertie/ncl/provisioner/components/IRequestToFlowsLogic.java
@@ -1,0 +1,11 @@
+package org.opennaas.extensions.ofertie.ncl.provisioner.components;
+
+import org.opennaas.extensions.ofertie.ncl.provisioner.api.model.FlowRequest;
+import org.opennaas.extensions.sdnnetwork.model.Route;
+import org.opennaas.extensions.sdnnetwork.model.SDNNetworkOFFlow;
+
+public interface IRequestToFlowsLogic {
+
+	public SDNNetworkOFFlow getRequiredFlowsToSatisfyRequest(FlowRequest flowRequest, Route route);
+
+}

--- a/extensions/bundles/ofertie.ncl/src/main/java/org/opennaas/extensions/ofertie/ncl/provisioner/components/mockup/RequestToFlowLogic.java
+++ b/extensions/bundles/ofertie.ncl/src/main/java/org/opennaas/extensions/ofertie/ncl/provisioner/components/mockup/RequestToFlowLogic.java
@@ -1,0 +1,28 @@
+package org.opennaas.extensions.ofertie.ncl.provisioner.components.mockup;
+
+import org.opennaas.extensions.ofertie.ncl.helpers.FlowRequestParser;
+import org.opennaas.extensions.ofertie.ncl.provisioner.api.model.FlowRequest;
+import org.opennaas.extensions.ofertie.ncl.provisioner.components.IRequestToFlowsLogic;
+import org.opennaas.extensions.sdnnetwork.model.Route;
+import org.opennaas.extensions.sdnnetwork.model.SDNNetworkOFFlow;
+
+public class RequestToFlowLogic implements IRequestToFlowsLogic {
+
+	public static final String	DEFAULT_FLOW_PRIORITY	= "32000";
+
+	@Override
+	public SDNNetworkOFFlow getRequiredFlowsToSatisfyRequest(FlowRequest flowRequest, Route route) {
+
+		SDNNetworkOFFlow flowWithRoute = FlowRequestParser.parseFlowRequestIntoSDNFlow(flowRequest, route);
+		flowWithRoute.setActive(true);
+		flowWithRoute.setPriority(DEFAULT_FLOW_PRIORITY);
+		// FIXME requesting a flow that won't filter by IP, by now
+		flowWithRoute.getMatch().setSrcIp(null);
+		flowWithRoute.getMatch().setDstIp(null);
+		// FIXME requesting a flow that won't filter by ToS, by now
+		flowWithRoute.getMatch().setTosBits(null);
+
+		return flowWithRoute;
+	}
+
+}

--- a/extensions/bundles/ofertie.ncl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/extensions/bundles/ofertie.ncl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -17,6 +17,7 @@
 	<bean id="networkSelector" class="org.opennaas.extensions.ofertie.ncl.provisioner.components.mockup.NetworkSelectorMockup">
 		<property name="resourceManager" ref="resourceManager" />
 	</bean>
+	<bean id="requestToFlowsLogic" class="org.opennaas.extensions.ofertie.ncl.provisioner.components.mockup.RequestToFlowsLogic"/>
 	<bean id="nclController" class="org.opennaas.extensions.ofertie.ncl.controller.NCLController"/>
 	
 	<!-- Instantiate NCLProvisioner and publish it -->
@@ -25,6 +26,7 @@
 		<property name="pathFinder" ref="pathFinder" />
 		<property name="networkSelector" ref="networkSelector" />
 		<property name="nclController" ref="nclController" />
+		<property name="requestToFlowsLogic" ref="requestToFlowsLogic" />
 	</bean>
 	<service ref="nclProvisioner" interface="org.opennaas.extensions.ofertie.ncl.provisioner.api.INCLProvisioner">
 		<service-properties>

--- a/extensions/bundles/ofertie.ncl/src/test/java/org/opennaas/extensions/ofertie/ncl/test/ProvisionerLogicTest.java
+++ b/extensions/bundles/ofertie.ncl/src/test/java/org/opennaas/extensions/ofertie/ncl/test/ProvisionerLogicTest.java
@@ -19,26 +19,31 @@ import org.opennaas.extensions.ofertie.ncl.provisioner.api.model.QoSRequirements
 import org.opennaas.extensions.ofertie.ncl.provisioner.components.INetworkSelector;
 import org.opennaas.extensions.ofertie.ncl.provisioner.components.IPathFinder;
 import org.opennaas.extensions.ofertie.ncl.provisioner.components.IQoSPDP;
+import org.opennaas.extensions.ofertie.ncl.provisioner.components.IRequestToFlowsLogic;
 import org.opennaas.extensions.sdnnetwork.model.Route;
+import org.opennaas.extensions.sdnnetwork.model.SDNNetworkOFFlow;
 
 public class ProvisionerLogicTest {
 
-	final String		userId	= "alice";
-	final String		netId	= "NET:1234";
-	final Route			route	= new Route();
-	final String		flowId	= "FLOW:1";
+	final String			userId	= "alice";
+	final String			netId	= "NET:1234";
+	final Route				route	= new Route();
+	final String			flowId	= "FLOW:1";
 
-	NCLProvisioner		provisioner;
-	IQoSPDP				qosPDP;
-	INetworkSelector	networkSelector;
-	IPathFinder			pathFinder;
-	INCLController		nclController;
+	NCLProvisioner			provisioner;
+	IQoSPDP					qosPDP;
+	INetworkSelector		networkSelector;
+	IPathFinder				pathFinder;
+	INCLController			nclController;
+	IRequestToFlowsLogic	requestToFlowsLogic;
 
-	FlowRequest			flowRequest;
+	FlowRequest				flowRequest;
+	SDNNetworkOFFlow		sdnFlow;
 
 	@Before
 	public void initFlowRequest() {
 		flowRequest = generateSampleFlow().getFlowRequest();
+		sdnFlow = new SDNNetworkOFFlow();
 	}
 
 	@Before
@@ -48,12 +53,15 @@ public class ProvisionerLogicTest {
 		networkSelector = createMock(INetworkSelector.class);
 		pathFinder = createMock(IPathFinder.class);
 		nclController = createMock(INCLController.class);
+		requestToFlowsLogic = createMock(IRequestToFlowsLogic.class);
 
 		provisioner = new NCLProvisioner();
 		provisioner.setQoSPDP(qosPDP);
 		provisioner.setNetworkSelector(networkSelector);
 		provisioner.setPathFinder(pathFinder);
 		provisioner.setNclController(nclController);
+		provisioner.setRequestToFlowsLogic(requestToFlowsLogic);
+
 	}
 
 	@Test
@@ -61,11 +69,13 @@ public class ProvisionerLogicTest {
 		expect(qosPDP.shouldAcceptRequest(userId, flowRequest)).andReturn(true);
 		expect(networkSelector.findNetworkForRequest(flowRequest)).andReturn(netId);
 		expect(pathFinder.findPathForRequest(flowRequest, netId)).andReturn(route);
-		expect(nclController.allocateFlow(flowRequest, route, netId)).andReturn(flowId);
+		expect(requestToFlowsLogic.getRequiredFlowsToSatisfyRequest(flowRequest, route)).andReturn(sdnFlow);
+		expect(nclController.allocateFlow(sdnFlow, netId)).andReturn(flowId);
 
 		replay(qosPDP);
 		replay(networkSelector);
 		replay(pathFinder);
+		replay(requestToFlowsLogic);
 		replay(nclController);
 
 		String result = provisioner.allocateFlow(flowRequest);
@@ -74,6 +84,7 @@ public class ProvisionerLogicTest {
 		verify(qosPDP);
 		verify(networkSelector);
 		verify(pathFinder);
+		verify(requestToFlowsLogic);
 		verify(nclController);
 	}
 
@@ -84,6 +95,7 @@ public class ProvisionerLogicTest {
 		replay(qosPDP);
 		replay(networkSelector);
 		replay(pathFinder);
+		replay(requestToFlowsLogic);
 		replay(nclController);
 
 		provisioner.allocateFlow(flowRequest);
@@ -91,6 +103,7 @@ public class ProvisionerLogicTest {
 		verify(qosPDP);
 		verify(networkSelector);
 		verify(pathFinder);
+		verify(requestToFlowsLogic);
 		verify(nclController);
 	}
 
@@ -102,6 +115,7 @@ public class ProvisionerLogicTest {
 		replay(qosPDP);
 		replay(networkSelector);
 		replay(pathFinder);
+		replay(requestToFlowsLogic);
 		replay(nclController);
 
 		provisioner.allocateFlow(flowRequest);
@@ -109,6 +123,7 @@ public class ProvisionerLogicTest {
 		verify(qosPDP);
 		verify(networkSelector);
 		verify(pathFinder);
+		verify(requestToFlowsLogic);
 		verify(nclController);
 	}
 
@@ -121,6 +136,7 @@ public class ProvisionerLogicTest {
 		replay(qosPDP);
 		replay(networkSelector);
 		replay(pathFinder);
+		replay(requestToFlowsLogic);
 		replay(nclController);
 
 		provisioner.allocateFlow(flowRequest);
@@ -128,6 +144,7 @@ public class ProvisionerLogicTest {
 		verify(qosPDP);
 		verify(networkSelector);
 		verify(pathFinder);
+		verify(requestToFlowsLogic);
 		verify(nclController);
 	}
 
@@ -136,11 +153,13 @@ public class ProvisionerLogicTest {
 		expect(qosPDP.shouldAcceptRequest(userId, flowRequest)).andReturn(true);
 		expect(networkSelector.findNetworkForRequest(flowRequest)).andReturn(netId);
 		expect(pathFinder.findPathForRequest(flowRequest, netId)).andReturn(route);
-		expect(nclController.allocateFlow(flowRequest, route, netId)).andThrow(new FlowAllocationException());
+		expect(requestToFlowsLogic.getRequiredFlowsToSatisfyRequest(flowRequest, route)).andReturn(sdnFlow);
+		expect(nclController.allocateFlow(sdnFlow, netId)).andThrow(new FlowAllocationException());
 
 		replay(qosPDP);
 		replay(networkSelector);
 		replay(pathFinder);
+		replay(requestToFlowsLogic);
 		replay(nclController);
 
 		provisioner.allocateFlow(flowRequest);
@@ -148,6 +167,7 @@ public class ProvisionerLogicTest {
 		verify(qosPDP);
 		verify(networkSelector);
 		verify(pathFinder);
+		verify(requestToFlowsLogic);
 		verify(nclController);
 	}
 


### PR DESCRIPTION
NCLController API and implementation has changed in order to use SDNNetworkFlows instead of FlowRequests.
- Logic for Tranlating from FlowRequest to SDNNetworkFlow has been moved to a dedicated component (RequestToFlowLogic) that is part of the provisioner.
- Logic for creating Flow from already allocated SDNNetworkFlow(s) has been moved to NCLProvisioner.
- NCLController is now very similar to SDNNetwork IOFProvisioningNetworkCapability.

Some tests have been updated.

This patch fixes issue:
http://jira.i2cat.net:8080/browse/OPENNAAS-1182
