### PR TITLE
Feature/visible aggr interfaces

### DIFF
--- a/extensions/bundles/fragment.velocity/src/main/resources/VM_files/configureUnitWithDescription.vm
+++ b/extensions/bundles/fragment.velocity/src/main/resources/VM_files/configureUnitWithDescription.vm
@@ -1,0 +1,25 @@
+#** 
+@param param: a String with the name of the interface to configure
+@param isLR: a boolean telling whether interface to be configured is in a logical router or not
+@param lrName: a String with the logical router name (only set if isLR is true)
+@param unitName: an int with the number of the unit to configure
+@param description: a String with the description to set to the unit
+*#
+<configuration>
+	#if($isLR)
+		<logical-systems>
+			<name>$lrName</name>
+	#end
+	<interfaces>
+		<interface>
+			<name>$param</name>
+			<unit operation="replace">
+				<name>$unitName</name>
+				<description>$description</description>
+			</unit>
+		</interface>
+	</interfaces>
+	#if($isLR)
+		</logical-systems>
+	#end
+</configuration>

--- a/extensions/bundles/fragment.velocity/src/main/resources/VM_files/createAggregatedInterface.vm
+++ b/extensions/bundles/fragment.velocity/src/main/resources/VM_files/createAggregatedInterface.vm
@@ -28,6 +28,11 @@
 					<link-speed>$param.getAggregatedOptions().getLinkSpeed()</link-speed>
 					#end
 				</aggregated-ether-options>
+## Unit 0 with description is created in order for opennaas being able to recognize the interface
+				<unit>
+					<name>0</name>
+					<description>$param.getElementName()</description>
+				</unit>
 		</interface>
 	</interfaces>
 	#if($isLR)

--- a/extensions/bundles/fragment.velocity/src/main/resources/VM_files/removeInterfaceUnit.vm
+++ b/extensions/bundles/fragment.velocity/src/main/resources/VM_files/removeInterfaceUnit.vm
@@ -1,0 +1,24 @@
+#** 
+@param param: a String with the name of the interface to modify
+@param isLR: a boolean telling whether interface to modify is in a logical router or not
+@param lrName: a String with the logical router name (only set if isLR is true)
+@param ifaceName: a String with the name of the interface to modify
+@param unitName: an int with the unit number to be removed
+*#
+<configuration>
+	#if($isLR)
+		<logical-systems>
+			<name>$lrName</name>
+	#end
+	<interfaces>
+		<interface>
+			<name>$param</name>
+			<unit operation="delete">
+				<name>$unitName</name>
+			</unit>
+		</interface>
+	</interfaces>
+	#if($isLR)
+		</logical-systems>
+	#end
+</configuration>

--- a/extensions/bundles/router.actionsets.junos/src/main/java/org/opennaas/extensions/router/junos/actionssets/actions/linkaggregation/CreateAggregatedInterfaceAction.java
+++ b/extensions/bundles/router.actionsets.junos/src/main/java/org/opennaas/extensions/router/junos/actionssets/actions/linkaggregation/CreateAggregatedInterfaceAction.java
@@ -20,7 +20,9 @@ package org.opennaas.extensions.router.junos.actionssets.actions.linkaggregation
  * #L%
  */
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
@@ -31,9 +33,12 @@ import org.opennaas.core.resources.helpers.XmlHelper;
 import org.opennaas.core.resources.protocol.IProtocolSession;
 import org.opennaas.extensions.router.capability.linkaggregation.LinkAggregationActionSet;
 import org.opennaas.extensions.router.junos.actionssets.actions.JunosAction;
+import org.opennaas.extensions.router.junos.commandsets.commands.CommandNetconfConstants;
 import org.opennaas.extensions.router.junos.commandsets.commands.EditNetconfCommand;
 import org.opennaas.extensions.router.model.AggregatedLogicalPort;
 import org.opennaas.extensions.router.model.ComputerSystem;
