### PR TITLE
Fix several bugs in nclprovisioner capability and ncl provisioner tests.

### DIFF
--- a/extensions/bundles/ofertie.ncl/pom.xml
+++ b/extensions/bundles/ofertie.ncl/pom.xml
@@ -88,7 +88,9 @@
 							org.opennaas.extensions.ofertie.ncl.provisioner.api.model,
 							org.opennaas.extensions.ofertie.ncl.provisioner.api.wrapper,
 							org.opennaas.extensions.ofertie.ncl.controller.api,
-							org.opennaas.extensions.ofertie.ncl.monitoring.api.model
+							org.opennaas.extensions.ofertie.ncl.monitoring.api.model,
+							org.opennaas.extensions.ofertie.ncl.provisioner.components,
+							org.opennaas.extensions.ofertie.ncl.notification
 						</Export-Package>
 					</instructions>
 				</configuration>

--- a/extensions/bundles/ofertie.ncl/src/main/java/org/opennaas/extensions/ofertie/ncl/provisioner/NCLProvisioner.java
+++ b/extensions/bundles/ofertie.ncl/src/main/java/org/opennaas/extensions/ofertie/ncl/provisioner/NCLProvisioner.java
@@ -256,11 +256,13 @@ public class NCLProvisioner implements INCLProvisioner {
 
 				nclProvCapab.deallocateCircuit(flowId);
 
+				QosPolicyRequest requestRemoved = QosPolicyRequestParser.fromCircuitRequest((getAllocatedRequests().get(flowId)));
+
 				getAllocatedRequests().remove(flowId);
 
 				log.debug("Notifiying SDN Module flow " + flowId + " has been deallocated.");
 
-				sdnClient.qosPolicyDeallocated(flowId, QosPolicyRequestParser.fromCircuitRequest((getAllocatedRequests().get(flowId))));
+				sdnClient.qosPolicyDeallocated(flowId, requestRemoved);
 
 			} catch (NotExistingCircuitException e) {
 				throw new FlowNotFoundException(e);

--- a/itests/ofertie.ncl/pom.xml
+++ b/itests/ofertie.ncl/pom.xml
@@ -39,5 +39,14 @@
  			<artifactId>org.opennaas.extensions.genericnetwork</artifactId>
 		</dependency>
 		
+		<dependency>
+			<groupId>org.powermock</groupId>
+			<artifactId>powermock-module-junit4</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.powermock</groupId>
+			<artifactId>powermock-api-mockito</artifactId>
+		</dependency>
+		
   </dependencies>
 </project>

--- a/itests/ofertie.ncl/src/test/java/org/opennaas/itests/ofertie/ncl/NCLWithMockServerTest.java
+++ b/itests/ofertie.ncl/src/test/java/org/opennaas/itests/ofertie/ncl/NCLWithMockServerTest.java
@@ -28,6 +28,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -46,6 +47,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mockito;
 import org.opennaas.core.endpoints.WSEndpointListenerHandler;
 import org.opennaas.core.resources.IResource;
 import org.opennaas.core.resources.IResourceManager;
@@ -63,12 +65,14 @@ import org.opennaas.extensions.genericnetwork.capability.nclprovisioner.NCLProvi
 import org.opennaas.extensions.genericnetwork.capability.nettopology.NetTopologyCapability;
 import org.opennaas.extensions.genericnetwork.capability.pathfinding.PathFindingCapability;
 import org.opennaas.extensions.genericnetwork.capability.pathfinding.PathFindingParamsMapping;
+import org.opennaas.extensions.ofertie.ncl.notification.INCLNotifierClient;
 import org.opennaas.extensions.ofertie.ncl.provisioner.api.INCLProvisioner;
 import org.opennaas.extensions.ofertie.ncl.provisioner.api.exceptions.FlowAllocationException;
 import org.opennaas.extensions.ofertie.ncl.provisioner.api.exceptions.ProvisionerException;
 import org.opennaas.extensions.ofertie.ncl.provisioner.api.model.Destination;
 import org.opennaas.extensions.ofertie.ncl.provisioner.api.model.QosPolicyRequest;
 import org.opennaas.extensions.ofertie.ncl.provisioner.api.model.Source;
+import org.opennaas.extensions.ofertie.ncl.provisioner.components.ClientManager;
 import org.opennaas.extensions.openflowswitch.capability.offorwarding.OpenflowForwardingCapability;
 import org.opennaas.extensions.openflowswitch.driver.floodlight.protocol.FloodlightProtocolSession;
 import org.opennaas.extensions.openflowswitch.model.FloodlightOFAction;
@@ -88,6 +92,7 @@ import org.ops4j.pax.exam.junit.PaxExam;
 import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
 import org.ops4j.pax.exam.spi.reactors.PerClass;
 import org.osgi.framework.BundleContext;
+import org.powermock.api.mockito.PowerMockito;
 
 /**
  * 
@@ -180,6 +185,11 @@ public class NCLWithMockServerTest extends MockHTTPServerTest {
 	private static final String			IP_ETHER_TYPE						= "0x0800";
 	private static final String			SRC_IP								= "192.168.10.10";
 	private static final String			DST_IP								= "192.168.10.11";
+
+	// mock sdn notifications
+	ClientManager						mockClientManager;
+	INCLNotifierClient					mockSdnClient;
+
 	@Inject
 	private IResourceManager			resourceManager;
 
@@ -198,7 +208,7 @@ public class NCLWithMockServerTest extends MockHTTPServerTest {
 				OpennaasExamOptions.opennaasDistributionConfiguration(),
 				OpennaasExamOptions.includeFeatures("opennaas-openflowswitch", "opennaas-genericnetwork",
 						"opennaas-openflowswitch-driver-floodlight", "opennaas-ofertie-ncl", "itests-helpers"),
-				OpennaasExamOptions.noConsole(), OpennaasExamOptions.doNotDelayShell(), 
+				OpennaasExamOptions.noConsole(), OpennaasExamOptions.doNotDelayShell(),
 				OpennaasExamOptions.keepLogConfiguration(),
 				OpennaasExamOptions.keepRuntimeFolder());
 	}
@@ -213,6 +223,15 @@ public class NCLWithMockServerTest extends MockHTTPServerTest {
 
 		createSDNNetwork();
 		createSwitches();
+
+		// mock and inject clientManager returning mocked sdnClient
+		mockSdnClient = PowerMockito.mock(INCLNotifierClient.class);
+		mockClientManager = PowerMockito.mock(ClientManager.class);
+		Field f = provisioner.getClass().getDeclaredField("clientManager");
+		f.setAccessible(true);
+		f.set(provisioner, mockClientManager);
+
+		PowerMockito.when(mockClientManager.getClient(Mockito.anyString())).thenReturn(mockSdnClient);
 
 		log.info("Test initialized.");
 	}


### PR DESCRIPTION
NCLProvisionerCapability:
- If SLA Manager information did not exists, it launches a capability exception. This capability exception was caught  by the Resource when starting its capabilities, and the capability was shut down. But NCLProvisioner capability should work even when there's no need to push information to SLA.
- Solve nullpointers regarding SLA notification and event listener when they're not initialized (nullpointer resided in deactivate method, which assumed they are not null -> they were initialized)

NCLProvisionerTest
- Mock sdnNotification client with powermockito.
