### PR TITLE
Feature/add vlan to circuits match

### DIFF
--- a/extensions/bundles/genericnetwork/src/main/java/org/opennaas/extensions/genericnetwork/capability/nclprovisioner/NCLProvisionerCapability.java
+++ b/extensions/bundles/genericnetwork/src/main/java/org/opennaas/extensions/genericnetwork/capability/nclprovisioner/NCLProvisionerCapability.java
@@ -127,6 +127,10 @@ public class NCLProvisionerCapability extends AbstractCapability implements INCL
 			Route route = pathFindingCapab.findPathForRequest(circuitRequest);
 			Circuit toAllocate = CircuitFactoryLogic.generateCircuit(circuitRequest, route);
 
+			// FIXME TO BE REMOVED: demo specific code.
+			if (circuitRequest.getVlan() != null && !circuitRequest.getVlan().isEmpty())
+				toAllocate.getTrafficFilter().setVlanId(circuitRequest.getVlan());
+
 			// call aggregation logic with all requested circuits and the one toAllocate
 			Set<Circuit> toAggregate = new HashSet<Circuit>();
 			toAggregate.addAll(getRequestedCircuits());
@@ -378,6 +382,10 @@ public class NCLProvisionerCapability extends AbstractCapability implements INCL
 
 		Circuit withNewRoute = CircuitFactoryLogic.generateCircuit(circuitRequest, route);
 		withNewRoute.setCircuitId(toReroute.getCircuitId());
+
+		// FIXME TO BE REMOVED: demo specific code.
+		if (toReroute.getTrafficFilter().getVlanId() != null && !toReroute.getTrafficFilter().getVlanId().isEmpty())
+			withNewRoute.getTrafficFilter().setVlanId(toReroute.getTrafficFilter().getVlanId());
 
 		// call aggregation logic with all requested circuits
 		// except the original one to be re-routed and with the one to be re-rerouted updated

--- a/extensions/bundles/genericnetwork/src/main/java/org/opennaas/extensions/genericnetwork/model/circuit/request/CircuitRequest.java
+++ b/extensions/bundles/genericnetwork/src/main/java/org/opennaas/extensions/genericnetwork/model/circuit/request/CircuitRequest.java
@@ -58,6 +58,21 @@ public class CircuitRequest {
 	@XmlElement(name = "qos_policy")
 	private QoSPolicy	qosPolicy;
 
+	// FIXME TO BE REMOVED: demo specific code.
+	@XmlAttribute(name = "vlan")
+	@XmlJavaTypeAdapter(NormalizedStringAdapter.class)
+	private String		vlan;
+
+	// FIXME TO BE REMOVED: demo specific code.
+	public String getVlan() {
+		return vlan;
+	}
+
+	// FIXME TO BE REMOVED: demo specific code.
+	public void setVlan(String vlan) {
+		this.vlan = vlan;
+	}
+
 	public String getAtomic() {
 		return atomic;
 	}

--- a/platform/src/main/filtered-resources/etc/org.ofertie.ncl.network.cfg
+++ b/platform/src/main/filtered-resources/etc/org.ofertie.ncl.network.cfg
@@ -2,3 +2,8 @@
 
 resource.type=genericnetwork
 resource.name=sdnNetwork
+
+
+# Specify a VLAN that will be added in the match for all circuit requests
+# -1 is the default value and indicates no VLAN will be set.
+circuits.match.vlan=-1


### PR DESCRIPTION
Add the option to set a vlan that will be used in the match for all circuits stablished by NCLProvisioner.

NCLProvisioner reads the option from the file org.ofertie.ncl.network.cfg
If a VLAN different than -1 is specified, it will be introduced in NCLProvisionerCapability requests.

NCLProvisionerCapability adds the VLAN (if any) to created circuits match.

IMPORTANT NOTE:
This patch is specific for a demo, and should never reach a standard release.
It does not respect modularity because it breaks component responsabilities.
