### PR TITLE
Upgrade netconf4j version to resolve guava conflict.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
 		<log4j.version>1.2.16</log4j.version>
 		<mantychore.version>${project.version}</mantychore.version>
 		<neethi.version>3.0.0</neethi.version>
-		<netconf4j.version>0.0.9</netconf4j.version>
+		<netconf4j.version>0.0.10-SNAPSHOT</netconf4j.version>
 		<nmr.version>1.6.1</nmr.version>
 		<opencsv.version>2.3</opencsv.version>
 		<openjpa.version>2.2.0</openjpa.version>


### PR DESCRIPTION
This version of guava upgrades guava to version 17.0, resolving the conflicts we had. Even though we should depend not on snapshot versions, I don't think it's a good idea to pubilsh a new netconf4j release with the minor fix of upgrading guava version...