### PR TITLE
Feature/complete vlan options

### DIFF
--- a/extensions/bundles/fragment.velocity/src/main/resources/VM_files/vlanBridge/ifaceVlanOptsSet.vm
+++ b/extensions/bundles/fragment.velocity/src/main/resources/VM_files/vlanBridge/ifaceVlanOptsSet.vm
@@ -1,3 +1,14 @@
+#**
+@param param: NetworkPort with a single NetworkPortVLANSettingData
+@param elementName: logical system element name
+@param hasInputFilter: boolean telling whether filter input should be added or not
+@param inputFilter: String with input-filter name
+@param hasOutputFilter: boolean telling whether filter output should be added or not
+@param outputFilter: String with output-filter name
+@param hasVlan: boolean telling whether vlan should be added or not
+@param vlanAllMembers: boolean telling whether vlan members all should be added or not
+@param vlanMembers: String with vlan members name
+*#
 <configuration>
 	#if(!$elementName.equals("") )		
 		<logical-systems>
@@ -18,7 +29,28 @@
 	    				#end
 	    				#if ($param.getElementsSettingData().get(0).getNativeVlanId() > -1)
 	    					<native-vlan-id>$param.getElementsSettingData().get(0).getNativeVlanId()</native-vlan-id>
-	    				#end    				
+	    				#end
+	    				#if ($hasInputFilter || $hasOutputFilter)
+	    					<filter>
+	    						#if ($hasInputFilter)
+	    						<input>$inputFilter</input>
+	    						#end
+	    						#if ($hasOutputFilter)
+	    						<output>$outputFilter</output>
+	    						#end
+	    					</filter>
+	    				#end
+	    				#if ($hasVlan)
+	    					<vlan>
+	    						<members>
+	    						#if ($vlanAllMembers)
+	    							<all/>
+	    						#else
+	    							<name>$vlanMembers</name>
+	    						#end
+	    						</members>
+	    					</vlan>
+	    				#end
 	    			</ethernet-switching>
     			</family>
     		</unit>

--- a/extensions/bundles/fragment.velocity/src/main/resources/VM_files/vlanBridge/ifaceVlanOptsSet.vm
+++ b/extensions/bundles/fragment.velocity/src/main/resources/VM_files/vlanBridge/ifaceVlanOptsSet.vm
@@ -6,7 +6,6 @@
 @param hasOutputFilter: boolean telling whether filter output should be added or not
 @param outputFilter: String with output-filter name
 @param hasVlan: boolean telling whether vlan should be added or not
-@param vlanAllMembers: boolean telling whether vlan members all should be added or not
 @param vlanMembers: String with vlan members name
 *#
 <configuration>
@@ -42,13 +41,7 @@
 	    				#end
 	    				#if ($hasVlan)
 	    					<vlan>
-	    						<members>
-	    						#if ($vlanAllMembers)
-	    							<all/>
-	    						#else
-	    							<name>$vlanMembers</name>
-	    						#end
-	    						</members>
+	    						<members operation="replace">$vlanMembers</members>
 	    					</vlan>
 	    				#end
 	    			</ethernet-switching>

--- a/extensions/bundles/fragment.velocity/src/main/resources/VM_files/vlanBridge/ifaceVlanOptsSet.vm
+++ b/extensions/bundles/fragment.velocity/src/main/resources/VM_files/vlanBridge/ifaceVlanOptsSet.vm
@@ -6,7 +6,7 @@
 @param hasOutputFilter: boolean telling whether filter output should be added or not
 @param outputFilter: String with output-filter name
 @param hasVlan: boolean telling whether vlan should be added or not
-@param vlanMembers: String with vlan members name
+@param vlanMembers: List<String> with vlan members name
 *#
 <configuration>
 	#if(!$elementName.equals("") )		
@@ -40,8 +40,10 @@
 	    					</filter>
 	    				#end
 	    				#if ($hasVlan)
-	    					<vlan>
-	    						<members operation="replace">$vlanMembers</members>
+	    					<vlan operation="replace">
+	    					#foreach( $member in $vlanMembers)
+	    						<members>$member</members>
+	    					#end
 	    					</vlan>
 	    				#end
 	    			</ethernet-switching>

--- a/extensions/bundles/router.actionsets.junos/src/main/java/org/opennaas/extensions/router/junos/actionssets/actions/vlanbridge/SetInterfaceVlanOptionsAction.java
+++ b/extensions/bundles/router.actionsets.junos/src/main/java/org/opennaas/extensions/router/junos/actionssets/actions/vlanbridge/SetInterfaceVlanOptionsAction.java
@@ -117,7 +117,7 @@ public class SetInterfaceVlanOptionsAction extends JunosAction {
 			}
 			
 			
