### PR TITLE
Fix/guava dependency ryu

### DIFF
--- a/extensions/bundles/ryu/src/main/resources/features.xml
+++ b/extensions/bundles/ryu/src/main/resources/features.xml
@@ -16,6 +16,8 @@
 		<bundle dependency="true">mvn:org.codehaus.jackson/jackson-xc/${jackson.version}</bundle>
 		<bundle dependency="true">mvn:org.codehaus.jackson/jackson-jaxrs/${jackson.version}</bundle>
 		
+		<bundle dependency="true">mvn:com.google.guava/guava/${guava.version}</bundle>		
+		
 		<bundle>mvn:org.opennaas/org.opennaas.extensions.ryu/${project.version}</bundle>
 
 	</feature>

--- a/itests/ryu/pom.xml
+++ b/itests/ryu/pom.xml
@@ -8,6 +8,8 @@
   
   <artifactId>org.opennaas.itests.ryu</artifactId>
   
+  <name>OpenNaaS :: iTests :: Ryu </name>
+  
   <dependencies>
   
   		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
 		<log4j.version>1.2.16</log4j.version>
 		<mantychore.version>${project.version}</mantychore.version>
 		<neethi.version>3.0.0</neethi.version>
-		<netconf4j.version>0.0.10-SNAPSHOT</netconf4j.version>
+		<netconf4j.version>0.0.9</netconf4j.version>
 		<nmr.version>1.6.1</nmr.version>
 		<opencsv.version>2.3</opencsv.version>
 		<openjpa.version>2.2.0</openjpa.version>


### PR DESCRIPTION
Ryu was depending on Guava, but this dependency was not declared in features.

By adding this dependency, OpenNaaS can depend once again in version 0.0.9 of netconf4j, which depends on guava-16.0.1 (not 17.0). Two versions of guava library will coexists, but since export packages are versioned, there's no problem in the OSGI container.