### PR TITLE
Refactor/router getinterfaces common logic

### DIFF
--- a/extensions/bundles/router.capability.chassis/src/main/java/org/opennaas/extensions/router/capability/chassis/shell/ShowInterfacesCommand.java
+++ b/extensions/bundles/router.capability.chassis/src/main/java/org/opennaas/extensions/router/capability/chassis/shell/ShowInterfacesCommand.java
@@ -28,7 +28,6 @@ import org.opennaas.core.resources.IResource;
 import org.opennaas.core.resources.ResourceException;
 import org.opennaas.core.resources.shell.GenericKarafCommand;
 import org.opennaas.extensions.router.model.ComputerSystem;
-import org.opennaas.extensions.router.model.GREService;
 import org.opennaas.extensions.router.model.LogicalTunnelPort;
 import org.opennaas.extensions.router.model.NetworkPort;
 import org.opennaas.extensions.router.model.ProtocolEndpoint;
@@ -56,8 +55,8 @@ public class ShowInterfacesCommand extends GenericKarafCommand {
 			List<NetworkPort> interfaces = ModelHelper.getInterfaces(model);
 			printInterfaces(interfaces);
 
-			List<GREService> greServiceList = model.getAllHostedServicesByType(new GREService());
-			printGREServicesAsInterfaces(greServiceList);
+			List<ProtocolEndpoint> grePEPs = ModelHelper.getGREProtocolEndpoints(model);
+			printGREPEPsAsInterfaces(grePEPs);
 
 		} catch (ResourceException e) {
 			printError(e);
@@ -111,19 +110,16 @@ public class ShowInterfacesCommand extends GenericKarafCommand {
 
 	}
 
-	private void printGREServicesAsInterfaces(List<GREService> greServices) {
-		if (!greServices.isEmpty()) {
-			GREService greService = greServices.get(0);
-			for (ProtocolEndpoint pE : greService.getProtocolEndpoint()) {
+	private void printGREPEPsAsInterfaces(List<ProtocolEndpoint> grePEPs) {
+		for (ProtocolEndpoint pE : grePEPs) {
 
-				printSymbolWithoutDoubleLine("GRE INTERFACE: " + pE.getName());
+			printSymbolWithoutDoubleLine("GRE INTERFACE: " + pE.getName());
 
-				printSymbolWithoutDoubleLine(doubleTab + "STATE: " + pE.getOperationalStatus());
+			printSymbolWithoutDoubleLine(doubleTab + "STATE: " + pE.getOperationalStatus());
 
-				if (pE.getDescription() != null && !pE.getDescription().equals(""))
-					printSymbolWithoutDoubleLine(doubleTab + "description: " + pE.getDescription());
-				printSymbol("");
-			}
+			if (pE.getDescription() != null && !pE.getDescription().equals(""))
+				printSymbolWithoutDoubleLine(doubleTab + "description: " + pE.getDescription());
+			printSymbol("");
 		}
 	}
 }

--- a/extensions/bundles/router.model/src/main/java/org/opennaas/extensions/router/model/utils/ModelHelper.java
+++ b/extensions/bundles/router.model/src/main/java/org/opennaas/extensions/router/model/utils/ModelHelper.java
@@ -29,6 +29,7 @@ import java.util.List;
 
 import org.opennaas.core.resources.capability.CapabilityException;
 import org.opennaas.extensions.router.model.ComputerSystem;
+import org.opennaas.extensions.router.model.GREService;
 import org.opennaas.extensions.router.model.IPProtocolEndpoint;
 import org.opennaas.extensions.router.model.LogicalDevice;
 import org.opennaas.extensions.router.model.NetworkPort;
@@ -48,6 +49,17 @@ public class ModelHelper {
 			}
 		}
 		return ports;
+	}
+
+	public static List<ProtocolEndpoint> getGREProtocolEndpoints(System system) {
+		List<ProtocolEndpoint> greEps = new ArrayList<ProtocolEndpoint>();
+		List<GREService> greServices = system.getAllHostedServicesByType(new GREService());
+		// FIXME why do we use greServices.get(0) instead of iterating over all greServices?
+		if (!greServices.isEmpty()) {
+			GREService greService = greServices.get(0);
+			greEps.addAll(greService.getProtocolEndpoint());
+		}
+		return greEps;
 	}
 
 	public static long ipv4StringToLong(String ip) throws IOException {


### PR DESCRIPTION
Puts logic to retrieve interfaces information in a common place where other pieces of code may reuse it.
Logic has been moved to org.opennaas.extensions.router.model.utils.ModelHelper

Related to issue:
http://jira.i2cat.net:8080/browse/OPENNAAS-1268
