### PR TITLE
Fix replace method: deallocate before allocate.

### DIFF
--- a/extensions/bundles/genericnetwork/src/main/java/org/opennaas/extensions/genericnetwork/capability/circuitprovisioning/CircuitProvisioningCapability.java
+++ b/extensions/bundles/genericnetwork/src/main/java/org/opennaas/extensions/genericnetwork/capability/circuitprovisioning/CircuitProvisioningCapability.java
@@ -111,8 +111,11 @@ public class CircuitProvisioningCapability extends AbstractCapability implements
 			}
 		}
 
-		allocateCircuits(toAllocate);
+		// HAVE TO DEALLOCATE BEFORE ALLOCATE
+		// if toDllocate and toDeallocate contain circuits with same id but with different from each others (i.e. because of re-routing)
+		// doing this in reverse order would mean deallocating the newly allocated circuit.
 		deallocateCircuits(toDeallocate);
+		allocateCircuits(toAllocate);
 	}
 
 	private void allocateCircuits(List<Circuit> circuits) throws CapabilityException {


### PR DESCRIPTION
When same ids are given it was not behaving correctly. It was deleting newly created circuits.
