### PR TITLE
Secure Ofertie URLs

### DIFF
--- a/core/security/src/main/resources/META-INF/spring/security-context.xml
+++ b/core/security/src/main/resources/META-INF/spring/security-context.xml
@@ -16,7 +16,7 @@
 	<bean id="mySecurityFilterChain" class="org.springframework.security.web.FilterChainProxy">
 		<security:filter-chain-map request-matcher="ant">
 			<!-- Unsecured urls -->
-			<security:filter-chain pattern="/opennaas/ofertie/**" filters="none" />
+			<!-- <security:filter-chain pattern="/opennaas/ofertie/**" filters="none" /> -->
 			<!-- Secured urls -->
 			<security:filter-chain pattern="/opennaas/**"
 				filters="securityContextPersistenceFilterWithASCFalseSkippingClearContext,


### PR DESCRIPTION
Now any URL accessed via HTTP REST WS is secured, including Ofertie ones.
We should take it into account in order to develop clients or modify current ones.
Fixes [OPENNAAS-1407](http://jira.i2cat.net/browse/OPENNAAS-1407).
