### PR TITLE
Include bod.drivers.dummy in opennaas platform.

### DIFF
--- a/extensions/bundles/all.features/src/main/resources/features.xml
+++ b/extensions/bundles/all.features/src/main/resources/features.xml
@@ -28,7 +28,7 @@
 		<feature version="${project.version}">opennaas-router-driver-all</feature>		
 		<feature version="${project.version}">opennaas-network</feature>
 		<feature version="${project.version}">opennaas-bod</feature>
-		<feature version="${project.version}">opennaas-bod-driver-autobahn</feature>			
+		<feature version="${project.version}">opennaas-bod-driver-all</feature>			
 		<feature version="${project.version}">opennaas-vnmapper</feature>
 		<feature version="${project.version}">opennaas-roadm</feature>
 		<feature version="${project.version}">opennaas-roadm-driver-proteus</feature>


### PR DESCRIPTION
This patch does so by including all bod drivers in all-features feature definition.
