### PR TITLE
PathFinderMockup uses RouteSelectionLogic to select routes given a FlowRequest.

### DIFF
--- a/extensions/bundles/ofertie.ncl/src/main/java/org/opennaas/extensions/ofertie/ncl/provisioner/components/mockup/routing/PathLoader.java
+++ b/extensions/bundles/ofertie.ncl/src/main/java/org/opennaas/extensions/ofertie/ncl/provisioner/components/mockup/routing/PathLoader.java
@@ -1,0 +1,74 @@
+package org.opennaas.extensions.ofertie.ncl.provisioner.components.mockup.routing;
+
+import java.io.BufferedReader;
+import java.io.CharArrayWriter;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.opennaas.core.resources.ObjectSerializer;
+import org.opennaas.core.resources.SerializationException;
+import org.opennaas.extensions.ofertie.ncl.provisioner.model.Route;
+
+public abstract class PathLoader {
+
+	private static Log	LOG	= LogFactory.getLog(PathLoader.class);
+
+	public static Map<String, Route> getRoutesFromXml(String xmlWithPaths) throws SerializationException {
+
+		LOG.debug("Parsing routes from xml.");
+
+		Map<String, Route> finalPaths = new HashMap<String, Route>();
+		List<Route> routes = ObjectSerializer.fromXML(xmlWithPaths, Route.class);
+
+		for (Route route : routes) {
+			finalPaths.put(route.getId(), route);
+
+		}
+
+		LOG.debug(routes.size() + " routes parsed from xml.");
+
+		return finalPaths;
+	}
+
+	public static String readXMLFile(String filePath) throws IOException {
+
+		LOG.debug("Reading content of file " + filePath);
+
+		InputStreamReader reader = null;
+		BufferedReader bufferReader = null;
+		try {
+			URL url = new URL(filePath);
+			reader = new InputStreamReader(url.openStream());
+			bufferReader = new BufferedReader(reader);
+		} catch (MalformedURLException ignore) {
+			// They try a file
+			File file = new File(filePath);
+			bufferReader = new BufferedReader(new FileReader(file));
+		}
+
+		CharArrayWriter w = new CharArrayWriter();
+
+		int n;
+		char[] buf = new char[8192];
+		while ((n = bufferReader.read(buf)) > 0) {
+			w.write(buf, 0, n);
+		}
+
+		bufferReader.close();
+
+		String fileContent = w.toString();
+
+		LOG.debug("Readed content of file " + filePath);
+
+		return fileContent;
+	}
+}

--- a/extensions/bundles/ofertie.ncl/src/main/java/org/opennaas/extensions/ofertie/ncl/provisioner/components/mockup/routing/RouteIds.java
+++ b/extensions/bundles/ofertie.ncl/src/main/java/org/opennaas/extensions/ofertie/ncl/provisioner/components/mockup/routing/RouteIds.java
@@ -1,0 +1,57 @@
+package org.opennaas.extensions.ofertie.ncl.provisioner.components.mockup.routing;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class RouteIds {
+
+	private List<String>	routeIds;
+
+	public RouteIds() {
+		routeIds = new ArrayList<String>();
+	}
+
+	public List<String> getRouteIds() {
+		return routeIds;
+	}
+
+	public void setRouteIds(List<String> routeIds) {
+		this.routeIds = routeIds;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see java.lang.Object#hashCode()
+	 */
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((routeIds == null) ? 0 : routeIds.hashCode());
+		return result;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see java.lang.Object#equals(java.lang.Object)
+	 */
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		RouteIds other = (RouteIds) obj;
+		if (routeIds == null) {
+			if (other.routeIds != null)
+				return false;
+		} else if (!routeIds.equals(other.routeIds))
+			return false;
+		return true;
+	}
+
+}

--- a/extensions/bundles/ofertie.ncl/src/main/java/org/opennaas/extensions/ofertie/ncl/provisioner/components/mockup/routing/RouteSelectionInput.java
+++ b/extensions/bundles/ofertie.ncl/src/main/java/org/opennaas/extensions/ofertie/ncl/provisioner/components/mockup/routing/RouteSelectionInput.java
@@ -1,0 +1,75 @@
+package org.opennaas.extensions.ofertie.ncl.provisioner.components.mockup.routing;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.FIELD)
+public class RouteSelectionInput {
+
+	private String	srcIP;
+	private String	dstIP;
+	private String	tos;
+
+	/**
+	 * Default constructor. ONLY FOR JAXB. Not to be used manually.
+	 */
+	public RouteSelectionInput() {
+
+	}
+
+	public RouteSelectionInput(String srcIP, String dstIP, String tos) {
+		super();
+		this.srcIP = srcIP;
+		this.dstIP = dstIP;
+		this.tos = tos;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see java.lang.Object#hashCode()
+	 */
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((dstIP == null) ? 0 : dstIP.hashCode());
+		result = prime * result + ((srcIP == null) ? 0 : srcIP.hashCode());
+		result = prime * result + ((tos == null) ? 0 : tos.hashCode());
+		return result;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see java.lang.Object#equals(java.lang.Object)
+	 */
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		RouteSelectionInput other = (RouteSelectionInput) obj;
+		if (dstIP == null) {
+			if (other.dstIP != null)
+				return false;
+		} else if (!dstIP.equals(other.dstIP))
+			return false;
+		if (srcIP == null) {
+			if (other.srcIP != null)
+				return false;
+		} else if (!srcIP.equals(other.srcIP))
+			return false;
+		if (tos == null) {
+			if (other.tos != null)
+				return false;
+		} else if (!tos.equals(other.tos))
+			return false;
+		return true;
+	}
+}

