### PR TITLE
Support multiple files appender in logs

### DIFF
--- a/platform/src/main/filtered-resources/etc/org.ops4j.pax.logging.cfg
+++ b/platform/src/main/filtered-resources/etc/org.ops4j.pax.logging.cfg
@@ -130,6 +130,7 @@ log4j.appender.allout.layout=org.apache.log4j.PatternLayout
 log4j.appender.allout.layout.ConversionPattern=${opennaas.log.usedPattern}
 log4j.appender.allout.file=${karaf.base}/data/log/all.log
 log4j.appender.allout.append=true
+log4j.appender.allout.maxBackupIndex=10
 
 # CORE file appender
 log4j.appender.coreout=org.apache.log4j.RollingFileAppender
@@ -138,6 +139,7 @@ log4j.appender.coreout.layout=org.apache.log4j.PatternLayout
 log4j.appender.coreout.layout.ConversionPattern=${opennaas.log.usedPattern}
 log4j.appender.coreout.file=${karaf.base}/data/log/core.log
 log4j.appender.coreout.append=true
+log4j.appender.coreout.maxBackupIndex=10
 
 # ROUTER file appender
 log4j.appender.routerout=org.apache.log4j.RollingFileAppender
@@ -146,6 +148,8 @@ log4j.appender.routerout.layout=org.apache.log4j.PatternLayout
 log4j.appender.routerout.layout.ConversionPattern=${opennaas.log.usedPattern}
 log4j.appender.routerout.file=${karaf.base}/data/log/router.log
 log4j.appender.routerout.append=true
+log4j.appender.routerout.maxBackupIndex=10
+
 
 # NETCONF file appender
 log4j.appender.netconfout=org.apache.log4j.RollingFileAppender
@@ -154,6 +158,7 @@ log4j.appender.netconfout.layout=org.apache.log4j.PatternLayout
 log4j.appender.netconfout.layout.ConversionPattern=${opennaas.log.usedPattern}
 log4j.appender.netconfout.file=${karaf.base}/data/log/router-netconf.log
 log4j.appender.netconfout.append=true
+log4j.appender.netconfout.maxBackupIndex=10
 
 # NETWORK file appender
 log4j.appender.networkout=org.apache.log4j.RollingFileAppender
@@ -162,6 +167,7 @@ log4j.appender.networkout.layout=org.apache.log4j.PatternLayout
 log4j.appender.networkout.layout.ConversionPattern=${opennaas.log.usedPattern}
 log4j.appender.networkout.file=${karaf.base}/data/log/network.log
 log4j.appender.networkout.append=true
+log4j.appender.networkout.maxBackupIndex=10
 
 # BOD file appender
 log4j.appender.bodout=org.apache.log4j.RollingFileAppender
@@ -170,6 +176,7 @@ log4j.appender.bodout.layout=org.apache.log4j.PatternLayout
 log4j.appender.bodout.layout.ConversionPattern=${opennaas.log.usedPattern}
 log4j.appender.bodout.file=${karaf.base}/data/log/bod.log
 log4j.appender.bodout.append=true
+log4j.appender.bodout.maxBackupIndex=10
 
 # VNMAPPER file appender
 log4j.appender.vnmapperout=org.apache.log4j.RollingFileAppender
@@ -178,6 +185,7 @@ log4j.appender.vnmapperout.layout=org.apache.log4j.PatternLayout
 log4j.appender.vnmapperout.layout.ConversionPattern=${opennaas.log.usedPattern}
 log4j.appender.vnmapperout.file=${karaf.base}/data/log/vnmapperout.log
 log4j.appender.vnmapperout.append=true
+log4j.appender.vnmapperout.maxBackupIndex=10
 
 # OFSWITCH file appender
 log4j.appender.ofswitchout=org.apache.log4j.RollingFileAppender
@@ -186,6 +194,7 @@ log4j.appender.ofswitchout.layout=org.apache.log4j.PatternLayout
 log4j.appender.ofswitchout.layout.ConversionPattern=${opennaas.log.usedPattern}
 log4j.appender.ofswitchout.file=${karaf.base}/data/log/ofswitchout.log
 log4j.appender.ofswitchout.append=true
+log4j.appender.ofswitchout.maxBackupIndex=10
 
 # QUANTUM file appender
 log4j.appender.quantumout=org.apache.log4j.RollingFileAppender
