### PR TITLE
Update netconf-server version and fix poms

### DIFF
--- a/core/resources/pom.xml
+++ b/core/resources/pom.xml
@@ -67,7 +67,13 @@
 		<dependency>
 			<groupId>net.i2cat.netconf</groupId>
 			<artifactId>netconf4j</artifactId>
+			<scope>test</scope>
 		</dependency>	
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<scope>test</scope>
+		</dependency>
 		<!-- REST annotations -->
 		<dependency>
 			<groupId>org.apache.servicemix.specs</groupId>

--- a/extensions/bundles/genericnetwork/pom.xml
+++ b/extensions/bundles/genericnetwork/pom.xml
@@ -35,6 +35,11 @@
 			<artifactId>commons-lang3</artifactId>
 			<!-- Required version is 3.0.1 or above as of http://jira.i2cat.net:8080/browse/OPENNAAS-1392-->
 		</dependency>
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/extensions/bundles/ofertie.ncl/pom.xml
+++ b/extensions/bundles/ofertie.ncl/pom.xml
@@ -47,7 +47,12 @@
 			<groupId>org.powermock</groupId>
 			<artifactId>powermock-api-mockito</artifactId>
 			<scope>test</scope>
-		</dependency>		
+		</dependency>
+		<dependency>
+			<groupId>commons-configuration</groupId>
+			<artifactId>commons-configuration</artifactId>
+		</dependency>
+				
 	</dependencies>
 	<build>
 		<plugins>

--- a/extensions/bundles/router.capabilities.api/pom.xml
+++ b/extensions/bundles/router.capabilities.api/pom.xml
@@ -13,6 +13,11 @@
 			<groupId>org.opennaas</groupId>
 			<artifactId>org.opennaas.extensions.router.model</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 <build>
 		<plugins>

--- a/extensions/bundles/router.capability.ip/pom.xml
+++ b/extensions/bundles/router.capability.ip/pom.xml
@@ -46,6 +46,11 @@
 			<artifactId>powermock-api-mockito</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<scope>test</scope>
+		</dependency>		
 	</dependencies>
 	<build>
 		<plugins>

--- a/itests/core/pom.xml
+++ b/itests/core/pom.xml
@@ -33,7 +33,7 @@
 			<groupId>org.opennaas</groupId>
 			<artifactId>org.opennaas.extensions.protocols.netconf</artifactId>
 		</dependency>
-		
+
 	</dependencies>
 
 </project>

--- a/itests/helpers/pom.xml
+++ b/itests/helpers/pom.xml
@@ -14,7 +14,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<packaging>bundle</packaging>
 
-		<dependencies>
+	<dependencies>
 		<dependency>
 			<groupId>org.opennaas</groupId>
 			<artifactId>org.opennaas.core.resources</artifactId>
@@ -80,8 +80,13 @@
 			<groupId>commons-lang</groupId>
 			<artifactId>commons-lang</artifactId>
 		</dependency>
-            
-            
+     
+   		<dependency>
+			<groupId>net.i2cat</groupId>
+			<artifactId>netconf-server</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+     
 	</dependencies>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 		<commons.configuration.version>1.6</commons.configuration.version>
 		<commons.dbcp.version>1.2.2_7</commons.dbcp.version>
 		<commons.digester.version>2.1</commons.digester.version>
-		<commons.io.version>1.4</commons.io.version>
+		<commons.io.version>2.4</commons.io.version>
 		<commons.jxpath.version>1.2_5</commons.jxpath.version>
 		<commons-lang.version>2.5</commons-lang.version>
 		<commons-lang3.version>3.3.2</commons-lang3.version>
@@ -140,7 +140,7 @@
 		<project.name>OpenNaaS</project.name>
 		
 		<!-- Netconf server for itests -->
-		<netconf-server.version>0.0.3</netconf-server.version>
+		<netconf-server.version>0.0.4</netconf-server.version>
 	</properties>
 
 	<dependencyManagement>
@@ -1195,6 +1195,12 @@
 				<groupId>org.eclipse.jetty</groupId>
 				<artifactId>jetty-http</artifactId>
 	           <version>${jetty.version}</version>				
+			</dependency>
+			
+			<dependency>
+				<groupId>commons-io</groupId>
+				<artifactId>commons-io</artifactId>
+				<version>${commons.io.version}</version>
 			</dependency>
 
 		</dependencies>


### PR DESCRIPTION
- Core only depends on netconf4j for testing. It implies that many projects need to import the commons-io right now (for testing as well).
  -Update netconf-server to solve problems with itests-helpers features.
