### PR TITLE
Feature/openstack adapter

### DIFF
--- a/extensions/bundles/openstack/pom.xml
+++ b/extensions/bundles/openstack/pom.xml
@@ -16,6 +16,18 @@
 			<groupId>org.opennaas</groupId>
 			<artifactId>org.opennaas.core.resources</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.jclouds</groupId>
+			<artifactId>jclouds-all</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.jclouds.labs</groupId>
+			<artifactId>openstack-neutron</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.opennaas</groupId>
+			<artifactId>org.opennaas.extensions.protocols.http</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/extensions/bundles/openstack/src/main/java/org/opennaas/extensions/openstack/capability/openstackadapter/IOpenstackAdapterCapability.java
+++ b/extensions/bundles/openstack/src/main/java/org/opennaas/extensions/openstack/capability/openstackadapter/IOpenstackAdapterCapability.java
@@ -25,6 +25,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.QueryParam;
 
+import org.opennaas.core.resources.capability.CapabilityException;
 import org.opennaas.core.resources.capability.ICapability;
 
 /**
@@ -37,10 +38,10 @@ public interface IOpenstackAdapterCapability extends ICapability {
 
 	@Path("/instance")
 	@GET
-    String getInstanceId(@QueryParam("name") String instanceName);
-	
+	String getInstanceId(@QueryParam("name") String instanceName, @QueryParam("tenantName") String tenantName) throws CapabilityException;
+
 	@Path("/instance/{instanceId}/port")
 	@GET
-    String getPortId(@PathParam("instanceId") String instanceId);
+	String getPortId(@PathParam("instanceId") String instanceId, @QueryParam("tenantName") String tenantName) throws CapabilityException;
 
 }

--- a/extensions/bundles/openstack/src/main/java/org/opennaas/extensions/openstack/capability/openstackadapter/OpenstackAdaperCapability.java
+++ b/extensions/bundles/openstack/src/main/java/org/opennaas/extensions/openstack/capability/openstackadapter/OpenstackAdaperCapability.java
@@ -20,32 +20,56 @@ package org.opennaas.extensions.openstack.capability.openstackadapter;
  * #L%
  */
 
+import java.util.Set;
+
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.jclouds.ContextBuilder;
+import org.jclouds.openstack.neutron.v2.NeutronApi;
+import org.jclouds.openstack.neutron.v2.domain.Port;
+import org.jclouds.openstack.neutron.v2.features.PortApi;
+import org.jclouds.openstack.nova.v2_0.NovaApi;
+import org.jclouds.openstack.nova.v2_0.domain.Server;
+import org.jclouds.openstack.nova.v2_0.features.ServerApi;
+import org.opennaas.core.resources.ActivatorException;
 import org.opennaas.core.resources.action.IAction;
 import org.opennaas.core.resources.action.IActionSet;
 import org.opennaas.core.resources.capability.AbstractCapability;
 import org.opennaas.core.resources.capability.CapabilityException;
 import org.opennaas.core.resources.descriptor.CapabilityDescriptor;
+import org.opennaas.core.resources.protocol.IProtocolSession;
+import org.opennaas.core.resources.protocol.IProtocolSessionManager;
+import org.opennaas.core.resources.protocol.ProtocolException;
+import org.opennaas.core.resources.protocol.ProtocolSessionContext;
 import org.opennaas.extensions.openstack.Activator;
