### PR TITLE
Try to reallocate only reallocable circuits.

### DIFF
--- a/extensions/bundles/genericnetwork/src/main/java/org/opennaas/extensions/genericnetwork/capability/nclprovisioner/NCLProvisionerCapability.java
+++ b/extensions/bundles/genericnetwork/src/main/java/org/opennaas/extensions/genericnetwork/capability/nclprovisioner/NCLProvisionerCapability.java
@@ -471,7 +471,8 @@ public class NCLProvisionerCapability extends AbstractCapability implements INCL
 				CircuitRequest circuitRequest = Circuit2RequestHelper.generateCircuitRequest(circuit.getQos(), circuit.getTrafficFilter());
 				alternativeRoute = pathFindingCapab.findPathForRequest(circuitRequest);
 			} catch (CapabilityException e) {
-				// ignored. CapabilityException means we were not able to get an alternative route
+				// ignored
+				log.debug("Unable to find uncongested alternative route for circuit " + circuit.getCircuitId() + ". Cause: " + e.getMessage());
 			}
 			if (alternativeRoute != null)
 				reallocableCircuits.add(circuit);


### PR DESCRIPTION
This patch solves a bug:
- With previous circuit selection strategy (select always the first circuit using given port) it may happen that the first one had no alternative route, and thus, fails to be re-routed in next steps. In that case, the circuit without alternative keeps being the first in the list and keeps being selected each time the re-route mechanism is triggered, although is not re-routed. This causes no harm if that circuit is the only one, but when other circuits are available, it may be the case that re-routing these others solves congestion. However, the strategy will never try these others :(

This patch solves this issue by picking up a circuit that is known to have an alternative route.
This way, each time the re-routing mechanism is triggered, a circuit is re-routed (if any available).
