### PR TITLE
NCLMonitoring still uses INetworkStatisticsCapability to get statistics.

### DIFF
--- a/extensions/bundles/genericnetwork/src/main/java/org/opennaas/extensions/genericnetwork/capability/nclmonitoring/NCLMonitoring.java
+++ b/extensions/bundles/genericnetwork/src/main/java/org/opennaas/extensions/genericnetwork/capability/nclmonitoring/NCLMonitoring.java
@@ -166,7 +166,6 @@ public class NCLMonitoring {
 					// congested ports temp var
 					Set<Port> newCongestedPorts = new HashSet<Port>();
 
-					//FIXME use PortStatisticsCapability to get statistics
 					log.debug("Getting network statistics...");
 					NetworkStatistics currentNetworkStatistics = readCurrentNetworkStatistics(network);
 					long currentTimestamp = System.currentTimeMillis();


### PR DESCRIPTION
NCLMonitoring still uses INetworkStatisticsCapability to get statistics with element id.

A network uses its own INetworkStatisticsCapability to get PortStatistics of all its elements.
INetworkStatisticsCapability at its turn uses IPortStatistics capability of each network element to get the PortStatistics, and translates the port ids.

OFSwitch resources allready have an IPortStatistics implementation.
GenericNetwork will also have an IPortStatistics implementation.
This implementation will use INetworkStatisticsCapability to retrieve PortStatistics with the element id, and will create a PortStatistics object (removing element id from NetworkStatistics).