+import org.opennaas.extensions.router.model.NetworkPort;
+import org.opennaas.extensions.router.model.utils.ModelHelper;
 
 /**
  * Implementation of LinkAggregationActionSet.CREATE_AGGRETATED_INTERFACE for junos 10.04 devices.
@@ -55,8 +60,10 @@ public class CreateAggregatedInterfaceAction extends JunosAction {
 
 	private static final String		CREATION_TEMPLATE					= "/VM_files/createAggregatedInterface.vm";
 	private static final String		ADD_TO_AGGREGATED_TEMPLATE			= "/VM_files/addInterfaceToAggregated.vm";
+	private static final String		REMOVE_UNIT_TEMPLATE				= "/VM_files/removeInterfaceUnit.vm";
 
 	private AggregatedLogicalPort	aggregator;
+	private boolean 				forceFlag 							= false;
 
 	public CreateAggregatedInterfaceAction() {
 		super();
@@ -95,9 +102,15 @@ public class CreateAggregatedInterfaceAction extends JunosAction {
 
 	@Override
 	public void executeListCommand(ActionResponse actionResponse, IProtocolSession protocol) throws ActionException {
-
+		
 		actionResponse.addResponse(execEditCommand(prepareCreateAggregatedInterfaceMessage(aggregator), protocol));
 		for (String interfaceName : aggregator.getInterfaces()) {
+			if (forceFlag) {
+				for (NetworkPort unitToClear : getInterfacesToRemove(interfaceName)) {
+					actionResponse.addResponse(execRemovingEditCommand(
+							prepareClearUnitMessage(interfaceName, unitToClear.getPortNumber()), protocol));
+				}
+			}
 			actionResponse.addResponse(execEditCommand(
 					prepareAddInterfaceToAggregatedMessage(interfaceName, aggregator.getElementName()), protocol));
 		}
@@ -142,6 +155,19 @@ public class CreateAggregatedInterfaceAction extends JunosAction {
 		try {
 			// FIXME passing unchecked values to junos (interfaceName and inside extraParams). May cause security issues.
 			return XmlHelper.formatXML(prepareVelocityCommand(interfaceName, ADD_TO_AGGREGATED_TEMPLATE, extraParams));
+		} catch (Exception e) {
+			throw new ActionException(e);
+		}
+	}
+	
+	private String prepareClearUnitMessage(String interfaceName, int portNumber) throws ActionException {
+		Map<String, Object> extraParams = prepareLRVelocityExtraParams();
+		extraParams.put("ifaceName", interfaceName);
+		extraParams.put("unitName", portNumber);
+		
+		try {
+			// FIXME passing unchecked values to junos (interfaceName and inside extraParams). May cause security issues.
+			return XmlHelper.formatXML(prepareVelocityCommand(interfaceName, REMOVE_UNIT_TEMPLATE, extraParams));
 		} catch (Exception e) {
 			throw new ActionException(e);
 		}
@@ -233,6 +259,28 @@ public class CreateAggregatedInterfaceAction extends JunosAction {
 		} catch (Exception e) {
 			throw new ActionException(this.actionID + ": " + e.getMessage(), e);
 		}
+	}
+	
+	private Response execRemovingEditCommand(String netconfMsg, IProtocolSession protocol) throws ActionException {
+		try {
+			// when removing tags, none operation should be used as default
+			EditNetconfCommand command = new EditNetconfCommand(netconfMsg, CommandNetconfConstants.NONE_OPERATION);
+			command.initialize();
+			return sendCommandToProtocol(command, protocol);
+		} catch (Exception e) {
+			throw new ActionException(this.actionID + ": " + e.getMessage(), e);
+		}
+	}
+	
+	private List<NetworkPort> getInterfacesToRemove(String interfaceName) {
+		List<NetworkPort> allPorts = ModelHelper.getInterfaces((ComputerSystem) modelToUpdate);
+		List<NetworkPort> filtered = new ArrayList<NetworkPort>();
+		
+		for (NetworkPort port : allPorts) {
+			if (port.getName().equals(interfaceName))
+				filtered.add(port);
+		}
+		return filtered;
 	}
 
 }

--- a/extensions/bundles/router.actionsets.junos/src/main/java/org/opennaas/extensions/router/junos/actionssets/actions/linkaggregation/CreateAggregatedInterfaceAction.java
+++ b/extensions/bundles/router.actionsets.junos/src/main/java/org/opennaas/extensions/router/junos/actionssets/actions/linkaggregation/CreateAggregatedInterfaceAction.java
@@ -73,12 +73,20 @@ public class CreateAggregatedInterfaceAction extends JunosAction {
 
 	@Override
 	public boolean checkParams(Object params) throws ActionException {
-
-		if (!(params instanceof AggregatedLogicalPort)) {
+		
+		Object[] paramsArray = (Object[]) params;
+		if (paramsArray.length != 2)
+			throw new ActionException("Invalid parameter in action " + actionID + ". Two parameters expected");
+		
+		if (!(paramsArray[0] instanceof AggregatedLogicalPort)) {
 			throw new ActionException("Invalid parameter in action " + actionID + ". Expected AggregatedLogicalPort.");
 		}
+		
+		if (!(paramsArray[1] instanceof Boolean)) {
+			throw new ActionException("Invalid parameter in action " + actionID + ". Expected Boolean.");
+		}
 
-		AggregatedLogicalPort aggregator = (AggregatedLogicalPort) params;
+		AggregatedLogicalPort aggregator = (AggregatedLogicalPort) paramsArray[0];
 		if (StringUtils.isEmpty(aggregator.getElementName()))
 			throw new ActionException("Invalid parameter in action " + actionID + "." +
 					" Missing AggregatedLogicalPort name.");
@@ -95,7 +103,9 @@ public class CreateAggregatedInterfaceAction extends JunosAction {
 	@Override
 	public void prepareMessage() throws ActionException {
 		checkParams(params);
-		this.aggregator = (AggregatedLogicalPort) params;
+		Object[] paramsArray = (Object[]) params;
+		this.aggregator = (AggregatedLogicalPort) paramsArray[0];
+		this.forceFlag = ((Boolean) paramsArray[1]).booleanValue();
 		// Nothing to prepare
 		// Messages are prepared in executeListCommand
 	}

--- a/extensions/bundles/router.actionsets.junos/src/main/resources/VM_files/configureUnitWithDescription.vm
+++ b/extensions/bundles/router.actionsets.junos/src/main/resources/VM_files/configureUnitWithDescription.vm
@@ -1,0 +1,25 @@
+#** 
+@param param: a String with the name of the interface to configure
+@param isLR: a boolean telling whether interface to be configured is in a logical router or not
+@param lrName: a String with the logical router name (only set if isLR is true)
+@param unitName: an int with the number of the unit to configure
+@param description: a String with the description to set to the unit
+*#
+<configuration>
+	#if($isLR)
+		<logical-systems>
+			<name>$lrName</name>
+	#end
+	<interfaces>
+		<interface>
+			<name>$param</name>
+			<unit operation="replace">
+				<name>$unitName</name>
+				<description>$description</description>
+			</unit>
+		</interface>
+	</interfaces>
+	#if($isLR)
+		</logical-systems>
+	#end
+</configuration>

--- a/extensions/bundles/router.actionsets.junos/src/main/resources/VM_files/createAggregatedInterface.vm
+++ b/extensions/bundles/router.actionsets.junos/src/main/resources/VM_files/createAggregatedInterface.vm
@@ -28,6 +28,11 @@
 					<link-speed>$param.getAggregatedOptions().getLinkSpeed()</link-speed>
 					#end
 				</aggregated-ether-options>
+## Unit 0 with description is created in order for opennaas being able to recognize the interface
+				<unit>
+					<name>0</name>
+					<description>$param.getElementName()</description>
+				</unit>
 		</interface>
 	</interfaces>
 	#if($isLR)

--- a/extensions/bundles/router.actionsets.junos/src/main/resources/VM_files/removeInterfaceUnit.vm
+++ b/extensions/bundles/router.actionsets.junos/src/main/resources/VM_files/removeInterfaceUnit.vm
@@ -1,0 +1,24 @@
+#** 
+@param param: a String with the name of the interface to modify
+@param isLR: a boolean telling whether interface to modify is in a logical router or not
+@param lrName: a String with the logical router name (only set if isLR is true)
+@param ifaceName: a String with the name of the interface to modify
+@param unitName: an int with the unit number to be removed
+*#
+<configuration>
+	#if($isLR)
+		<logical-systems>
+			<name>$lrName</name>
+	#end
+	<interfaces>
+		<interface>
+			<name>$param</name>
+			<unit operation="delete">
+				<name>$unitName</name>
+			</unit>
+		</interface>
+	</interfaces>
+	#if($isLR)
+		</logical-systems>
+	#end
+</configuration>

--- a/extensions/bundles/router.capability.linkaggregation/src/main/java/org/opennaas/extensions/router/capability/linkaggregation/ILinkAggregationCapability.java
+++ b/extensions/bundles/router.capability.linkaggregation/src/main/java/org/opennaas/extensions/router/capability/linkaggregation/ILinkAggregationCapability.java
@@ -27,6 +27,7 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
 import org.opennaas.core.resources.capability.CapabilityException;
@@ -64,11 +65,15 @@ public interface ILinkAggregationCapability extends ICapability {
 	/**
 	 * Creates an aggregated interface
 	 * 
+	 * 
+	 * @param aggregatedInterface Description of the interface to create
+	 * @param force when true this operation will erase any configuration subinterfaces may have.
+	 * @throws CapabilityException
 	 */
 	@POST
 	@Path("/")
 	@Consumes(MediaType.APPLICATION_XML)
