### PR TITLE
Add relative path to parent POM in child projects with more than one subleveled folders.

### DIFF
--- a/itests/ip/opener/pom.xml
+++ b/itests/ip/opener/pom.xml
@@ -5,6 +5,7 @@
 		<groupId>org.opennaas</groupId>
 		<artifactId>org.opennaas.itests</artifactId>
 		<version>0.25-SNAPSHOT</version>
+		<relativePath>../../</relativePath>
 	</parent>
 	<artifactId>org.opennaas.itests.ip.opener</artifactId>
 	<name>OpenNaaS :: iTests :: IP :: Opener</name>

--- a/itests/monitoring/floodlight/pom.xml
+++ b/itests/monitoring/floodlight/pom.xml
@@ -5,6 +5,7 @@
 		<groupId>org.opennaas</groupId>
 		<artifactId>org.opennaas.itests</artifactId>
 		<version>0.25-SNAPSHOT</version>
+		<relativePath>../../</relativePath>
 	</parent>
 	<artifactId>org.opennaas.itests.monitoring.floodlight</artifactId>
 	<name>OpenNaaS :: iTests :: Monitoring :: Floodlight</name>

--- a/itests/openflowforwarding/floodlight/pom.xml
+++ b/itests/openflowforwarding/floodlight/pom.xml
@@ -5,6 +5,7 @@
 		<groupId>org.opennaas</groupId>
 		<artifactId>org.opennaas.itests</artifactId>
 		<version>0.25-SNAPSHOT</version>
+		<relativePath>../../</relativePath>
 	</parent>
 	<artifactId>org.opennaas.itests.openflowforwarding.floodlight</artifactId>
 	<name>OpenNaaS :: iTests :: OpenflowForwarding :: Floodlight</name>

--- a/itests/vrrp/junos10/pom.xml
+++ b/itests/vrrp/junos10/pom.xml
@@ -4,6 +4,7 @@
 		<artifactId>org.opennaas.itests</artifactId>
 		<groupId>org.opennaas</groupId>
 		<version>0.25-SNAPSHOT</version>
+		<relativePath>../../</relativePath>
 	</parent>
 
 	<artifactId>org.opennaas.itests.vrrp.junos10</artifactId>


### PR DESCRIPTION
Add relative path to parent POM in child projects with more than one subleveled folders.