-			if (StringUtils.isEmpty(settings.getVlanMembers())) {
+			if (settings.getVlanMembers() == null || settings.getVlanMembers().isEmpty()) {
 				extraParams.put("hasVlan", false);
 			} else {
 				extraParams.put("hasVlan", true);

--- a/extensions/bundles/router.actionsets.junos/src/main/java/org/opennaas/extensions/router/junos/actionssets/actions/vlanbridge/SetInterfaceVlanOptionsAction.java
+++ b/extensions/bundles/router.actionsets.junos/src/main/java/org/opennaas/extensions/router/junos/actionssets/actions/vlanbridge/SetInterfaceVlanOptionsAction.java
@@ -121,13 +121,7 @@ public class SetInterfaceVlanOptionsAction extends JunosAction {
 				extraParams.put("hasVlan", false);
 			} else {
 				extraParams.put("hasVlan", true);
-				
-				if (settings.isVlanMembersAll())
-					extraParams.put("vlanAllMembers", true);
-				else {
-					extraParams.put("vlanAllMembers", false);
-					extraParams.put("vlanMembers", settings.getVlanMembers());
-				}
+				extraParams.put("vlanMembers", settings.getVlanMembers());
 			}
 
 			setVelocityMessage(prepareVelocityCommand(params, template, extraParams));

--- a/extensions/bundles/router.actionsets.junos/src/main/java/org/opennaas/extensions/router/junos/actionssets/actions/vlanbridge/SetInterfaceVlanOptionsAction.java
+++ b/extensions/bundles/router.actionsets.junos/src/main/java/org/opennaas/extensions/router/junos/actionssets/actions/vlanbridge/SetInterfaceVlanOptionsAction.java
@@ -104,8 +104,31 @@ public class SetInterfaceVlanOptionsAction extends JunosAction {
 				elementName = ((ComputerSystem) modelToUpdate).getElementName();
 			}
 			Map<String, Object> extraParams = new HashMap<String, Object>();
-
 			extraParams.put("elementName", elementName);
+			
+			NetworkPortVLANSettingData settings = (NetworkPortVLANSettingData)((NetworkPort) params).getElementsSettingData().get(0);
+			if (!StringUtils.isEmpty(settings.getInputFilterName())) {
+				extraParams.put("hasInputFilter", false);
+				extraParams.put("inputFilter", settings.getInputFilterName());
+			}
+			if (!StringUtils.isEmpty(settings.getOutputFilterName())) {
+				extraParams.put("hasOutputFilter", false);
+				extraParams.put("outputFilter", settings.getOutputFilterName());
+			}
+			
+			
+			if (StringUtils.isEmpty(settings.getVlanMembers())) {
+				extraParams.put("hasVlan", false);
+			} else {
+				extraParams.put("hasVlan", true);
+				
+				if (settings.isVlanMembersAll())
+					extraParams.put("vlanAllMembers", true);
+				else {
+					extraParams.put("vlanAllMembers", false);
+					extraParams.put("vlanMembers", settings.getVlanMembers());
+				}
+			}
 
 			setVelocityMessage(prepareVelocityCommand(params, template, extraParams));
 

--- a/extensions/bundles/router.actionsets.junos/src/main/java/org/opennaas/extensions/router/junos/commandsets/digester/IPInterfaceParser.java
+++ b/extensions/bundles/router.actionsets.junos/src/main/java/org/opennaas/extensions/router/junos/commandsets/digester/IPInterfaceParser.java
@@ -171,7 +171,7 @@ public class IPInterfaceParser extends DigesterEngine {
 			addCallMethod("*/interfaces/interface/unit/family/ethernet-switching/port-mode", "setPortMode", 0);
 			addCallMethod("*/interfaces/interface/unit/family/ethernet-switching/filter/input", "setInputFilterName", 0);
 			addCallMethod("*/interfaces/interface/unit/family/ethernet-switching/filter/output", "setOutputFilterName", 0);
-			addCallMethod("*/interfaces/interface/unit/family/ethernet-switching/vlan/members", "setVlanMembers", 0);
+			addCallMethod("*/interfaces/interface/unit/family/ethernet-switching/vlan/members", "addVlanMember", 0);
 			addCallMethod("*/interfaces/interface/unit/family/ethernet-switching/native-vlan-id", "setNativeVlanId", 0, new Class[] { Integer.TYPE });
 			addSetNext("*/interfaces/interface/unit/family/ethernet-switching", "addElementSettingData");
 

--- a/extensions/bundles/router.actionsets.junos/src/main/java/org/opennaas/extensions/router/junos/commandsets/digester/IPInterfaceParser.java
+++ b/extensions/bundles/router.actionsets.junos/src/main/java/org/opennaas/extensions/router/junos/commandsets/digester/IPInterfaceParser.java
@@ -169,6 +169,10 @@ public class IPInterfaceParser extends DigesterEngine {
 			// VLANBridge
 			addObjectCreate("*/interfaces/interface/unit/family/ethernet-switching", NetworkPortVLANSettingData.class);
 			addCallMethod("*/interfaces/interface/unit/family/ethernet-switching/port-mode", "setPortMode", 0);
+			addCallMethod("*/interfaces/interface/unit/family/ethernet-switching/filter/input", "setInputFilterName", 0);
+			addCallMethod("*/interfaces/interface/unit/family/ethernet-switching/filter/output", "setOutputFilterName", 0);
+			addCallMethod("*/interfaces/interface/unit/family/ethernet-switching/vlan/members/name", "setVlanMembers", 0);
+			addMyRule("*/interfaces/interface/unit/family/ethernet-switching/vlan/members/all", "setVlanMembersAll", 0);
 			addCallMethod("*/interfaces/interface/unit/family/ethernet-switching/native-vlan-id", "setNativeVlanId", 0, new Class[] { Integer.TYPE });
 			addSetNext("*/interfaces/interface/unit/family/ethernet-switching", "addElementSettingData");
 
@@ -483,6 +487,16 @@ public class IPInterfaceParser extends DigesterEngine {
 				aggregator.getInterfaces().addAll(aggregationMap.get(aggregator.getElementName()));
 			}
 		}
+	}
+	
+	/**
+	 * Sets setVlanMembersAll to true, in the NetworkPortVLANSettingData that is at the top of the stack.
+	 */
+	public void setVlanMembersAll() {
+		Object obj = peek(0);
+		assert (obj instanceof NetworkPortVLANSettingData);
+		NetworkPortVLANSettingData settings = (NetworkPortVLANSettingData) obj;
+		settings.setVlanMembersAll(true);
 	}
 
 	@Deprecated

--- a/extensions/bundles/router.actionsets.junos/src/main/java/org/opennaas/extensions/router/junos/commandsets/digester/IPInterfaceParser.java
+++ b/extensions/bundles/router.actionsets.junos/src/main/java/org/opennaas/extensions/router/junos/commandsets/digester/IPInterfaceParser.java
@@ -172,7 +172,6 @@ public class IPInterfaceParser extends DigesterEngine {
 			addCallMethod("*/interfaces/interface/unit/family/ethernet-switching/filter/input", "setInputFilterName", 0);
 			addCallMethod("*/interfaces/interface/unit/family/ethernet-switching/filter/output", "setOutputFilterName", 0);
 			addCallMethod("*/interfaces/interface/unit/family/ethernet-switching/vlan/members", "setVlanMembers", 0);
-			addMyRule("*/interfaces/interface/unit/family/ethernet-switching/vlan/members/all", "setVlanMembersAll", 0);
 			addCallMethod("*/interfaces/interface/unit/family/ethernet-switching/native-vlan-id", "setNativeVlanId", 0, new Class[] { Integer.TYPE });
 			addSetNext("*/interfaces/interface/unit/family/ethernet-switching", "addElementSettingData");
 
@@ -487,16 +486,6 @@ public class IPInterfaceParser extends DigesterEngine {
 				aggregator.getInterfaces().addAll(aggregationMap.get(aggregator.getElementName()));
 			}
 		}
-	}
-	
-	/**
-	 * Sets setVlanMembersAll to true, in the NetworkPortVLANSettingData that is at the top of the stack.
-	 */
-	public void setVlanMembersAll() {
-		Object obj = peek(0);
-		assert (obj instanceof NetworkPortVLANSettingData);
-		NetworkPortVLANSettingData settings = (NetworkPortVLANSettingData) obj;
-		settings.setVlanMembersAll(true);
 	}
 
 	@Deprecated

--- a/extensions/bundles/router.actionsets.junos/src/main/java/org/opennaas/extensions/router/junos/commandsets/digester/IPInterfaceParser.java
+++ b/extensions/bundles/router.actionsets.junos/src/main/java/org/opennaas/extensions/router/junos/commandsets/digester/IPInterfaceParser.java
@@ -171,7 +171,7 @@ public class IPInterfaceParser extends DigesterEngine {
 			addCallMethod("*/interfaces/interface/unit/family/ethernet-switching/port-mode", "setPortMode", 0);
 			addCallMethod("*/interfaces/interface/unit/family/ethernet-switching/filter/input", "setInputFilterName", 0);
 			addCallMethod("*/interfaces/interface/unit/family/ethernet-switching/filter/output", "setOutputFilterName", 0);
-			addCallMethod("*/interfaces/interface/unit/family/ethernet-switching/vlan/members/name", "setVlanMembers", 0);
+			addCallMethod("*/interfaces/interface/unit/family/ethernet-switching/vlan/members", "setVlanMembers", 0);
 			addMyRule("*/interfaces/interface/unit/family/ethernet-switching/vlan/members/all", "setVlanMembersAll", 0);
 			addCallMethod("*/interfaces/interface/unit/family/ethernet-switching/native-vlan-id", "setNativeVlanId", 0, new Class[] { Integer.TYPE });
 			addSetNext("*/interfaces/interface/unit/family/ethernet-switching", "addElementSettingData");

--- a/extensions/bundles/router.actionsets.junos/src/main/resources/VM_files/vlanBridge/ifaceVlanOptsSet.vm
+++ b/extensions/bundles/router.actionsets.junos/src/main/resources/VM_files/vlanBridge/ifaceVlanOptsSet.vm
@@ -1,3 +1,14 @@
+#**
+@param param: NetworkPort with a single NetworkPortVLANSettingData
+@param elementName: logical system element name
+@param hasInputFilter: boolean telling whether filter input should be added or not
+@param inputFilter: String with input-filter name
+@param hasOutputFilter: boolean telling whether filter output should be added or not
+@param outputFilter: String with output-filter name
+@param hasVlan: boolean telling whether vlan should be added or not
+@param vlanAllMembers: boolean telling whether vlan members all should be added or not
+@param vlanMembers: String with vlan members name
+*#
 <configuration>
 	#if(!$elementName.equals("") )		
 		<logical-systems>
@@ -18,7 +29,28 @@
 	    				#end
 	    				#if ($param.getElementsSettingData().get(0).getNativeVlanId() > -1)
 	    					<native-vlan-id>$param.getElementsSettingData().get(0).getNativeVlanId()</native-vlan-id>
-	    				#end    				
+	    				#end
+	    				#if ($hasInputFilter || $hasOutputFilter)
+	    					<filter>
+	    						#if ($hasInputFilter)
+	    						<input>$inputFilter</input>
+	    						#end
+	    						#if ($hasOutputFilter)
+	    						<output>$outputFilter</output>
+	    						#end
+	    					</filter>
+	    				#end
+	    				#if ($hasVlan)
+	    					<vlan>
+	    						<members>
+	    						#if ($vlanAllMembers)
+	    							<all/>
+	    						#else
+	    							<name>$vlanMembers</name>
+	    						#end
+	    						</members>
+	    					</vlan>
+	    				#end
 	    			</ethernet-switching>
     			</family>
     		</unit>

--- a/extensions/bundles/router.actionsets.junos/src/main/resources/VM_files/vlanBridge/ifaceVlanOptsSet.vm
+++ b/extensions/bundles/router.actionsets.junos/src/main/resources/VM_files/vlanBridge/ifaceVlanOptsSet.vm
@@ -6,7 +6,6 @@
 @param hasOutputFilter: boolean telling whether filter output should be added or not
 @param outputFilter: String with output-filter name
 @param hasVlan: boolean telling whether vlan should be added or not
-@param vlanAllMembers: boolean telling whether vlan members all should be added or not
 @param vlanMembers: String with vlan members name
 *#
 <configuration>
@@ -42,13 +41,7 @@
 	    				#end
 	    				#if ($hasVlan)
 	    					<vlan>
-	    						<members>
-	    						#if ($vlanAllMembers)
-	    							<all/>
-	    						#else
-	    							<name>$vlanMembers</name>
-	    						#end
-	    						</members>
+	    						<members operation="replace">$vlanMembers</members>
 	    					</vlan>
 	    				#end
 	    			</ethernet-switching>

--- a/extensions/bundles/router.actionsets.junos/src/main/resources/VM_files/vlanBridge/ifaceVlanOptsSet.vm
+++ b/extensions/bundles/router.actionsets.junos/src/main/resources/VM_files/vlanBridge/ifaceVlanOptsSet.vm
@@ -6,7 +6,7 @@
 @param hasOutputFilter: boolean telling whether filter output should be added or not
 @param outputFilter: String with output-filter name
 @param hasVlan: boolean telling whether vlan should be added or not
-@param vlanMembers: String with vlan members name
+@param vlanMembers: List<String> with vlan members name
 *#
 <configuration>
 	#if(!$elementName.equals("") )		
@@ -40,8 +40,10 @@
 	    					</filter>
 	    				#end
 	    				#if ($hasVlan)
-	    					<vlan>
-	    						<members operation="replace">$vlanMembers</members>
+	    					<vlan operation="replace">
+	    					#foreach( $member in $vlanMembers)
+	    						<members>$member</members>
+	    					#end
 	    					</vlan>
 	    				#end
 	    			</ethernet-switching>

--- a/extensions/bundles/router.capabilities.api/src/main/java/org/opennaas/extensions/router/capabilities/api/helper/VLANBridgeApiHelper.java
+++ b/extensions/bundles/router.capabilities.api/src/main/java/org/opennaas/extensions/router/capabilities/api/helper/VLANBridgeApiHelper.java
@@ -118,9 +118,7 @@ public abstract class VLANBridgeApiHelper {
 		if (!StringUtils.isEmpty(networkPortVLANSettingData.getOutputFilterName()))
 			vlanOptions.put(FILTER_OUTPUT, networkPortVLANSettingData.getOutputFilterName());
 		
-		if (networkPortVLANSettingData.isVlanMembersAll())
-			vlanOptions.put(VLAN_MEMBERS, "all");
-		else if (!StringUtils.isEmpty(networkPortVLANSettingData.getVlanMembers()))
+		if (!StringUtils.isEmpty(networkPortVLANSettingData.getVlanMembers()))
 			vlanOptions.put(VLAN_MEMBERS, networkPortVLANSettingData.getVlanMembers());
 
 		vlanOpts.setVlanOptions(vlanOptions);
@@ -144,11 +142,7 @@ public abstract class VLANBridgeApiHelper {
 				else if (key.equals(FILTER_OUTPUT))
 					modelVlanOpts.setOutputFilterName(vlanOptions.getVlanOptions().get(FILTER_OUTPUT));
 				else if (key.equals(VLAN_MEMBERS)) {
-					String vlanMembers = vlanOptions.getVlanOptions().get(VLAN_MEMBERS);
-					if ("all".equals(vlanMembers))
-						modelVlanOpts.setVlanMembersAll(true);
-					else
-						modelVlanOpts.setVlanMembers(vlanMembers);
+					modelVlanOpts.setVlanMembers(vlanOptions.getVlanOptions().get(VLAN_MEMBERS));
 				} else {
 					ignoredOptions.add(key);
 				}

--- a/extensions/bundles/router.capabilities.api/src/main/java/org/opennaas/extensions/router/capabilities/api/helper/VLANBridgeApiHelper.java
+++ b/extensions/bundles/router.capabilities.api/src/main/java/org/opennaas/extensions/router/capabilities/api/helper/VLANBridgeApiHelper.java
@@ -21,6 +21,7 @@ package org.opennaas.extensions.router.capabilities.api.helper;
  */
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -118,9 +119,15 @@ public abstract class VLANBridgeApiHelper {
 		if (!StringUtils.isEmpty(networkPortVLANSettingData.getOutputFilterName()))
 			vlanOptions.put(FILTER_OUTPUT, networkPortVLANSettingData.getOutputFilterName());
 		
-		if (!StringUtils.isEmpty(networkPortVLANSettingData.getVlanMembers()))
-			vlanOptions.put(VLAN_MEMBERS, networkPortVLANSettingData.getVlanMembers());
-
+		if (networkPortVLANSettingData.getVlanMembers() != null && !networkPortVLANSettingData.getVlanMembers().isEmpty()) {
+			StringBuilder sb = new StringBuilder();
+			for (String member : networkPortVLANSettingData.getVlanMembers()) {
+				sb.append(member);
+				sb.append(",");
+			}
+			// substring used to remove last ","
+			vlanOptions.put(VLAN_MEMBERS, sb.substring(0, sb.length()-1));
+		}
 		vlanOpts.setVlanOptions(vlanOptions);
 
 		return vlanOpts;
@@ -142,7 +149,9 @@ public abstract class VLANBridgeApiHelper {
 				else if (key.equals(FILTER_OUTPUT))
 					modelVlanOpts.setOutputFilterName(vlanOptions.getVlanOptions().get(FILTER_OUTPUT));
 				else if (key.equals(VLAN_MEMBERS)) {
-					modelVlanOpts.setVlanMembers(vlanOptions.getVlanOptions().get(VLAN_MEMBERS));
+					String[] allMembersArray = vlanOptions.getVlanOptions().get(VLAN_MEMBERS).split(",");
+					List<String> allMembers = new ArrayList<String>(Arrays.asList(allMembersArray));
+					modelVlanOpts.setVlanMembers(allMembers);
 				} else {
 					ignoredOptions.add(key);
 				}

--- a/extensions/bundles/router.capabilities.api/src/main/java/org/opennaas/extensions/router/capabilities/api/helper/VLANBridgeApiHelper.java
+++ b/extensions/bundles/router.capabilities.api/src/main/java/org/opennaas/extensions/router/capabilities/api/helper/VLANBridgeApiHelper.java
@@ -45,6 +45,10 @@ public abstract class VLANBridgeApiHelper {
 
 	public static final String	PORT_MODE_KEY	= "port-mode";
 	public static final String	NATIVE_VLAN_KEY	= "native-vlan-id";
+	public static final String	FILTER_INPUT	= "filter-input";
+	public static final String	FILTER_OUTPUT	= "filter-output";
+	public static final String	VLAN_MEMBERS	= "vlan-members";
+	
 
 	public static BridgeDomains buildApiBridgeDomains(List<org.opennaas.extensions.router.model.BridgeDomain> modelBridgeDomains) {
 
@@ -97,7 +101,7 @@ public abstract class VLANBridgeApiHelper {
 		return modelBrDomain;
 	}
 
-	public static InterfaceVLANOptions buildApiIfaceVlanOptions(NetworkPortVLANSettingData networkPortVLANSettingData) {
+	public static InterfaceVLANOptions buildApiIfaceVlanOptions(final NetworkPortVLANSettingData networkPortVLANSettingData) {
 
 		InterfaceVLANOptions vlanOpts = new InterfaceVLANOptions();
 		Map<String, String> vlanOptions = new HashMap<String, String>();
@@ -107,31 +111,51 @@ public abstract class VLANBridgeApiHelper {
 
 		if (networkPortVLANSettingData.getNativeVlanId() != NetworkPortVLANSettingData.NATIVE_VLAN_DEFAULT_VALUE)
 			vlanOptions.put(NATIVE_VLAN_KEY, String.valueOf(networkPortVLANSettingData.getNativeVlanId()));
+		
+		if (!StringUtils.isEmpty(networkPortVLANSettingData.getInputFilterName()))
+			vlanOptions.put(FILTER_INPUT, networkPortVLANSettingData.getInputFilterName());
+		
+		if (!StringUtils.isEmpty(networkPortVLANSettingData.getOutputFilterName()))
+			vlanOptions.put(FILTER_OUTPUT, networkPortVLANSettingData.getOutputFilterName());
+		
+		if (networkPortVLANSettingData.isVlanMembersAll())
+			vlanOptions.put(VLAN_MEMBERS, "all");
+		else if (!StringUtils.isEmpty(networkPortVLANSettingData.getVlanMembers()))
+			vlanOptions.put(VLAN_MEMBERS, networkPortVLANSettingData.getVlanMembers());
 
 		vlanOpts.setVlanOptions(vlanOptions);
 
 		return vlanOpts;
 	}
 
-	public static NetworkPortVLANSettingData buildModelIfaceVlanOptions(InterfaceVLANOptions vlanOptions) {
+	public static NetworkPortVLANSettingData buildModelIfaceVlanOptions(final InterfaceVLANOptions vlanOptions) {
 		NetworkPortVLANSettingData modelVlanOpts = new NetworkPortVLANSettingData();
 
+		List<String> ignoredOptions = new ArrayList<String>();
 		if (vlanOptions.getVlanOptions() != null) {
-
-			if (vlanOptions.getVlanOptions().containsKey(PORT_MODE_KEY)) {
-				modelVlanOpts.setPortMode(vlanOptions.getVlanOptions().get(PORT_MODE_KEY));
-				vlanOptions.getVlanOptions().remove(PORT_MODE_KEY);
+			
+			for (String key : vlanOptions.getVlanOptions().keySet()) {
+				if (key.equals(PORT_MODE_KEY)) 
+					modelVlanOpts.setPortMode(vlanOptions.getVlanOptions().get(PORT_MODE_KEY));
+				else if (key.equals(NATIVE_VLAN_KEY)) 
+					modelVlanOpts.setNativeVlanId((Integer.valueOf(vlanOptions.getVlanOptions().get(NATIVE_VLAN_KEY))));
+				else if (key.equals(FILTER_INPUT))
+					modelVlanOpts.setInputFilterName(vlanOptions.getVlanOptions().get(FILTER_INPUT));
+				else if (key.equals(FILTER_OUTPUT))
+					modelVlanOpts.setOutputFilterName(vlanOptions.getVlanOptions().get(FILTER_OUTPUT));
+				else if (key.equals(VLAN_MEMBERS)) {
+					String vlanMembers = vlanOptions.getVlanOptions().get(VLAN_MEMBERS);
+					if ("all".equals(vlanMembers))
+						modelVlanOpts.setVlanMembersAll(true);
+					else
+						modelVlanOpts.setVlanMembers(vlanMembers);
+				} else {
+					ignoredOptions.add(key);
+				}
 			}
-
-			if (vlanOptions.getVlanOptions().containsKey(NATIVE_VLAN_KEY)) {
-				modelVlanOpts.setNativeVlanId((Integer.valueOf(vlanOptions.getVlanOptions().get(NATIVE_VLAN_KEY))));
-				vlanOptions.getVlanOptions().remove(NATIVE_VLAN_KEY);
-			}
-
-			if ((!vlanOptions.getVlanOptions().containsKey(NATIVE_VLAN_KEY)) && (!vlanOptions.getVlanOptions().containsKey(PORT_MODE_KEY)) && (!vlanOptions
-					.getVlanOptions().isEmpty()))
-
-				log.warn("Ignoring unknown interfaceVlanOptions values : " + vlanOptions.getVlanOptions().keySet());
+			
+			if (!ignoredOptions.isEmpty())
+				log.warn("Ignoring unknown interfaceVlanOptions values : " + ignoredOptions);
 		}
 
 		return modelVlanOpts;

--- a/extensions/bundles/router.capability.vlanbridge/src/main/java/org/opennaas/extensions/router/capability/vlanbridge/VLANBridgeCapability.java
+++ b/extensions/bundles/router.capability.vlanbridge/src/main/java/org/opennaas/extensions/router/capability/vlanbridge/VLANBridgeCapability.java
@@ -207,6 +207,8 @@ public class VLANBridgeCapability extends AbstractCapability implements IVLANBri
 
 		ComputerSystem system = (ComputerSystem) this.resource.getModel();
 		NetworkPort netPort = ModelHelper.getNetworkPortFromName(ifaceName, system);
+		if (netPort == null)
+			throw new ModelElementNotFoundException("Unknown iface " + ifaceName);
 
 		List<NetworkPortVLANSettingData> modelVlanOpts = netPort.getAllElementSettingDataByType(NetworkPortVLANSettingData.class);
 

--- a/extensions/bundles/router.model/src/main/java/org/opennaas/extensions/router/model/ManagedElement.java
+++ b/extensions/bundles/router.model/src/main/java/org/opennaas/extensions/router/model/ManagedElement.java
@@ -485,7 +485,7 @@ public class ManagedElement implements IModel, Serializable {
 
 		ArrayList<T> toReturn = new ArrayList<T>();
 		for (SettingData settingData : list) {
-			if (clazz.getClass().isInstance(settingData)) {
+			if (clazz.isInstance(settingData)) {
 				toReturn.add((T) settingData);
 			}
 		}

--- a/extensions/bundles/router.model/src/main/java/org/opennaas/extensions/router/model/NetworkPortVLANSettingData.java
+++ b/extensions/bundles/router.model/src/main/java/org/opennaas/extensions/router/model/NetworkPortVLANSettingData.java
@@ -35,6 +35,11 @@ public class NetworkPortVLANSettingData extends SettingData implements Serializa
 
 	private int					nativeVlanId;
 	private String				portMode;
+	
+	private String				inputFilterName;
+	private String				outputFilterName;
+	private boolean				vlanMembersAll;
+	private String				vlanMembers;
 
 	public NetworkPortVLANSettingData() {
 		// FIXME if the NetworkPortVLANSettingData is created and the setNativeVlanId is never called, there's no way to distinguish
@@ -58,12 +63,53 @@ public class NetworkPortVLANSettingData extends SettingData implements Serializa
 		this.portMode = portMode;
 	}
 
+	public String getInputFilterName() {
+		return inputFilterName;
+	}
+
+	public void setInputFilterName(String inputFilterName) {
+		this.inputFilterName = inputFilterName;
+	}
+
+	public String getOutputFilterName() {
+		return outputFilterName;
+	}
+
+	public void setOutputFilterName(String outputFilterName) {
+		this.outputFilterName = outputFilterName;
+	}
+
+	public boolean isVlanMembersAll() {
+		return vlanMembersAll;
+	}
+
+	public void setVlanMembersAll(boolean vlanMembersAll) {
+		this.vlanMembersAll = vlanMembersAll;
+	}
+
+	public String getVlanMembers() {
+		return vlanMembers;
+	}
+
+	public void setVlanMembers(String vlanMembers) {
+		this.vlanMembers = vlanMembers;
+	}
+
 	@Override
 	public int hashCode() {
 		final int prime = 31;
 		int result = 1;
+		result = prime * result
+				+ ((inputFilterName == null) ? 0 : inputFilterName.hashCode());
 		result = prime * result + nativeVlanId;
-		result = prime * result + ((portMode == null) ? 0 : portMode.hashCode());
+		result = prime
+				* result
+				+ ((outputFilterName == null) ? 0 : outputFilterName.hashCode());
+		result = prime * result
+				+ ((portMode == null) ? 0 : portMode.hashCode());
+		result = prime * result
+				+ ((vlanMembers == null) ? 0 : vlanMembers.hashCode());
+		result = prime * result + (vlanMembersAll ? 1231 : 1237);
 		return result;
 	}
 
@@ -76,19 +122,41 @@ public class NetworkPortVLANSettingData extends SettingData implements Serializa
 		if (getClass() != obj.getClass())
 			return false;
 		NetworkPortVLANSettingData other = (NetworkPortVLANSettingData) obj;
+		if (inputFilterName == null) {
+			if (other.inputFilterName != null)
+				return false;
+		} else if (!inputFilterName.equals(other.inputFilterName))
+			return false;
 		if (nativeVlanId != other.nativeVlanId)
+			return false;
+		if (outputFilterName == null) {
+			if (other.outputFilterName != null)
+				return false;
+		} else if (!outputFilterName.equals(other.outputFilterName))
 			return false;
 		if (portMode == null) {
 			if (other.portMode != null)
 				return false;
 		} else if (!portMode.equals(other.portMode))
 			return false;
+		if (vlanMembers == null) {
+			if (other.vlanMembers != null)
+				return false;
+		} else if (!vlanMembers.equals(other.vlanMembers))
+			return false;
+		if (vlanMembersAll != other.vlanMembersAll)
+			return false;
 		return true;
 	}
 
 	@Override
 	public String toString() {
-		return "NetworkPortVLANSettingData [nativeVlanId=" + nativeVlanId + ", portMode=" + portMode + "]";
+		return "NetworkPortVLANSettingData [nativeVlanId=" + nativeVlanId
+				+ ", portMode=" + portMode + ", inputFilterName="
+				+ inputFilterName + ", outputFilterName=" + outputFilterName
+				+ ", vlanMembersAll=" + vlanMembersAll + ", vlanMembers="
+				+ vlanMembers + "]";
 	}
-
+	
+	
 }

--- a/extensions/bundles/router.model/src/main/java/org/opennaas/extensions/router/model/NetworkPortVLANSettingData.java
+++ b/extensions/bundles/router.model/src/main/java/org/opennaas/extensions/router/model/NetworkPortVLANSettingData.java
@@ -21,6 +21,8 @@ package org.opennaas.extensions.router.model;
  */
 
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * 
@@ -38,12 +40,14 @@ public class NetworkPortVLANSettingData extends SettingData implements Serializa
 	
 	private String				inputFilterName;
 	private String				outputFilterName;
-	private String				vlanMembers;
+	private List<String>		vlanMembers;
 
 	public NetworkPortVLANSettingData() {
 		// FIXME if the NetworkPortVLANSettingData is created and the setNativeVlanId is never called, there's no way to distinguish
 		// betweeen the default value of the int (0) and the vlanId 0.
 		nativeVlanId = NATIVE_VLAN_DEFAULT_VALUE;
+		
+		vlanMembers = new ArrayList<String>();
 	}
 
 	public int getNativeVlanId() {
@@ -78,12 +82,16 @@ public class NetworkPortVLANSettingData extends SettingData implements Serializa
 		this.outputFilterName = outputFilterName;
 	}
 
-	public String getVlanMembers() {
+	public List<String> getVlanMembers() {
 		return vlanMembers;
 	}
 
-	public void setVlanMembers(String vlanMembers) {
+	public void setVlanMembers(List<String> vlanMembers) {
 		this.vlanMembers = vlanMembers;
+	}
+	
+	public void addVlanMember(String vlanMember) {
+		this.vlanMembers.add(vlanMember);
 	}
 
 	@Override
@@ -144,6 +152,4 @@ public class NetworkPortVLANSettingData extends SettingData implements Serializa
 				+ inputFilterName + ", outputFilterName=" + outputFilterName
 				+ ", vlanMembers=" + vlanMembers + "]";
 	}
-	
-	
 }

--- a/extensions/bundles/router.model/src/main/java/org/opennaas/extensions/router/model/NetworkPortVLANSettingData.java
+++ b/extensions/bundles/router.model/src/main/java/org/opennaas/extensions/router/model/NetworkPortVLANSettingData.java
@@ -38,7 +38,6 @@ public class NetworkPortVLANSettingData extends SettingData implements Serializa
 	
 	private String				inputFilterName;
 	private String				outputFilterName;
-	private boolean				vlanMembersAll;
 	private String				vlanMembers;
 
 	public NetworkPortVLANSettingData() {
@@ -79,14 +78,6 @@ public class NetworkPortVLANSettingData extends SettingData implements Serializa
 		this.outputFilterName = outputFilterName;
 	}
 
-	public boolean isVlanMembersAll() {
-		return vlanMembersAll;
-	}
-
-	public void setVlanMembersAll(boolean vlanMembersAll) {
-		this.vlanMembersAll = vlanMembersAll;
-	}
-
 	public String getVlanMembers() {
 		return vlanMembers;
 	}
@@ -109,7 +100,6 @@ public class NetworkPortVLANSettingData extends SettingData implements Serializa
 				+ ((portMode == null) ? 0 : portMode.hashCode());
 		result = prime * result
 				+ ((vlanMembers == null) ? 0 : vlanMembers.hashCode());
-		result = prime * result + (vlanMembersAll ? 1231 : 1237);
 		return result;
 	}
 
@@ -144,8 +134,6 @@ public class NetworkPortVLANSettingData extends SettingData implements Serializa
 				return false;
 		} else if (!vlanMembers.equals(other.vlanMembers))
 			return false;
-		if (vlanMembersAll != other.vlanMembersAll)
-			return false;
 		return true;
 	}
 
@@ -154,8 +142,7 @@ public class NetworkPortVLANSettingData extends SettingData implements Serializa
 		return "NetworkPortVLANSettingData [nativeVlanId=" + nativeVlanId
 				+ ", portMode=" + portMode + ", inputFilterName="
 				+ inputFilterName + ", outputFilterName=" + outputFilterName
-				+ ", vlanMembersAll=" + vlanMembersAll + ", vlanMembers="
-				+ vlanMembers + "]";
+				+ ", vlanMembers=" + vlanMembers + "]";
 	}
 	
 	


### PR DESCRIPTION
This patch adds support for missing vlan options. OpenNaaS now supports all vlan options supported by JunOS.

Following xml shows how to specify suported vlan options:
```xml
<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<ns2:interfaceVLANOptions 
    xmlns:ns2="opennaas.api">
    <vlanOptions>
        <entry>
            <key>native-vlan-id</key>
            <value>120</value>
        </entry>
        <entry>
            <key>vlan-members</key>
            <value>129,200</value>
        </entry>
        <entry>
            <key>port-mode</key>
            <value>trunk</value>
        </entry>
        <entry>
            <key>filter-input</key>
            <value>filterA</value>
        </entry>
        <entry>
            <key>filter-output</key>
            <value>filterB</value>
        </entry>
    </vlanOptions>
</ns2:interfaceVLANOptions>
```
vlan-members is a comma-separated list of values. One may specify "all" to refer to all vlans.

Fixes issue http://jira.i2cat.net/browse/OPENNAAS-1593