### PR TITLE
Bundle skeleton for router capabilities API.

### DIFF
--- a/extensions/bundles/pom.xml
+++ b/extensions/bundles/pom.xml
@@ -37,6 +37,7 @@
 		<module>router.capability.staticroute</module>
 		<module>router.capability.bgp</module>
 		<module>router.capability.vrrp</module>
+		<module>router.capabilities.api</module>		
 		<module>router.model</module>
 		<module>router.features</module>
 
@@ -137,5 +138,5 @@
 		<!-- OFERTIE -->
 		<module>ofertie.ncl</module>
 		<module>ofertie.features</module>
-  </modules>
+	</modules>
 </project>

--- a/extensions/bundles/router.capabilities.api/pom.xml
+++ b/extensions/bundles/router.capabilities.api/pom.xml
@@ -1,0 +1,46 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.opennaas</groupId>
+    <artifactId>org.opennaas.extensions.bundles</artifactId>
+    <version>0.26-SNAPSHOT</version>
+  </parent>
+  <artifactId>org.opennaas.extensions.router.capabilities.api</artifactId>
+  <packaging>bundle</packaging>
+  <name>OpenNaaS :: Router :: Capabilities :: API</name>
+  <dependencies>
+		<dependency>
+			<groupId>org.opennaas</groupId>
+			<artifactId>org.opennaas.extensions.router.model</artifactId>
+		</dependency>
+	</dependencies>
+<build>
+		<plugins>
+			<plugin>
+				<groupId>org.ops4j</groupId>
+				<artifactId>maven-pax-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<extensions>true</extensions>
+				<!--
+					| the following instructions build a simple set of public/private
+					classes into an OSGi bundle
+				-->
+				<configuration>
+					<instructions>		
+					    	<Import-Package>!org.opennaas.extensions.router.capabilities.api.model,
+  							org.slf4j,
+							org.apache.felix.service.command,
+							*
+							</Import-Package>				
+						<Export-Package>
+							org.opennaas.extensions.router.capabilities.api.model;version="${project.version}"
+						</Export-Package>
+					</instructions>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>	
+</project>

--- a/extensions/bundles/router.capabilities.api/src/main/java/org/opennaas/extensions/router/capabilities/api/model/SampleClass.java
+++ b/extensions/bundles/router.capabilities.api/src/main/java/org/opennaas/extensions/router/capabilities/api/model/SampleClass.java
@@ -1,0 +1,25 @@
+package org.opennaas.extensions.router.capabilities.api.model;
+
+/*
+ * #%L
+ * OpenNaaS :: Router :: Capabilities :: API
+ * %%
+ * Copyright (C) 2007 - 2014 Fundació Privada i2CAT, Internet i Innovació a Catalunya
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+public class SampleClass {
+
+}

--- a/extensions/bundles/router.features/src/main/resources/features.xml
+++ b/extensions/bundles/router.features/src/main/resources/features.xml
@@ -26,6 +26,7 @@
 		<bundle>mvn:org.opennaas/org.opennaas.extensions.router.capability.staticroute/${project.version}</bundle>
 		<bundle>mvn:org.opennaas/org.opennaas.extensions.router.capability.bgp/${project.version}</bundle>
 		<bundle>mvn:org.opennaas/org.opennaas.extensions.router.capability.vrrp/${project.version}</bundle>
+		<bundle>mvn:org.opennaas/org.opennaas.extensions.router.capabilities.api/${project.version}</bundle>
 	</feature>	
 	
 	

--- a/pom.xml
+++ b/pom.xml
@@ -292,6 +292,11 @@
 				<version>${project.version}</version>
 			</dependency>
 			<dependency>
+			 	<groupId>org.opennaas</groupId>
+			 	<artifactId>org.opennaas.extensions.router.capabilities.api</artifactId>
+			 	<version>${project.version}</version>
+			</dependency>			
+			<dependency>
 				<groupId>org.opennaas</groupId>
 				<artifactId>org.opennaas.extensions.network.capability.basic</artifactId>
 				<version>${project.version}</version>


### PR DESCRIPTION
This bundle will contain all model classes and helpers for the capabilities API. 
I needed to insert an empty class, because the plugin allows not to generate "empty" bundles. It will be removed when a class is inserted in the bundle.
