### PR TITLE
Rename MonitoringNetworkCapability to NetworkStatisticsCapability

### DIFF
--- a/extensions/bundles/ofertie.ncl/src/main/java/org/opennaas/extensions/ofertie/ncl/monitoring/NCLMonitoring.java
+++ b/extensions/bundles/ofertie.ncl/src/main/java/org/opennaas/extensions/ofertie/ncl/monitoring/NCLMonitoring.java
@@ -42,7 +42,7 @@ import org.opennaas.extensions.ofertie.ncl.Activator;
 import org.opennaas.extensions.ofertie.ncl.controller.api.INCLController;
 import org.opennaas.extensions.ofertie.ncl.provisioner.model.NCLModel;
 import org.opennaas.extensions.ofertie.ncl.provisioner.model.Port;
-import org.opennaas.extensions.ofnetwork.capability.monitoring.IMonitoringNetworkCapability;
+import org.opennaas.extensions.ofnetwork.capability.statistics.INetworkStatisticsCapability;
 import org.opennaas.extensions.ofnetwork.events.LinkCongestionEvent;
 import org.opennaas.extensions.ofnetwork.model.NetworkStatistics;
 import org.opennaas.extensions.ofnetwork.repository.OFNetworkRepository;
@@ -216,20 +216,20 @@ public class NCLMonitoring {
 
 			NetworkStatistics currentNetworkStatistics = null;
 
-			IMonitoringNetworkCapability monitoringNetworkCapability = null;
+			INetworkStatisticsCapability networkStatisticsCapability = null;
 			try {
 				// get port switch statistics for each network
-				monitoringNetworkCapability = (IMonitoringNetworkCapability) network
-						.getCapabilityByInterface(IMonitoringNetworkCapability.class);
+				networkStatisticsCapability = (INetworkStatisticsCapability) network
+						.getCapabilityByInterface(INetworkStatisticsCapability.class);
 			} catch (ResourceException e) {
-				// there is not IMonitoringNetworkCapability in this network
-				log.debug("Openflow network resource without IMonitoringNetworkCapability.");
+				// there is not INetworkStatisticsCapability in this network
+				log.debug("Openflow network resource without INetworkStatisticsCapability.");
 			}
 
-			if (monitoringNetworkCapability != null) {
+			if (networkStatisticsCapability != null) {
 
 				log.debug("Getting network statistics...");
-				currentNetworkStatistics = monitoringNetworkCapability.getNetworkStatistics();
+				currentNetworkStatistics = networkStatisticsCapability.getNetworkStatistics();
 			}
 			return currentNetworkStatistics;
 		}

--- a/extensions/bundles/ofnetwork/src/main/java/org/opennaas/extensions/ofnetwork/capability/statistics/INetworkStatisticsCapability.java
+++ b/extensions/bundles/ofnetwork/src/main/java/org/opennaas/extensions/ofnetwork/capability/statistics/INetworkStatisticsCapability.java
@@ -1,4 +1,4 @@
-package org.opennaas.extensions.ofnetwork.capability.monitoring;
+package org.opennaas.extensions.ofnetwork.capability.statistics;
 
 /*
  * #%L
@@ -20,8 +20,13 @@ package org.opennaas.extensions.ofnetwork.capability.monitoring;
  * #L%
  */
 
-import org.opennaas.core.resources.action.ActionResponse;
-import org.opennaas.core.resources.action.IActionSetDefinition;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.opennaas.core.resources.capability.CapabilityException;
+import org.opennaas.core.resources.capability.ICapability;
 import org.opennaas.extensions.ofnetwork.model.NetworkStatistics;
 
 /**
@@ -29,11 +34,12 @@ import org.opennaas.extensions.ofnetwork.model.NetworkStatistics;
  * @author Adrian Rosello Rey (i2CAT)
  * 
  */
-public class MonitoringNetworkActionSet implements IActionSetDefinition {
+@Path("/")
+public interface INetworkStatisticsCapability extends ICapability {
 
-	/**
-	 * An action that retrieves the statistics of all port of the network switches. It receives no parameters, and it returns a
-	 * {@link NetworkStatistics} object in the {@link ActionResponse#getResult()} method.
-	 */
-	public static final String	GET_NETWORK_STATISTICS	= "getNetworkStatistics";
+	@GET
+	@Path("readNetworkStatistics")
+	@Produces(MediaType.APPLICATION_XML)
+	public NetworkStatistics getNetworkStatistics() throws CapabilityException;
+
 }

--- a/extensions/bundles/ofnetwork/src/main/java/org/opennaas/extensions/ofnetwork/capability/statistics/NetworkStatisticsActionSet.java
+++ b/extensions/bundles/ofnetwork/src/main/java/org/opennaas/extensions/ofnetwork/capability/statistics/NetworkStatisticsActionSet.java
@@ -1,4 +1,4 @@
-package org.opennaas.extensions.ofnetwork.capability.monitoring;
+package org.opennaas.extensions.ofnetwork.capability.statistics;
 
 /*
  * #%L
@@ -20,13 +20,8 @@ package org.opennaas.extensions.ofnetwork.capability.monitoring;
  * #L%
  */
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-
-import org.opennaas.core.resources.capability.CapabilityException;
-import org.opennaas.core.resources.capability.ICapability;
+import org.opennaas.core.resources.action.ActionResponse;
+import org.opennaas.core.resources.action.IActionSetDefinition;
 import org.opennaas.extensions.ofnetwork.model.NetworkStatistics;
 
 /**
@@ -34,12 +29,11 @@ import org.opennaas.extensions.ofnetwork.model.NetworkStatistics;
  * @author Adrian Rosello Rey (i2CAT)
  * 
  */
-@Path("/")
-public interface IMonitoringNetworkCapability extends ICapability {
+public class NetworkStatisticsActionSet implements IActionSetDefinition {
 
-	@GET
-	@Path("readNetworkStatistics")
-	@Produces(MediaType.APPLICATION_XML)
-	public NetworkStatistics getNetworkStatistics() throws CapabilityException;
-
+	/**
+	 * An action that retrieves the statistics of all port of the network switches. It receives no parameters, and it returns a
+	 * {@link NetworkStatistics} object in the {@link ActionResponse#getResult()} method.
+	 */
+	public static final String	GET_NETWORK_STATISTICS	= "getNetworkStatistics";
 }

--- a/extensions/bundles/ofnetwork/src/main/java/org/opennaas/extensions/ofnetwork/capability/statistics/NetworkStatisticsCapability.java
+++ b/extensions/bundles/ofnetwork/src/main/java/org/opennaas/extensions/ofnetwork/capability/statistics/NetworkStatisticsCapability.java
@@ -1,4 +1,4 @@
-package org.opennaas.extensions.ofnetwork.capability.monitoring;
+package org.opennaas.extensions.ofnetwork.capability.statistics;
 
 /*
  * #%L
@@ -43,29 +43,29 @@ import org.opennaas.extensions.ofnetwork.model.NetworkStatistics;
  * @author Adrian Rosello Rey (i2CAT)
  * 
  */
-public class MonitoringNetworkCapability extends AbstractCapability implements IMonitoringNetworkCapability {
+public class NetworkStatisticsCapability extends AbstractCapability implements INetworkStatisticsCapability {
 
-	public static final String	CAPABILITY_TYPE	= "netmonitoring";
+	public static final String	CAPABILITY_TYPE	= "netstatistics";
 
-	Log							log				= LogFactory.getLog(MonitoringNetworkCapability.class);
+	Log							log				= LogFactory.getLog(NetworkStatisticsCapability.class);
 
 	private String				resourceId		= "";
 
-	public MonitoringNetworkCapability(CapabilityDescriptor descriptor, String resourceId) {
+	public NetworkStatisticsCapability(CapabilityDescriptor descriptor, String resourceId) {
 		super(descriptor);
 		this.resourceId = resourceId;
-		log.debug("Built new Monitoring Network Capability");
+		log.debug("Built new Network Statistics Capability");
 	}
 
 	// //////////////////////////////////// //
-	// IMonitoringNetworkCapability Methods //
+	// INetworkStatisticsCapability Methods //
 	// //////////////////////////////////// //
 
 	@Override
 	public NetworkStatistics getNetworkStatistics() throws CapabilityException {
 		log.info("Start of getNetworkStatistics call");
 
-		IAction action = createActionAndCheckParams(MonitoringNetworkActionSet.GET_NETWORK_STATISTICS, null);
+		IAction action = createActionAndCheckParams(NetworkStatisticsActionSet.GET_NETWORK_STATISTICS, null);
 		ActionResponse response = executeAction(action);
 
 		if (!response.getStatus().equals(ActionResponse.STATUS.OK))
@@ -111,7 +111,7 @@ public class MonitoringNetworkCapability extends AbstractCapability implements I
 	@Override
 	public void activate() throws CapabilityException {
 		registerService(Activator.getContext(), CAPABILITY_TYPE, getResourceType(), getResourceName(),
-				IMonitoringNetworkCapability.class.getName());
+				INetworkStatisticsCapability.class.getName());
 		super.activate();
 	}
 

--- a/extensions/bundles/ofnetwork/src/main/java/org/opennaas/extensions/ofnetwork/capability/statistics/NetworkStatisticsCapabilityFactory.java
+++ b/extensions/bundles/ofnetwork/src/main/java/org/opennaas/extensions/ofnetwork/capability/statistics/NetworkStatisticsCapabilityFactory.java
@@ -1,4 +1,4 @@
-package org.opennaas.extensions.ofnetwork.capability.monitoring;
+package org.opennaas.extensions.ofnetwork.capability.statistics;
 
 /*
  * #%L
@@ -26,12 +26,12 @@ import org.opennaas.core.resources.capability.CapabilityException;
 import org.opennaas.core.resources.capability.ICapability;
 import org.opennaas.core.resources.descriptor.CapabilityDescriptor;
 
-public class MonitoringNetworkCapabilityFactory extends AbstractCapabilityFactory {
+public class NetworkStatisticsCapabilityFactory extends AbstractCapabilityFactory {
 
 	@Override
 	public ICapability create(IResource resource) throws CapabilityException {
 		ICapability capability = this.create(resource.getResourceDescriptor()
-				.getCapabilityDescriptor(MonitoringNetworkCapability.CAPABILITY_TYPE),
+				.getCapabilityDescriptor(NetworkStatisticsCapability.CAPABILITY_TYPE),
 				resource.getResourceDescriptor().getId());
 		capability.setResource(resource);
 		return capability;
@@ -39,6 +39,6 @@ public class MonitoringNetworkCapabilityFactory extends AbstractCapabilityFactor
 
 	@Override
 	public ICapability createCapability(CapabilityDescriptor capabilityDescriptor, String resourceId) throws CapabilityException {
-		return new MonitoringNetworkCapability(capabilityDescriptor, resourceId);
+		return new NetworkStatisticsCapability(capabilityDescriptor, resourceId);
 	}
 }

--- a/extensions/bundles/ofnetwork/src/main/java/org/opennaas/extensions/ofnetwork/driver/internal/actionsets/OFNetworkInternalActionsetImplementation.java
+++ b/extensions/bundles/ofnetwork/src/main/java/org/opennaas/extensions/ofnetwork/driver/internal/actionsets/OFNetworkInternalActionsetImplementation.java
@@ -24,8 +24,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.opennaas.core.resources.action.ActionSet;
-import org.opennaas.extensions.ofnetwork.capability.monitoring.MonitoringNetworkActionSet;
 import org.opennaas.extensions.ofnetwork.capability.ofprovision.OFProvisioningNetworkActionSet;
+import org.opennaas.extensions.ofnetwork.capability.statistics.NetworkStatisticsActionSet;
 import org.opennaas.extensions.ofnetwork.driver.internal.actionsets.actions.AllocateFlowAction;
 import org.opennaas.extensions.ofnetwork.driver.internal.actionsets.actions.DeallocateFlowAction;
 import org.opennaas.extensions.ofnetwork.driver.internal.actionsets.actions.GetAllocatedFlowsAction;
@@ -48,7 +48,7 @@ public class OFNetworkInternalActionsetImplementation extends ActionSet {
 		this.putAction(OFProvisioningNetworkActionSet.DEALLOCATEFLOW, DeallocateFlowAction.class);
 		this.putAction(OFProvisioningNetworkActionSet.GETALLOCATEDFLOWS, GetAllocatedFlowsAction.class);
 
-		this.putAction(MonitoringNetworkActionSet.GET_NETWORK_STATISTICS, GetNetworkStatisticsAction.class);
+		this.putAction(NetworkStatisticsActionSet.GET_NETWORK_STATISTICS, GetNetworkStatisticsAction.class);
 	}
 
 	@Override
@@ -59,7 +59,7 @@ public class OFNetworkInternalActionsetImplementation extends ActionSet {
 		actionNames.add(OFProvisioningNetworkActionSet.DEALLOCATEFLOW);
 		actionNames.add(OFProvisioningNetworkActionSet.GETALLOCATEDFLOWS);
 
-		actionNames.add(MonitoringNetworkActionSet.GET_NETWORK_STATISTICS);
+		actionNames.add(NetworkStatisticsActionSet.GET_NETWORK_STATISTICS);
 
 		return actionNames;
 	}

--- a/extensions/bundles/ofnetwork/src/main/resources/OSGI-INF/blueprint/core.xml
+++ b/extensions/bundles/ofnetwork/src/main/resources/OSGI-INF/blueprint/core.xml
@@ -47,14 +47,14 @@
 		</service-properties>
 	</service>
 	
-	<bean id="monitoringNetworkCapabilityFactory" class="org.opennaas.extensions.ofnetwork.capability.monitoring.MonitoringNetworkCapabilityFactory">
-		<property name="type" value="netmonitoring"/>
+	<bean id="networkStatisticsCapabilityFactory" class="org.opennaas.extensions.ofnetwork.capability.statistics.NetworkStatisticsCapabilityFactory">
+		<property name="type" value="netstatistics"/>
 	</bean>	
 	<!-- Register the Service as an OSGi Service -->
-	<service ref="monitoringNetworkCapabilityFactory" interface="org.opennaas.core.resources.capability.ICapabilityFactory">
+	<service ref="networkStatisticsCapabilityFactory" interface="org.opennaas.core.resources.capability.ICapabilityFactory">
 		<service-properties>
 			<!--  TODO it is necessary to use two parameters to get capability -->
-			<entry key="capability" value="netmonitoring"/>
+			<entry key="capability" value="netstatistics"/>
 			<entry key="capability.model" value="ofnetwork"/>
 			<entry key="capability.version" value="1.0.0"/>
 		</service-properties>


### PR DESCRIPTION
- Rename package `org.opennaas.extensions.ofnetwork.capability.monitoring` to `org.opennaas.extensions.ofnetwork.capability.statistics`
- Rename interface `IMonitoringNetwork` to `INetworkStatisticsCapability`
- Rename class `MonitoringNetwork` to `NetworkStatisticsCapability`
- Rename capability name `"netmonitoring"` to `"netstatistics"`
- ActionSet `MonitoringNetworkActionSet` to `NetworkStatisticsActionSet`

**Important note:** remember renaming capability name in descriptors after this change is applied.
