### PR TITLE
Support requests specifying only one of min or max value per QoS parameter

### DIFF
--- a/extensions/bundles/genericnetwork/src/main/java/org/opennaas/extensions/genericnetwork/model/circuit/QoSPolicy.java
+++ b/extensions/bundles/genericnetwork/src/main/java/org/opennaas/extensions/genericnetwork/model/circuit/QoSPolicy.java
@@ -35,6 +35,8 @@ public class QoSPolicy implements Serializable {
 	 */
 	private static final long	serialVersionUID	= 7226728765828544543L;
 
+	public static final int		UNSPECIFIED_VALUE	= -1;
+
 	private int					minLatency;
 	private int					maxLatency;
 
@@ -47,7 +49,20 @@ public class QoSPolicy implements Serializable {
 	private int					minPacketLoss;
 	private int					maxPacketLoss;
 
+	public QoSPolicy() {
+		minLatency = UNSPECIFIED_VALUE;
+		maxLatency = UNSPECIFIED_VALUE;
+		minJitter = UNSPECIFIED_VALUE;
+		maxJitter = UNSPECIFIED_VALUE;
+		minThroughput = UNSPECIFIED_VALUE;
+		maxThroughput = UNSPECIFIED_VALUE;
+		minPacketLoss = UNSPECIFIED_VALUE;
+		maxPacketLoss = UNSPECIFIED_VALUE;
+	}
+
 	/**
+	 * -1 indicates UNSPECIFIED_VALUE
+	 * 
 	 * @return the minLantency
 	 */
 	public int getMinLatency() {
@@ -63,6 +78,8 @@ public class QoSPolicy implements Serializable {
 	}
 
 	/**
+	 * -1 indicates UNSPECIFIED_VALUE
+	 * 
 	 * @return the maxLatency
 	 */
 	public int getMaxLatency() {
@@ -78,6 +95,8 @@ public class QoSPolicy implements Serializable {
 	}
 
 	/**
+	 * -1 indicates UNSPECIFIED_VALUE
+	 * 
 	 * @return the minJitter
 	 */
 	public int getMinJitter() {
@@ -93,6 +112,8 @@ public class QoSPolicy implements Serializable {
 	}
 
 	/**
+	 * -1 indicates UNSPECIFIED_VALUE
+	 * 
 	 * @return the maxJitter
 	 */
 	public int getMaxJitter() {
@@ -108,6 +129,8 @@ public class QoSPolicy implements Serializable {
 	}
 
 	/**
+	 * -1 indicates UNSPECIFIED_VALUE
+	 * 
 	 * @return the minThroughput
 	 */
 	public int getMinThroughput() {
@@ -123,6 +146,8 @@ public class QoSPolicy implements Serializable {
 	}
 
 	/**
+	 * -1 indicates UNSPECIFIED_VALUE
+	 * 
 	 * @return the maxThroughput
 	 */
 	public int getMaxThroughput() {
@@ -138,6 +163,8 @@ public class QoSPolicy implements Serializable {
 	}
 
 	/**
+	 * -1 indicates UNSPECIFIED_VALUE
+	 * 
 	 * @return the minPacketLoss
 	 */
 	public int getMinPacketLoss() {
@@ -153,6 +180,8 @@ public class QoSPolicy implements Serializable {
 	}
 
 	/**
+	 * -1 indicates UNSPECIFIED_VALUE
+	 * 
 	 * @return the maxPaquetLoss
 	 */
 	public int getMaxPacketLoss() {

--- a/extensions/bundles/ofertie.ncl/src/main/java/org/opennaas/extensions/ofertie/ncl/helpers/QoSPolicyParser.java
+++ b/extensions/bundles/ofertie.ncl/src/main/java/org/opennaas/extensions/ofertie/ncl/helpers/QoSPolicyParser.java
@@ -56,8 +56,18 @@ public abstract class QoSPolicyParser {
 
 		Latency latency = new Latency();
 
-		latency.setMax(String.valueOf(genericNetQos.getMaxLatency()));
-		latency.setMin(String.valueOf(genericNetQos.getMinLatency()));
+		if (genericNetQos.getMaxLatency() == QoSPolicy.UNSPECIFIED_VALUE)
+			latency.setMax(null);
+		else
+			latency.setMax(String.valueOf(genericNetQos.getMaxLatency()));
+
+		if (genericNetQos.getMinLatency() == QoSPolicy.UNSPECIFIED_VALUE)
+			latency.setMin(null);
+		else
+			latency.setMin(String.valueOf(genericNetQos.getMinLatency()));
+
+		if (latency.getMax() == null && latency.getMin() == null)
+			latency = null;
 
 		return latency;
 	}
@@ -66,8 +76,18 @@ public abstract class QoSPolicyParser {
 
 		PacketLoss packetLoss = new PacketLoss();
 
-		packetLoss.setMax(String.valueOf(genericNetQos.getMaxPacketLoss()));
-		packetLoss.setMin(String.valueOf(genericNetQos.getMinPacketLoss()));
+		if (genericNetQos.getMaxPacketLoss() == QoSPolicy.UNSPECIFIED_VALUE)
+			packetLoss.setMax(null);
+		else
+			packetLoss.setMax(String.valueOf(genericNetQos.getMaxPacketLoss()));
+
+		if (genericNetQos.getMinPacketLoss() == QoSPolicy.UNSPECIFIED_VALUE)
+			packetLoss.setMin(null);
+		else
+			packetLoss.setMin(String.valueOf(genericNetQos.getMinPacketLoss()));
+
+		if (packetLoss.getMax() == null && packetLoss.getMin() == null)
+			packetLoss = null;
 
 		return packetLoss;
 	}
@@ -76,8 +96,18 @@ public abstract class QoSPolicyParser {
 
 		Throughput throughput = new Throughput();
 
-		throughput.setMax(String.valueOf(genericNetQos.getMaxThroughput()));
-		throughput.setMin(String.valueOf(genericNetQos.getMinThroughput()));
+		if (genericNetQos.getMaxThroughput() == QoSPolicy.UNSPECIFIED_VALUE)
+			throughput.setMax(null);
+		else
+			throughput.setMax(String.valueOf(genericNetQos.getMaxThroughput()));
+
+		if (genericNetQos.getMinThroughput() == QoSPolicy.UNSPECIFIED_VALUE)
+			throughput.setMin(null);
+		else
+			throughput.setMin(String.valueOf(genericNetQos.getMinThroughput()));
+
+		if (throughput.getMax() == null && throughput.getMin() == null)
+			throughput = null;
 
 		return throughput;
 	}
@@ -86,8 +116,18 @@ public abstract class QoSPolicyParser {
 
 		Jitter jitter = new Jitter();
 
-		jitter.setMax(String.valueOf(genericNetQos.getMaxJitter()));
-		jitter.setMin(String.valueOf(genericNetQos.getMinJitter()));
+		if (genericNetQos.getMaxJitter() == QoSPolicy.UNSPECIFIED_VALUE)
+			jitter.setMax(null);
+		else
+			jitter.setMax(String.valueOf(genericNetQos.getMaxJitter()));
+
+		if (genericNetQos.getMinJitter() == QoSPolicy.UNSPECIFIED_VALUE)
+			jitter.setMin(null);
+		else
+			jitter.setMin(String.valueOf(genericNetQos.getMinJitter()));
+
+		if (jitter.getMax() == null && jitter.getMin() == null)
+			jitter = null;
 
 		return jitter;
 	}

--- a/extensions/bundles/ofertie.ncl/src/main/java/org/opennaas/extensions/ofertie/ncl/helpers/QosPolicyRequestParser.java
+++ b/extensions/bundles/ofertie.ncl/src/main/java/org/opennaas/extensions/ofertie/ncl/helpers/QosPolicyRequestParser.java
@@ -80,37 +80,31 @@ public class QosPolicyRequestParser {
 			return null;
 
 		if (qosPolicy.getJitter() != null) {
-			if (StringUtils.isEmpty(qosPolicy.getJitter().getMax()) || StringUtils.isEmpty(qosPolicy.getJitter().getMin()))
-				throw new ProvisionerException("You didin't specify a valid Jitter value.");
-
-			qosToReturn.setMaxJitter(Integer.valueOf(qosPolicy.getJitter().getMax()));
-			qosToReturn.setMinJitter(Integer.valueOf(qosPolicy.getJitter().getMin()));
+			if (!StringUtils.isEmpty(qosPolicy.getJitter().getMax()))
+				qosToReturn.setMaxJitter(Integer.valueOf(qosPolicy.getJitter().getMax()));
+			if (!StringUtils.isEmpty(qosPolicy.getJitter().getMin()))
+				qosToReturn.setMinJitter(Integer.valueOf(qosPolicy.getJitter().getMin()));
 		}
 
 		if (qosPolicy.getLatency() != null) {
-			if (StringUtils.isEmpty(qosPolicy.getLatency().getMax()) || StringUtils.isEmpty(qosPolicy.getLatency().getMin()))
-				throw new ProvisionerException("You didin't specify a valid Latency value.");
-
-			qosToReturn.setMaxLatency(Integer.valueOf(qosPolicy.getLatency().getMax()));
-			qosToReturn.setMinLatency(Integer.valueOf(qosPolicy.getLatency().getMin()));
+			if (!StringUtils.isEmpty(qosPolicy.getLatency().getMax()))
+				qosToReturn.setMaxLatency(Integer.valueOf(qosPolicy.getLatency().getMax()));
+			if (!StringUtils.isEmpty(qosPolicy.getLatency().getMin()))
+				qosToReturn.setMinLatency(Integer.valueOf(qosPolicy.getLatency().getMin()));
 		}
 
 		if (qosPolicy.getPacketLoss() != null) {
-			if (StringUtils.isEmpty(qosPolicy.getPacketLoss().getMax()) || StringUtils.isEmpty(qosPolicy.getPacketLoss().getMin()))
-				throw new ProvisionerException("You didin't specify a valid PacketLoss value.");
-
-			qosToReturn.setMaxPacketLoss(Integer.valueOf(qosPolicy.getPacketLoss().getMax()));
-			qosToReturn.setMinPacketLoss(Integer.valueOf(qosPolicy.getPacketLoss().getMin()));
-
+			if (!StringUtils.isEmpty(qosPolicy.getPacketLoss().getMax()))
+				qosToReturn.setMaxPacketLoss(Integer.valueOf(qosPolicy.getPacketLoss().getMax()));
+			if (!StringUtils.isEmpty(qosPolicy.getPacketLoss().getMin()))
+				qosToReturn.setMinPacketLoss(Integer.valueOf(qosPolicy.getPacketLoss().getMin()));
 		}
 
 		if (qosPolicy.getThroughput() != null) {
-			if (StringUtils.isEmpty(qosPolicy.getThroughput().getMax()) || StringUtils.isEmpty(qosPolicy.getThroughput().getMin()))
-				throw new ProvisionerException("You didin't specify a valid Throughput value.");
-
-			qosToReturn.setMaxThroughput(Integer.valueOf(qosPolicy.getThroughput().getMax()));
-			qosToReturn.setMinThroughput(Integer.valueOf(qosPolicy.getThroughput().getMin()));
-
+			if (!StringUtils.isEmpty(qosPolicy.getThroughput().getMax()))
+				qosToReturn.setMaxThroughput(Integer.valueOf(qosPolicy.getThroughput().getMax()));
+			if (!StringUtils.isEmpty(qosPolicy.getThroughput().getMin()))
+				qosToReturn.setMinThroughput(Integer.valueOf(qosPolicy.getThroughput().getMin()));
 		}
 
 		return qosToReturn;

--- a/extensions/bundles/ofertie.ncl/src/test/java/org/opennaas/extensions/ofertie/ncl/test/QosPolicyRequestParserTest.java
+++ b/extensions/bundles/ofertie.ncl/src/test/java/org/opennaas/extensions/ofertie/ncl/test/QosPolicyRequestParserTest.java
@@ -106,23 +106,23 @@ public class QosPolicyRequestParserTest {
 
 		Assert.assertFalse(StringUtils.isEmpty(qos.getJitter().getMax()));
 		Assert.assertFalse(StringUtils.isEmpty(qos.getJitter().getMin()));
-		Assert.assertEquals(String.valueOf(GenericNetworkModelUtils.JITTER_MAX), qos.getJitter().getMax());
-		Assert.assertEquals(String.valueOf(GenericNetworkModelUtils.JITTER_MIN), qos.getJitter().getMin());
+		Assert.assertEquals("Max jitter should match", String.valueOf(GenericNetworkModelUtils.JITTER_MAX), qos.getJitter().getMax());
+		Assert.assertEquals("Min jitter should match", String.valueOf(GenericNetworkModelUtils.JITTER_MIN), qos.getJitter().getMin());
 
 		Assert.assertFalse(StringUtils.isEmpty(qos.getLatency().getMax()));
 		Assert.assertFalse(StringUtils.isEmpty(qos.getLatency().getMin()));
-		Assert.assertEquals(String.valueOf(GenericNetworkModelUtils.LATENCY_MAX), qos.getLatency().getMax());
-		Assert.assertEquals(String.valueOf(GenericNetworkModelUtils.LATENCY_MIN), qos.getLatency().getMin());
+		Assert.assertEquals("Max latency should match", String.valueOf(GenericNetworkModelUtils.LATENCY_MAX), qos.getLatency().getMax());
+		Assert.assertEquals("Min latency should match", String.valueOf(GenericNetworkModelUtils.LATENCY_MIN), qos.getLatency().getMin());
 
 		Assert.assertFalse(StringUtils.isEmpty(qos.getPacketLoss().getMax()));
 		Assert.assertFalse(StringUtils.isEmpty(qos.getPacketLoss().getMin()));
-		Assert.assertEquals(String.valueOf(GenericNetworkModelUtils.PACKETLOSS_MAX), qos.getPacketLoss().getMax());
-		Assert.assertEquals(String.valueOf(GenericNetworkModelUtils.PACKETLOSS_MIN), qos.getPacketLoss().getMin());
+		Assert.assertEquals("Max packetloss should match", String.valueOf(GenericNetworkModelUtils.PACKETLOSS_MAX), qos.getPacketLoss().getMax());
+		Assert.assertEquals("Min packetloss should match", String.valueOf(GenericNetworkModelUtils.PACKETLOSS_MIN), qos.getPacketLoss().getMin());
 
 		Assert.assertFalse(StringUtils.isEmpty(qos.getThroughput().getMax()));
 		Assert.assertFalse(StringUtils.isEmpty(qos.getThroughput().getMin()));
-		Assert.assertEquals(String.valueOf(GenericNetworkModelUtils.THROUGHPUT_MAX), qos.getThroughput().getMax());
-		Assert.assertEquals(String.valueOf(GenericNetworkModelUtils.THROUGHPUT_MIN), qos.getThroughput().getMin());
+		Assert.assertEquals("Max throughput should match", String.valueOf(GenericNetworkModelUtils.THROUGHPUT_MAX), qos.getThroughput().getMax());
+		Assert.assertEquals("Min throughput should match", String.valueOf(GenericNetworkModelUtils.THROUGHPUT_MIN), qos.getThroughput().getMin());
 
 	}
 }


### PR DESCRIPTION
QoSPolicy now uses a marked value (UNSPECIFIED_VALUE = -1) to indicate a value has not been specified.
Parsers for QoSPolicy now translate null values into UNSPECIFIED_VALUE, and vice-versa.

There is no need to change any driver implementation as QoSPolicy parameters are unused by now.

This patch fixes issue OPENNAAS-1367 (http://jira.i2cat.net:8080/browse/OPENNAAS-1367)