@@ -194,6 +203,7 @@ log4j.appender.quantumout.layout=org.apache.log4j.PatternLayout
 log4j.appender.quantumout.layout.ConversionPattern=${opennaas.log.usedPattern}
 log4j.appender.quantumout.file=${karaf.base}/data/log/quantumout.log
 log4j.appender.quantumout.append=true
+log4j.appender.quantumout.maxBackupIndex=10
 
 # NCL file appender
 log4j.appender.nclout=org.apache.log4j.RollingFileAppender
@@ -202,6 +212,7 @@ log4j.appender.nclout.layout=org.apache.log4j.PatternLayout
 log4j.appender.nclout.layout.ConversionPattern=${opennaas.log.usedPattern}
 log4j.appender.nclout.file=${karaf.base}/data/log/nclout.log
 log4j.appender.nclout.append=true
+log4j.appender.nclout.maxBackupIndex=10
 
 
 # OPTICALSWITCH file appender
@@ -211,6 +222,7 @@ log4j.appender.opticalswitchout.layout=org.apache.log4j.PatternLayout
 log4j.appender.opticalswitchout.layout.ConversionPattern=${opennaas.log.usedPattern}
 log4j.appender.opticalswitchout.file=${karaf.base}/data/log/opticalswitch.log
 log4j.appender.opticalswitchout.append=true
+log4j.appender.opticalswitchout.maxBackupIndex=10
 
 # MACBRIDGE file appender
 log4j.appender.macbridgeout=org.apache.log4j.RollingFileAppender
@@ -219,6 +231,7 @@ log4j.appender.macbridgeout.layout=org.apache.log4j.PatternLayout
 log4j.appender.macbridgeout.layout.ConversionPattern=${opennaas.log.usedPattern}
 log4j.appender.macbridgeout.file=${karaf.base}/data/log/macbridge.log
 log4j.appender.macbridgeout.append=true
+log4j.appender.macbridgeout.maxBackupIndex=10
 
 # VCPE file appender
 log4j.appender.vcpeout=org.apache.log4j.RollingFileAppender
@@ -227,6 +240,7 @@ log4j.appender.vcpeout.layout=org.apache.log4j.PatternLayout
 log4j.appender.vcpeout.layout.ConversionPattern=${opennaas.log.usedPattern}
 log4j.appender.vcpeout.file=${karaf.base}/data/log/vcpe.log
 log4j.appender.vcpeout.append=true
+log4j.appender.vcpeout.maxBackupIndex=10
 
 # PROTOCOLS file appender
 log4j.appender.protocolout=org.apache.log4j.RollingFileAppender
@@ -235,6 +249,7 @@ log4j.appender.protocolout.layout=org.apache.log4j.PatternLayout
 log4j.appender.protocolout.layout.ConversionPattern=${opennaas.log.usedPattern}
 log4j.appender.protocolout.file=${karaf.base}/data/log/protocols.log
 log4j.appender.protocolout.append=true
+log4j.appender.protocolout.maxBackupIndex=10
 
 # WS file appender 
 log4j.appender.wsout=org.apache.log4j.RollingFileAppender
@@ -243,6 +258,7 @@ log4j.appender.wsout.layout=org.apache.log4j.PatternLayout
 log4j.appender.wsout.layout.ConversionPattern=${opennaas.log.usedPattern}
 log4j.appender.wsout.file=${karaf.base}/data/log/ws.log
 log4j.appender.wsout.append=true
+log4j.appender.wsout.maxBackupIndex=10
 
 # ITESTS file appender
 log4j.appender.itestsout=org.apache.log4j.RollingFileAppender
@@ -251,3 +267,5 @@ log4j.appender.itestsout.layout=org.apache.log4j.PatternLayout
 log4j.appender.itestsout.layout.ConversionPattern=${opennaas.log.usedPattern}
 log4j.appender.itestsout.file=${karaf.base}/data/log/itests.log
 log4j.appender.itestsout.append=true
+log4j.appender.itestsout.maxBackupIndex=10
+


### PR DESCRIPTION
### Log4j Configuration
- Default maxBackupIndex value is 1. Therefore, we only had 1 appender file for the logs. New value is set to 10.
