### PR TITLE
ListResponse changed to SessionIdsList, since it was only user for it.

### DIFF
--- a/core/resources/src/main/java/org/opennaas/core/protocols/sessionmanager/ProtocolSessionManager.java
+++ b/core/resources/src/main/java/org/opennaas/core/protocols/sessionmanager/ProtocolSessionManager.java
@@ -136,9 +136,9 @@ public class ProtocolSessionManager implements IProtocolSessionManager, IProtoco
 	}
 
 	@Override
-	public ListResponse getAllProtocolSessionIdsWS() {
-		ListResponse resp = new ListResponse();
-		resp.setList(new ArrayList<String>(getAllProtocolSessionIds()));
+	public SessionIdList getAllProtocolSessionIdsWS() {
+		SessionIdList resp = new SessionIdList();
+		resp.setSessionsIds(new ArrayList<String>(getAllProtocolSessionIds()));
 		return resp;
 	}
 

--- a/core/resources/src/main/java/org/opennaas/core/protocols/sessionmanager/SessionIdList.java
+++ b/core/resources/src/main/java/org/opennaas/core/protocols/sessionmanager/SessionIdList.java
@@ -27,29 +27,35 @@ package org.opennaas.core.protocols.sessionmanager;
 
 import java.util.List;
 
+import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
 /**
  * @author Jordi
+ * @author Adrian Rosello Rey (i2CAT)
  */
 @XmlRootElement
-public class ListResponse {
+public class SessionIdList {
 
-	private List<?>	list;
+	private List<String>	sessions;
 
 	/**
-	 * @return the list
+	 * Returns the list of sessionsIds
+	 * 
+	 * @return
 	 */
-	public List<?> getList() {
-		return list;
+	@XmlElement(name = "session")
+	public List<String> getSessionsIds() {
+		return sessions;
 	}
 
 	/**
-	 * @param list
-	 *            the list to set
+	 * Sets a new list of sessionsIds
+	 * 
+	 * @param newSessions
 	 */
-	public void setList(List<?> list) {
-		this.list = list;
+	public void setSessionsIds(List<String> newSessions) {
+		this.sessions = newSessions;
 	}
 
 }

--- a/core/resources/src/main/java/org/opennaas/core/resources/protocol/IProtocolSessionManager.java
+++ b/core/resources/src/main/java/org/opennaas/core/resources/protocol/IProtocolSessionManager.java
@@ -34,7 +34,7 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
-import org.opennaas.core.protocols.sessionmanager.ListResponse;
+import org.opennaas.core.protocols.sessionmanager.SessionIdList;
 
 /**
  * Manages all the sessions with a single device, identified by device_id
@@ -60,7 +60,7 @@ public interface IProtocolSessionManager {
 	@GET
 	@Path("/session/")
 	@Produces(MediaType.APPLICATION_XML)
-	public ListResponse getAllProtocolSessionIdsWS();
+	public SessionIdList getAllProtocolSessionIdsWS();
 
 	public Set<String> getAllProtocolSessionIds();
 


### PR DESCRIPTION
The ListResponse was used for returning the list of sessionsIds stored by the protocolSessionManager. When it was serialized, the structure of the xml was something like:

``` xml
<ListResponse >
   <list xs:namespace...... xsd:string> 1238123-123131-313 </list>
<ListResponse>
```

So the ListResponse was modified to return the following format:

``` xml
<SessionsIds>
    <session>1212556-231231-123</list>
</SessionsIds>
```