-	public void createAggregatedInterface(AggregatedInterface aggregatedInterface) throws CapabilityException;
+	public void createAggregatedInterface(AggregatedInterface aggregatedInterface, @QueryParam("force") boolean force) throws CapabilityException;
 
 	/**
 	 * Removes an Aggregated Interface given the aggregatedInterfaceId

--- a/extensions/bundles/router.capability.linkaggregation/src/main/java/org/opennaas/extensions/router/capability/linkaggregation/LinkAggregationCapability.java
+++ b/extensions/bundles/router.capability.linkaggregation/src/main/java/org/opennaas/extensions/router/capability/linkaggregation/LinkAggregationCapability.java
@@ -121,7 +121,11 @@ public class LinkAggregationCapability extends AbstractCapability implements ILi
 
 		AggregatedLogicalPort aggregator = LinkAggregationAPIAdapter.api2Model(aggregatedInterface);
 
-		IAction action = createActionAndCheckParams(LinkAggregationActionSet.CREATE_AGGREGATED_INTERFACE, aggregator);
+		Object[] actionParams = new Object[2];
+		actionParams[0] = aggregator;
+		actionParams[1] = Boolean.valueOf(force);
+		
+		IAction action = createActionAndCheckParams(LinkAggregationActionSet.CREATE_AGGREGATED_INTERFACE, actionParams);
 		queueAction(action);
 
 	}

--- a/extensions/bundles/router.capability.linkaggregation/src/main/java/org/opennaas/extensions/router/capability/linkaggregation/LinkAggregationCapability.java
+++ b/extensions/bundles/router.capability.linkaggregation/src/main/java/org/opennaas/extensions/router/capability/linkaggregation/LinkAggregationCapability.java
@@ -117,7 +117,7 @@ public class LinkAggregationCapability extends AbstractCapability implements ILi
 	}
 
 	@Override
-	public void createAggregatedInterface(AggregatedInterface aggregatedInterface) throws CapabilityException {
+	public void createAggregatedInterface(AggregatedInterface aggregatedInterface, boolean force) throws CapabilityException {
 
 		AggregatedLogicalPort aggregator = LinkAggregationAPIAdapter.api2Model(aggregatedInterface);
 


### PR DESCRIPTION
This patch improves usability of aggregated interfaces:
- It makes aggregated interfaces visible in getInterfaces
- It makes subinterfaces visible when aggregated interface is deleted.
- It allows creating aggregated interfaces from configured interfaces (by using the "force" flag)

It fixes following issues:
http://jira.i2cat.net/browse/OPENNAAS-1590
http://jira.i2cat.net/browse/OPENNAAS-1591
http://jira.i2cat.net/browse/OPENNAAS-1592