+import org.opennaas.extensions.protocols.http.HttpProtocolSession;
 
 /**
  * 
  * @author Isart Canyameres Gimenez (i2cat)
+ * @author Adrián Roselló Rey (i2CAT)
  * 
  */
 public class OpenstackAdaperCapability extends AbstractCapability implements IOpenstackAdapterCapability {
 
-	public static final String	CAPABILITY_TYPE			= "openstackadapter";
-	
-	private Log					log						= LogFactory.getLog(OpenstackAdaperCapability.class);
-	private String				resourceId				= "";
-	
+	public static final String	CAPABILITY_TYPE		= "openstackadapter";
+
+	private Log					log					= LogFactory.getLog(OpenstackAdaperCapability.class);
+	private String				resourceId			= "";
+
+	private final static String	NOVA_PROVIDER_ID	= "openstack-nova";
+	private final static String	NEUTRON_PROVIDER_ID	= "openstack-neutron";
+
+	private NovaApi				novaClient;
+	private NeutronApi			neutronClient;
+
+	private IProtocolSession	protocolSession;
+
 	public OpenstackAdaperCapability(CapabilityDescriptor descriptor, String resourceId) {
 		super(descriptor);
 		this.resourceId = resourceId;
 		log.debug("Built new NCLProvisioner Capability");
-
 	}
 
 	@Override
@@ -58,6 +82,7 @@ public class OpenstackAdaperCapability extends AbstractCapability implements IOp
 		registerService(Activator.getContext(), CAPABILITY_TYPE, getResourceType(), getResourceName(),
 				IOpenstackAdapterCapability.class.getName());
 		super.activate();
+
 	}
 
 	@Override
@@ -67,15 +92,66 @@ public class OpenstackAdaperCapability extends AbstractCapability implements IOp
 	}
 
 	@Override
