### PR TITLE
Upgrade PaxExam version to 2.3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
 		<opensaml.version>2.4.1_1</opensaml.version>
 		<oro.version>2.0.8_4</oro.version>
 		<osgi.version>4.2.0</osgi.version>
-		<pax.exam2.version>2.3.0</pax.exam2.version>
+		<pax.exam2.version>2.3.1</pax.exam2.version>
 		<paxexam-karaf-container.version>0.5.1</paxexam-karaf-container.version>
 		<pax.logging.version>1.6.5</pax.logging.version>
 		<plexus.api.version>1.0-alpha-32</plexus.api.version>


### PR DESCRIPTION
Upgrade Pax-Exam version from 2.3.0 to 2.3.1 due to a bug in combination with latest Guava library upgraded version (from 10.0.1 to 16.0.1).

Documented bug and solution:
- Karaf bug: [KARAF-1207](https://issues.apache.org/jira/browse/KARAF-1207)
- PaxExam fixed release: [PAXEXAM-353](https://ops4j1.jira.com/browse/PAXEXAM-353)
