### PR TITLE
This patch causes OpenNaaS to use decimal format for ToS values.

### DIFF
--- a/extensions/bundles/ofertie.ncl/src/main/java/org/opennaas/extensions/ofertie/ncl/helpers/QoSPolicyRequestParser.java
+++ b/extensions/bundles/ofertie.ncl/src/main/java/org/opennaas/extensions/ofertie/ncl/helpers/QoSPolicyRequestParser.java
@@ -82,9 +82,9 @@ public abstract class QoSPolicyRequestParser {
 		match.setSrcPort(qosPolicyRequest.getSource() != null ? qosPolicyRequest.getSource().getPort() : null);
 		match.setDstPort(qosPolicyRequest.getDestination() != null ? qosPolicyRequest.getDestination().getPort() : null);
 
-		// The last two bits of the ToS are discarded, therefore we divide the hexadecimal value per 4
+		// The last two bits of the ToS are discarded, therefore we divide the value per 4
 		// More information at http://www.tucny.com/Home/dscp-tos
-		String tosBits = Integer.toHexString(Integer.parseInt(qosPolicyRequest.getLabel()) / 4);
+		String tosBits = Integer.toString(Integer.parseInt(qosPolicyRequest.getLabel()) / 4);
 		match.setTosBits(tosBits);
 
 		if (qosPolicyRequest.getSource() == null || qosPolicyRequest.getSource().getAddress() == null || qosPolicyRequest.getSource().getAddress()

--- a/extensions/bundles/ofertie.ncl/src/test/java/org/opennaas/extensions/ofertie/ncl/test/RequestToFlowsLogicTest.java
+++ b/extensions/bundles/ofertie.ncl/src/test/java/org/opennaas/extensions/ofertie/ncl/test/RequestToFlowsLogicTest.java
@@ -121,7 +121,7 @@ public class RequestToFlowsLogicTest {
 
 	@Test
 	public void requestWithToSTest() throws Exception {
-		int tos = 4;
+		int tos = 42;
 		int flowTos = tos / 4; // last 2 bits discarded
 
 		qosPolicyRequest.setLabel(String.valueOf(tos));
@@ -130,7 +130,7 @@ public class RequestToFlowsLogicTest {
 		for (NetOFFlow flow : flows) {
 			Assert.assertNotNull(flow);
 			Assert.assertNotNull(flow.getMatch());
-			Assert.assertEquals(String.valueOf(flowTos), flow.getMatch().getTosBits());
+			Assert.assertEquals(flowTos, Integer.parseInt(flow.getMatch().getTosBits()));
 			Assert.assertEquals("2048", flow.getMatch().getEtherType());
 		}
 		verify(pathFinder);
@@ -153,7 +153,7 @@ public class RequestToFlowsLogicTest {
 			Assert.assertNotNull(flow.getMatch());
 			Assert.assertEquals(srcIp, flow.getMatch().getSrcIp());
 			Assert.assertEquals(dstIp, flow.getMatch().getDstIp());
-			Assert.assertEquals(String.valueOf(flowTos), flow.getMatch().getTosBits());
+			Assert.assertEquals(flowTos, Integer.parseInt(flow.getMatch().getTosBits()));
 			Assert.assertEquals("2048", flow.getMatch().getEtherType());
 		}
 		verify(pathFinder);


### PR DESCRIPTION
Before this patch, hexadecimal values were used.

However, values where not represented nor sent to floodlight using the format expected by floodlight.
Floodlight accepts decimal values or hexadecimal ones preceded by "0x" prefix. OpenNaaS was using the result of Integer.toHexString(i), which is not using any prefix. e.g. 10 was represented as "a" and floodlight expected value is "0xa".

Instead of changing default hexadecimal representation, we changed to decimal one, which turned to be simpler.