--- a/extensions/bundles/ofertie.ncl/src/main/java/org/opennaas/extensions/ofertie/ncl/provisioner/components/mockup/routing/RouteSelectionLogic.java
+++ b/extensions/bundles/ofertie.ncl/src/main/java/org/opennaas/extensions/ofertie/ncl/provisioner/components/mockup/routing/RouteSelectionLogic.java
@@ -1,0 +1,47 @@
+package org.opennaas.extensions.ofertie.ncl.provisioner.components.mockup.routing;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.opennaas.core.resources.SerializationException;
+
+public class RouteSelectionLogic {
+
+	private final static String	PATHS_FILE_URL	= "etc/org.opennaas.extensions.ofertie.ncl.routemapping.xml";
+
+	private RouteSelectionMap	routeMap;
+
+	public RouteSelectionLogic() throws IOException, SerializationException {
+		String xml = RouteSelectionMapLoader.readXMLFile(PATHS_FILE_URL);
+		routeMap = RouteSelectionMapLoader.getRouteSelectionMapFromXml(xml);
+	}
+
+	/**
+	 * @return the routeMap
+	 */
+	public RouteSelectionMap getRouteMap() {
+		return routeMap;
+	}
+
+	/**
+	 * @param routeMap
+	 *            the routeMap to set
+	 */
+	public void setRouteMap(RouteSelectionMap routeMapping) {
+		this.routeMap = routeMapping;
+	}
+
+	/**
+	 * 
+	 * @param input
+	 * @return potential routes for given input
+	 */
+	public List<String> getPotentialRoutes(RouteSelectionInput input) {
+		if (!routeMap.getRouteMapping().containsKey(input))
+			return new ArrayList<String>(0);
+
+		return routeMap.getRouteMapping().get(input).getRouteIds();
+	}
+
+}

--- a/extensions/bundles/ofertie.ncl/src/main/java/org/opennaas/extensions/ofertie/ncl/provisioner/components/mockup/routing/RouteSelectionMap.java
+++ b/extensions/bundles/ofertie.ncl/src/main/java/org/opennaas/extensions/ofertie/ncl/provisioner/components/mockup/routing/RouteSelectionMap.java
@@ -1,0 +1,73 @@
+package org.opennaas.extensions.ofertie.ncl.provisioner.components.mockup.routing;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.FIELD)
+public class RouteSelectionMap {
+
+	/**
+	 * Key: RouteSelectionInput, Value: RouteIds
+	 */
+	private Map<RouteSelectionInput, RouteIds>	routeMapping;
+
+	public RouteSelectionMap() {
+		routeMapping = new HashMap<RouteSelectionInput, RouteIds>();
+	}
+
+	/**
+	 * @return the routeMapping
+	 */
+	public Map<RouteSelectionInput, RouteIds> getRouteMapping() {
+		return routeMapping;
+	}
+
+	/**
+	 * @param routeMapping
+	 *            the routeMapping to set
+	 */
+	public void setRouteMapping(Map<RouteSelectionInput, RouteIds> routeMapping) {
+		this.routeMapping = routeMapping;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see java.lang.Object#hashCode()
+	 */
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((routeMapping == null) ? 0 : routeMapping.hashCode());
+		return result;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see java.lang.Object#equals(java.lang.Object)
+	 */
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		RouteSelectionMap other = (RouteSelectionMap) obj;
+		if (routeMapping == null) {
+			if (other.routeMapping != null)
+				return false;
+		} else if (!routeMapping.equals(other.routeMapping))
+			return false;
+		return true;
+	}
+
+}

--- a/extensions/bundles/ofertie.ncl/src/main/java/org/opennaas/extensions/ofertie/ncl/provisioner/components/mockup/routing/RouteSelectionMapLoader.java
+++ b/extensions/bundles/ofertie.ncl/src/main/java/org/opennaas/extensions/ofertie/ncl/provisioner/components/mockup/routing/RouteSelectionMapLoader.java
@@ -1,4 +1,4 @@
-package org.opennaas.extensions.ofertie.ncl.provisioner.components.mockup;
+package org.opennaas.extensions.ofertie.ncl.provisioner.components.mockup.routing;
 
 import java.io.BufferedReader;
 import java.io.CharArrayWriter;