-	public String getInstanceId(String instanceName) {
-		// TODO Auto-generated method stub
-		return null;
+	public String getInstanceId(String instanceName, String tenantName) throws CapabilityException {
+		try {
+			if (StringUtils.isEmpty(instanceName) || StringUtils.isEmpty(tenantName))
+				throw new NullPointerException("Instance name is required.");
+
+			protocolSession = getHttpProtocolSession(Activator.getProtocolManagerService().getProtocolSessionManager(resourceId));
+
+			String username = (String) protocolSession.getSessionContext().getSessionParameters().get(ProtocolSessionContext.USERNAME);
+			String password = (String) protocolSession.getSessionContext().getSessionParameters().get(ProtocolSessionContext.PASSWORD);
+			String uri = (String) protocolSession.getSessionContext().getSessionParameters().get(ProtocolSessionContext.PROTOCOL_URI);
+
+			String identity = new StringBuilder().append(tenantName).append(":").append(username).toString();
+
+			novaClient = ContextBuilder.newBuilder(NOVA_PROVIDER_ID).endpoint(uri).credentials(identity, password)
+					.buildApi(NovaApi.class);
+
+			Set<String> zones = novaClient.getConfiguredZones();
+			for (String zone : zones) {
+				ServerApi serverApi = novaClient.getServerApiForZone(zone);
+
+				for (Server server : serverApi.listInDetail().concat())
+					if (StringUtils.equals(server.getName(), instanceName))
+						return server.getId();
+
+			}
+
+		} catch (ProtocolException p) {
+			throw new CapabilityException(p);
+		} catch (ActivatorException p) {
+			throw new CapabilityException(p);
+		}
+		throw new CapabilityException("There's no instance with name: " + instanceName);
 	}
 
 	@Override
-	public String getPortId(String instanceId) {
-		// TODO Auto-generated method stub
-		return null;
+	public String getPortId(String instanceId, String tenantName) throws CapabilityException {
+
+		if (StringUtils.isEmpty(instanceId) || StringUtils.isEmpty(tenantName))
+			throw new NullPointerException("InstanceId and tenantName parameters are required.");
+
+		String username = (String) protocolSession.getSessionContext().getSessionParameters().get(ProtocolSessionContext.USERNAME);
+		String password = (String) protocolSession.getSessionContext().getSessionParameters().get(ProtocolSessionContext.PASSWORD);
+		String uri = (String) protocolSession.getSessionContext().getSessionParameters().get(ProtocolSessionContext.PROTOCOL_URI);
+
+		String identity = new StringBuilder().append(tenantName).append(":").append(username).toString();
+
+		neutronClient = ContextBuilder.newBuilder(NEUTRON_PROVIDER_ID).endpoint(uri).credentials(identity, password)
+				.buildApi(NeutronApi.class);
+
+		Set<String> zones = neutronClient.getConfiguredRegions();
+		for (String zone : zones) {
+			PortApi portApi = neutronClient.getPortApi(zone);
+			for (Port port : portApi.list().concat()) {
+				if (StringUtils.equals(instanceId, port.getDeviceId()))
+					return port.getId();
+			}
+		}
+
+		throw new CapabilityException("There's no port in instance: " + instanceId);
+
 	}
 
 	@Override
@@ -86,5 +162,9 @@ public class OpenstackAdaperCapability extends AbstractCapability implements IOp
 	@Override
 	public IActionSet getActionSet() throws CapabilityException {
 		throw new UnsupportedOperationException("Not implemented");
+	}
+
+	protected HttpProtocolSession getHttpProtocolSession(IProtocolSessionManager protocolSessionManager) throws ProtocolException {
+		return (HttpProtocolSession) protocolSessionManager.obtainSessionByProtocol(HttpProtocolSession.HTTP_PROTOCOL_TYPE, false);
 	}
 }

--- a/extensions/bundles/openstack/src/main/resources/features.xml
+++ b/extensions/bundles/openstack/src/main/resources/features.xml
@@ -1,6 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <features xmlns="http://karaf.apache.org/xmlns/features/v1.0.0">	
+
+	<repository>mvn:org.apache.jclouds.karaf/jclouds-karaf/${jclouds.version}/xml/features</repository>	
+	<repository>mvn:org.opennaas/org.opennaas.extensions.protocols.features/${project.version}/xml/features</repository>	
+
+
 	<feature name="opennaas-openstack" version="${project.version}">
-		<bundle>mvn:org.opennaas/org.opennaas.extensions.openstack/${project.version}</bundle>
+		<feature version="${project.version}">opennaas-protocol-http</feature>		
+	
+		<feature version="${jclouds.version}">jclouds</feature>
+		<feature version="${jclouds.version}">jclouds-api-openstack-keystone</feature>		
+		<feature version="${jclouds.version}">jclouds-api-openstack-nova</feature>
+
+		<bundle dependency="true">wrap:mvn:org.apache.jclouds.labs/openstack-neutron/${jclouds.version}$overwrite=merge&amp;Import-Package=com.google.common.base;version=&quot;[17.0,18)&quot;,com.google.common.cache;version=&quot;[17.0,18)&quot;,com.google.common.collect;version=&quot;[17.0,18)&quot;,com.google.gson.annotations;version=&quot;[2.2,3)&quot;,com.google.inject;version=&quot;[1.3,2)&quot;,com.google.inject.binder;version=&quot;[1.3,2)&quot;,javax.inject,javax.ws.rs;version=&quot;[1.1,2)&quot;,org.jclouds;version=&quot;${jclouds.version}&quot;,org.jclouds.apis;version=&quot;${jclouds.version}&quot;,org.jclouds.apis.internal;version=&quot;${jclouds.version}&quot;,org.jclouds.collect;version=&quot;${jclouds.version}&quot;,org.jclouds.collect.internal;version=&quot;${jclouds.version}&quot;,org.jclouds.http;version=&quot;${jclouds.version}&quot;,org.jclouds.http.annotation;version=&quot;${jclouds.version}&quot;,org.jclouds.http.functions;version=&quot;${jclouds.version}&quot;,org.jclouds.io;version=&quot;${jclouds.version}&quot;,org.jclouds.javax.annotation;version=&quot;${jclouds.version}&quot;,org.jclouds.json;version=&quot;${jclouds.version}&quot;,org.jclouds.json.config;version=&quot;${jclouds.version}&quot;,org.jclouds.location;version=&quot;${jclouds.version}&quot;,org.jclouds.location.functions;version=&quot;${jclouds.version}&quot;,org.jclouds.openstack.keystone.v2_0;version=&quot;${jclouds.version}&quot;,org.jclouds.openstack.keystone.v2_0.config;version=&quot;${jclouds.version}&quot;,org.jclouds.openstack.keystone.v2_0.filters;version=&quot;${jclouds.version}&quot;,org.jclouds.openstack.v2_0.domain;version=&quot;${jclouds.version}&quot;,org.jclouds.openstack.v2_0.features;version=&quot;${jclouds.version}&quot;,org.jclouds.openstack.v2_0.functions;version=&quot;${jclouds.version}&quot;,org.jclouds.openstack.v2_0.options;version=&quot;${jclouds.version}&quot;,org.jclouds.openstack.v2_0.services;version=&quot;${jclouds.version}&quot;,org.jclouds.rest;version=&quot;${jclouds.version}&quot;,org.jclouds.rest.annotations;version=&quot;${jclouds.version}&quot;,org.jclouds.rest.binders;version=&quot;${jclouds.version}&quot;,org.jclouds.rest.config;version=&quot;${jclouds.version}&quot;,org.jclouds.rest.functions;version=&quot;${jclouds.version}&quot;,org.jclouds.rest.internal;version=&quot;${jclouds.version}&quot;,org.jclouds.util;version=&quot;${jclouds.version}&quot;&amp;Export-Package=org.jclouds.openstack.neutron.v2;version=&quot;${jclouds.version}&quot;,org.jclouds.openstack.neutron.v2.domain;version=&quot;${jclouds.version}&quot;,org.jclouds.openstack.neutron.v2.features;version=&quot;${jclouds.version}&quot;</bundle>
+	
+		<bundle>mvn:org.opennaas/org.opennaas.extensions.openstack/${project.version}</bundle>  
 	</feature>
 </features>

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,8 @@
 		<jackson.version>1.9.12</jackson.version>
 		<javamail.version>1.4.4</javamail.version>
 		<javax.ws.rs.version>2.0.0.m10</javax.ws.rs.version>
-		<jaxb.impl.version>2.2.1.1_1</jaxb.impl.version>		
+		<jaxb.impl.version>2.2.1.1_1</jaxb.impl.version>
+		<jclouds.version>1.8.1</jclouds.version>
 		<jersey-bundle.version>1.10-b01</jersey-bundle.version>	
 		<jersey-core.version>1.12</jersey-core.version>
 		<jetty.version>7.5.4.v20111024</jetty.version>
@@ -1224,6 +1225,16 @@
 				<groupId>net.sf.opencsv</groupId>
 				<artifactId>opencsv</artifactId>
 				<version>${opencsv.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.jclouds</groupId>
+				<artifactId>jclouds-all</artifactId>
+				<version>${jclouds.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.jclouds.labs</groupId>
+				<artifactId>openstack-neutron</artifactId>
+				<version>${jclouds.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
 		<geronimo.jta.version>1.1.1</geronimo.jta.version>
 		<geronimo.wsmetadata.version>1.1.3</geronimo.wsmetadata.version>
 		<geronimo.servlet.version>1.1.2</geronimo.servlet.version>
-		<guava.version>16.0.1</guava.version>
+		<guava.version>17.0</guava.version>
 		<hibernate.version>3.6.9.Final</hibernate.version>
 		<hibernate-validator>4.3.0.Final</hibernate-validator>
 		<hibernate.jpa-api.version>2.0-cr-1</hibernate.jpa-api.version>


### PR DESCRIPTION
This pull request introduces the implementation of the Openstack-adapter capability.

This capability uses the jclouds library (introduces in OpenNaaS in this pull request) to:

- Get the id of a specific instance.
- Get the port of a specific instance.

The jclouds library required to update the Guava version from 16.0.1 to 17.0. 

The features of the openstack bundle required to wrap the jcloud-neutron library, since manifest was broken. It seems like in future versions of jclouds library this error is fixed (but it's still in snapshot version and under development) 

