### PR TITLE
PathFinder takes into account congestion detected by NCLMonitoring.

### DIFF
--- a/extensions/bundles/genericnetwork/src/main/java/org/opennaas/extensions/genericnetwork/driver/internal/actionsets/actions/pathfinding/FindPathForRequestAction.java
+++ b/extensions/bundles/genericnetwork/src/main/java/org/opennaas/extensions/genericnetwork/driver/internal/actionsets/actions/pathfinding/FindPathForRequestAction.java
@@ -40,9 +40,12 @@ import org.opennaas.extensions.genericnetwork.capability.pathfinding.PathFinding
 import org.opennaas.extensions.genericnetwork.driver.internal.actionsets.actions.pathfinding.model.PathLoader;
 import org.opennaas.extensions.genericnetwork.driver.internal.actionsets.actions.pathfinding.model.RouteSelectionInput;
 import org.opennaas.extensions.genericnetwork.driver.internal.actionsets.actions.pathfinding.model.RouteSelectionLogic;
+import org.opennaas.extensions.genericnetwork.model.GenericNetworkModel;
 import org.opennaas.extensions.genericnetwork.model.circuit.NetworkConnection;
 import org.opennaas.extensions.genericnetwork.model.circuit.Route;
 import org.opennaas.extensions.genericnetwork.model.circuit.request.CircuitRequest;
+import org.opennaas.extensions.genericnetwork.model.topology.NetworkElement;
+import org.opennaas.extensions.genericnetwork.model.topology.Port;
 
 /**
  * 
@@ -210,9 +213,24 @@ public class FindPathForRequestAction extends Action {
 	private boolean isCongestedRoute(String routeId) {
 		Route route = routes.get(routeId);
 		for (NetworkConnection connection : route.getNetworkConnections())
-			if (connection.getSource().getState().isCongested() || connection.getDestination().getState().isCongested())
+			if (isCongestedPort(connection.getSource()) || isCongestedPort(connection.getDestination()))
 				return true;
 
 		return false;
 	}
+
+	private boolean isCongestedPort(Port port) {
+		if (((GenericNetworkModel) modelToUpdate).getTopology() != null) {
+			for (NetworkElement ne : ((GenericNetworkModel) modelToUpdate).getTopology().getNetworkElements()) {
+				for (Port aPort : ne.getPorts()) {
+					if (aPort.getId().equals(port.getId())) {
+						return aPort.getState().isCongested();
+					}
+				}
+			}
+		}
+		// if port is not in the model, it is considered not to be congested
+		return false;
+	}
+
 }


### PR DESCRIPTION
NCLMonitoring reports congestion in the resource model.

PathFinder was gathering congestion information from a configuration file, which is static.

This patch modifies pathfinder to look for congestion information in the resource model, just where  NCLMonitoring updates it.
