### PR TITLE
UpdateFlow implementation calling deallocate and allocateFLow.

### DIFF
--- a/extensions/bundles/ofertie.ncl/src/main/java/org/opennaas/extensions/ofertie/ncl/provisioner/NCLProvisioner.java
+++ b/extensions/bundles/ofertie.ncl/src/main/java/org/opennaas/extensions/ofertie/ncl/provisioner/NCLProvisioner.java
@@ -154,8 +154,22 @@ public class NCLProvisioner implements INCLProvisioner {
 	public String updateFlow(String flowId, FlowRequest updatedFlowRequest)
 			throws FlowAllocationException, FlowNotFoundException,
 			ProvisionerException {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException("Not implemented");
+
+		deallocateFlow(flowId);
+		String newFlowId = allocateFlow(updatedFlowRequest);
+
+		// keep previous id for new circuit.
+		Circuit circuit = allocatedCircuits.get(newFlowId);
+		List<SDNNetworkOFFlow> circuitFlows = allocatedFlows.get(newFlowId);
+
+		allocatedCircuits.remove(newFlowId);
+		allocatedFlows.remove(newFlowId);
+
+		circuit.setId(flowId);
+		allocatedCircuits.put(flowId, circuit);
+		allocatedFlows.put(flowId, circuitFlows);
+
+		return circuit.getId();
 	}
 
 	@Override


### PR DESCRIPTION
Implementation keeps previous circuit id, by re-setting the id to the previous one, after new allocation has taken place.
Not very elegant, but effective.

Related to task:
http://jira.i2cat.net:8080/browse/OPENNAAS-1099
