### PR TITLE
Delayed auto-reroute mechanism.

### DIFF
--- a/platform/src/main/filtered-resources/etc/org.ofertie.ncl.monitoring.cfg
+++ b/platform/src/main/filtered-resources/etc/org.ofertie.ncl.monitoring.cfg
@@ -2,4 +2,4 @@
 throughput_threshold = 50
 
 # Ofertie NCL Monitoring statistics poller frequency (seconds)
-statistics_poller_freq = 10
+statistics_poller_freq = 21

--- a/platform/src/main/filtered-resources/etc/org.opennaas.extensions.ofertie.ncl.cfg
+++ b/platform/src/main/filtered-resources/etc/org.opennaas.extensions.ofertie.ncl.cfg
@@ -1,0 +1,7 @@
+# Ofertie NCL Provisioning Capability configuration file
+
+# Tells the capability if it should launch auto reroute when congestion is detected (defaults to false)
+ncl.autoreroute=true
+
+# Tells the capability the amount of time in seconds it should wait before launching auto-reroute (when enabled) (defaults to 0, meaning don't wait)
+ncl.autoreroute.delay=10


### PR DESCRIPTION
Add the possibility to delay auto reroute mechanism.
Desired delay is configurable using the property ncl.autoreroute.delay in
org.opennaas.extensions.ofertie.ncl.cfg platform configuration file.

Statistics poller default time has been increased to avoid congestion detection when auto-reroute is pending.