@@ -8,35 +8,25 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.opennaas.core.resources.ObjectSerializer;
 import org.opennaas.core.resources.SerializationException;
-import org.opennaas.extensions.ofertie.ncl.provisioner.model.Route;
 
-public abstract class PathLoader {
+public abstract class RouteSelectionMapLoader {
 
-	private static Log	LOG	= LogFactory.getLog(PathLoader.class);
+	private static Log	LOG	= LogFactory.getLog(RouteSelectionMapLoader.class);
 
-	public static Map<String, Route> getRoutesFromXml(String xmlWithPaths) throws SerializationException {
+	public static RouteSelectionMap getRouteSelectionMapFromXml(String xmlWithMap) throws SerializationException {
 
-		LOG.debug("Parsing routes from xml.");
+		LOG.debug("Parsing RouteSelectionMap from xml.");
 
-		Map<String, Route> finalPaths = new HashMap<String, Route>();
-		List<Route> routes = ObjectSerializer.fromXML(xmlWithPaths, Route.class);
+		RouteSelectionMap map = (RouteSelectionMap) ObjectSerializer.fromXml(xmlWithMap, RouteSelectionMap.class);
 
-		for (Route route : routes) {
-			finalPaths.put(route.getId(), route);
+		LOG.debug("RouteSelectionMap parsed from xml.");
 
-		}
-
-		LOG.debug(routes.size() + " routes parsed from xml.");
-
-		return finalPaths;
+		return map;
 	}
 
 	public static String readXMLFile(String filePath) throws IOException {

--- a/extensions/bundles/ofertie.ncl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/extensions/bundles/ofertie.ncl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -14,7 +14,7 @@
 	<!-- Instantiate NCLProvisioner components -->
 	<bean id="nclModel" class="org.opennaas.extensions.ofertie.ncl.provisioner.model.NCLModel"/>
 	<bean id="qosPDP" class="org.opennaas.extensions.ofertie.ncl.provisioner.components.mockup.QoSPDPMockup"/>
-	<bean id="pathFinder" class="org.opennaas.extensions.ofertie.ncl.provisioner.components.mockup.PathFinderMockup">
+	<bean id="pathFinder" class="org.opennaas.extensions.ofertie.ncl.provisioner.components.mockup.routing.PathFinderMockup">
 		<property name="nclModel" ref="nclModel" />
 	</bean>
 	<bean id="networkSelector" class="org.opennaas.extensions.ofertie.ncl.provisioner.components.mockup.NetworkSelectorMockup">

--- a/extensions/bundles/ofertie.ncl/src/test/java/org/opennaas/extensions/ofertie/ncl/test/PathLoaderTest.java
+++ b/extensions/bundles/ofertie.ncl/src/test/java/org/opennaas/extensions/ofertie/ncl/test/PathLoaderTest.java
@@ -10,7 +10,7 @@ import junit.framework.Assert;
 
 import org.junit.Test;
 import org.opennaas.core.resources.SerializationException;
-import org.opennaas.extensions.ofertie.ncl.provisioner.components.mockup.PathLoader;
+import org.opennaas.extensions.ofertie.ncl.provisioner.components.mockup.routing.PathLoader;
 import org.opennaas.extensions.ofertie.ncl.provisioner.model.NetworkConnection;
 import org.opennaas.extensions.ofertie.ncl.provisioner.model.Route;
 

--- a/extensions/bundles/ofertie.ncl/src/test/java/org/opennaas/extensions/ofertie/ncl/test/ProvisionerSerializationTest.java
+++ b/extensions/bundles/ofertie.ncl/src/test/java/org/opennaas/extensions/ofertie/ncl/test/ProvisionerSerializationTest.java
@@ -1,5 +1,10 @@
 package org.opennaas.extensions.ofertie.ncl.test;
 
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import junit.framework.Assert;
 
 import org.junit.Test;
@@ -8,6 +13,9 @@ import org.opennaas.core.resources.SerializationException;
 import org.opennaas.extensions.ofertie.ncl.provisioner.api.model.Circuit;
 import org.opennaas.extensions.ofertie.ncl.provisioner.api.model.FlowRequest;
 import org.opennaas.extensions.ofertie.ncl.provisioner.api.model.QoSRequirements;
+import org.opennaas.extensions.ofertie.ncl.provisioner.components.mockup.routing.RouteIds;
+import org.opennaas.extensions.ofertie.ncl.provisioner.components.mockup.routing.RouteSelectionInput;
+import org.opennaas.extensions.ofertie.ncl.provisioner.components.mockup.routing.RouteSelectionMap;
 
 public class ProvisionerSerializationTest {
 
@@ -29,6 +37,75 @@ public class ProvisionerSerializationTest {
 		String xml2 = ObjectSerializer.toXml(generated);
 		Assert.assertEquals(original, generated);
 		Assert.assertEquals(xml, xml2);
+	}
+
+	@Test
+	public void routeSelectionMapSerializationTest() throws SerializationException {
+		RouteSelectionMap original = generateSampleRouteSelectionMap();
+		String xml = ObjectSerializer.toXml(original);
+		RouteSelectionMap generated = (RouteSelectionMap) ObjectSerializer.fromXml(xml, RouteSelectionMap.class);
+		String xml2 = ObjectSerializer.toXml(generated);
+		Assert.assertEquals(original, generated);
+		Assert.assertEquals(xml, xml2);
+		System.out.println(xml);
+	}
+
+	// <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+	// <routeSelectionMap>
+	// <routeMapping>
+	// <entry>
+	// <key>
+	// <srcIP>192.168.1.1</srcIP>
+	// <dstIP>192.168.1.2</dstIP>
+	// <tos>4</tos>
+	// </key>
+	// <value>
+	// <routeIds>1</routeIds>
+	// <routeIds>2</routeIds>
+	// <routeIds>3</routeIds>
+	// </value>
+	// </entry>
+	// <entry>
+	// <key>
+	// <srcIP>192.168.1.2</srcIP>
+	// <dstIP>192.168.1.1</dstIP>
+	// <tos>4</tos>
+	// </key>
+	// <value>
+	// <routeIds>3</routeIds>
+	// <routeIds>4</routeIds>
+	// <routeIds>5</routeIds>
+	// <routeIds>1</routeIds>
+	// </value>
+	// </entry>
+	// </routeMapping>
+	// </routeSelectionMap>
+	private RouteSelectionMap generateSampleRouteSelectionMap() {
+
+		String srcIP = "192.168.1.1";
+		String dstIP = "192.168.1.2";
+		String tos = "4";
+
+		RouteSelectionInput input1 = new RouteSelectionInput(srcIP, dstIP, tos);
+		RouteSelectionInput input2 = new RouteSelectionInput(dstIP, srcIP, tos);
+
+		List<String> routes1 = Arrays.asList("1", "2", "3");
+		List<String> routes2 = Arrays.asList("3", "4", "5", "1");
+
+		RouteIds ids1 = new RouteIds();
+		ids1.setRouteIds(routes1);
+
+		RouteIds ids2 = new RouteIds();
+		ids2.setRouteIds(routes2);
+
+		Map<RouteSelectionInput, RouteIds> routeMapping = new HashMap<RouteSelectionInput, RouteIds>();
+		routeMapping.put(input1, ids1);
+		routeMapping.put(input2, ids2);
+
+		RouteSelectionMap routeMap = new RouteSelectionMap();
+		routeMap.setRouteMapping(routeMapping);
+
+		return routeMap;
 	}
 
 	// <?xml version="1.0" encoding="UTF-8" standalone="yes"?>

--- a/platform/src/main/filtered-resources/etc/org.opennaas.extensions.ofertie.ncl.routemapping.xml
+++ b/platform/src/main/filtered-resources/etc/org.opennaas.extensions.ofertie.ncl.routemapping.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<routeSelectionMap>
+    <routeMapping>
+        <entry>
+            <key>
+                <srcIP>192.168.1.1</srcIP>
+                <dstIP>192.168.1.2</dstIP>
+                <tos>4</tos>
+            </key>
+            <value>
+                <routeIds>1</routeIds>
+                <routeIds>2</routeIds>
+                <routeIds>3</routeIds>
+            </value>
+        </entry>
+        <entry>
+            <key>
+                <srcIP>192.168.1.2</srcIP>
+                <dstIP>192.168.1.1</dstIP>
+                <tos>4</tos>
+            </key>
+            <value>
+                <routeIds>3</routeIds>
+                <routeIds>4</routeIds>
+                <routeIds>5</routeIds>
+                <routeIds>1</routeIds>
+            </value>
+        </entry>
+    </routeMapping>
+</routeSelectionMap>


### PR DESCRIPTION
RouteSelectionLogic selects routes according to a Map.
This Map maps RouteSelectionInput to a list of routeIds, which are possible routes.
This Map is provided by a config file named: etc/org.opennaas.extensions.ofertie.ncl.routemapping.xml
The map key is formed by srcIPAddress, dstIPAddress and ToS values, according to http://jira.i2cat.net:8080/browse/OPENNAAS-1206

PathFinder then selects the first possible route that is not congested.

Solves issues:
http://jira.i2cat.net:8080/browse/OPENNAAS-1205
http://jira.i2cat.net:8080/browse/OPENNAAS-1206
